### PR TITLE
[PLAT-8963] Manual View Load spans

### DIFF
--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -5,7 +5,7 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
-#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformanceViewType.h>
 #import <memory>
 
 namespace bugsnag {
@@ -20,6 +20,10 @@ public:
                bool autoInstrumentAppStarts) noexcept;
     
     std::unique_ptr<class Span> startSpan(NSString *name, CFAbsoluteTime startTime) noexcept;
+    
+    std::unique_ptr<class Span> startViewLoadedSpan(BugsnagPerformanceViewType viewType,
+                                                    NSString *className,
+                                                    CFAbsoluteTime startTime) noexcept;
     
 private:
     std::shared_ptr<class SpanProcessor> spanProcessor_;

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -46,3 +46,22 @@ std::unique_ptr<Span>
 Tracer::startSpan(NSString *name, CFAbsoluteTime startTime) noexcept {
     return std::make_unique<Span>(std::make_unique<SpanData>(name, startTime), spanProcessor_);
 }
+
+std::unique_ptr<class Span>
+Tracer::startViewLoadedSpan(BugsnagPerformanceViewType viewType,
+                            NSString *className,
+                            CFAbsoluteTime startTime) noexcept {
+    NSString *type;
+    switch (viewType) {
+        case BugsnagPerformanceViewTypeSwiftUI: type = @"SwiftUI"; break;
+        case BugsnagPerformanceViewTypeUIKit:   type = @"UIKit"; break;
+        default:                                type = @"?"; break;
+    }
+    NSString *name = [NSString stringWithFormat:@"ViewLoaded/%@/%@", type, className];
+    auto span = startSpan(name, startTime);
+    span->addAttributes(@{
+        @"bugsnag.span_category": @"view_load",
+        @"bugsnag.view_type": type
+    });
+    return span;
+}

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -35,4 +35,14 @@ static Tracer tracer;
             tracer.startSpan(name, startTime.timeIntervalSinceReferenceDate)];
 }
 
++ (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name viewType:(BugsnagPerformanceViewType)viewType {
+    return [[BugsnagPerformanceSpan alloc] initWithSpan:
+            tracer.startViewLoadedSpan(viewType, name, CFAbsoluteTimeGetCurrent())];
+}
+
++ (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name viewType:(BugsnagPerformanceViewType)viewType startTime:(NSDate *)startTime {
+    return [[BugsnagPerformanceSpan alloc] initWithSpan:
+            tracer.startViewLoadedSpan(viewType, name, startTime.timeIntervalSinceReferenceDate)];
+}
+
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -7,6 +7,7 @@
 
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <BugsnagPerformance/BugsnagPerformanceViewType.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,6 +22,19 @@ NS_ASSUME_NONNULL_BEGIN
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name NS_SWIFT_NAME(startSpan(name:));
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name startTime:(NSDate *)startTime NS_SWIFT_NAME(startSpan(name:startTime:));
+
+@end
+
+@interface BugsnagPerformance (/* Manual view load spans */)
+
++ (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name
+                                             viewType:(BugsnagPerformanceViewType)viewType
+  NS_SWIFT_NAME(startViewLoadSpan(name:viewType:));
+
++ (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name
+                                             viewType:(BugsnagPerformanceViewType)viewType
+                                            startTime:(NSDate *)startTime
+  NS_SWIFT_NAME(startViewLoadSpan(name:viewType:startTime:));
 
 @end
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceViewType.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceViewType.h
@@ -1,0 +1,13 @@
+//
+//  BugsnagPerformanceViewType.h
+//  BugsnagPerformance
+//
+//  Created by Nick Dowell on 10/10/2022.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, BugsnagPerformanceViewType) {
+    BugsnagPerformanceViewTypeSwiftUI = 1,
+    BugsnagPerformanceViewTypeUIKit = 2,
+};

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */; };
+		01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */; };
 		01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */; };
 		01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DA828E1AEBD00D1F239 /* AppDelegate.swift */; };
 		01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DAA28E1AEBD00D1F239 /* SceneDelegate.swift */; };
@@ -23,6 +24,7 @@
 
 /* Begin PBXFileReference section */
 		01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentAppStartsScenario.swift; sourceTree = "<group>"; };
+		01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualViewLoadScenario.swift; sourceTree = "<group>"; };
 		01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanBeforeStartScenario.swift; sourceTree = "<group>"; };
 		01FE4DA528E1AEBD00D1F239 /* Fixture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fixture.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		01FE4DA828E1AEBD00D1F239 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
+				01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
 			);
 			path = Scenarios;
@@ -187,6 +190,7 @@
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */,
 				01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */,
+				01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */,
 				01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */,
 				01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/ManualViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualViewLoadScenario.swift
@@ -1,0 +1,17 @@
+//
+//  ManualViewLoadScenario.swift
+//  Fixture
+//
+//  Created by Nick Dowell on 10/10/2022.
+//
+
+import BugsnagPerformance
+
+class ManualViewLoadScenario: Scenario {
+    
+    override func run() {
+        BugsnagPerformance.startViewLoadSpan(name: "ManualViewController", viewType: .uiKit).end()
+        
+        BugsnagPerformance.startViewLoadSpan(name: "ManualView", viewType: .swiftUI, startTime: Date()).end()
+    }
+}

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -26,3 +26,20 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.version" equals "0.0"
+
+  Scenario: Starting and ending a span before starting the SDK
+    Given I run "ManualViewLoadScenario"
+    And I wait to receive 2 traces
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ViewLoaded/UIKit/ManualViewController"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.span_category" equals "view_load"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.view_type" equals "UIKit"
+    And I discard the oldest trace
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ViewLoaded/SwiftUI/ManualView"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.span_category" equals "view_load"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.view_type" equals "SwiftUI"


### PR DESCRIPTION
## Goal

Enable manual reporting of view load spans.

## Design

https://smartbear.atlassian.net/wiki/spaces/EN/pages/3312189550/ROAD-847+ED+-+Screen+Load+Instrumentation#Manual-spans

## Changeset

Adds `BugsnagPerformance.startViewLoadSpan(name:viewType:startTime:)`

## Testing

Adds an E2E scenario.