### PR TITLE
[PLAT-9021] View Controller Instrumentation

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -14,7 +14,37 @@
 		010656B128DB2E8E00F2A9A6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 010656B028DB2E8E00F2A9A6 /* Assets.xcassets */; };
 		010656B428DB2E8E00F2A9A6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 010656B228DB2E8E00F2A9A6 /* LaunchScreen.storyboard */; };
 		010656C328DB543B00F2A9A6 /* BugsnagPerformance in Frameworks */ = {isa = PBXBuildFile; productRef = 010656C228DB543B00F2A9A6 /* BugsnagPerformance */; };
+		011C69DD28F5747200C5BA3C /* SomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011C69DC28F5747200C5BA3C /* SomeView.swift */; };
+		011C69E128F5CA1E00C5BA3C /* IgnoredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011C69E028F5CA1E00C5BA3C /* IgnoredViewController.swift */; };
+		0185C46728F6C04B006F9BDC /* ExampleLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 0185C46628F6C04B006F9BDC /* ExampleLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0185C46A28F6C04B006F9BDC /* ExampleLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0185C46428F6C04B006F9BDC /* ExampleLibrary.framework */; };
+		0185C46C28F6C04B006F9BDC /* ExampleLibrary.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0185C46428F6C04B006F9BDC /* ExampleLibrary.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		0185C47028F6C05D006F9BDC /* AnotherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011C69DE28F57F1500C5BA3C /* AnotherViewController.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0185C46828F6C04B006F9BDC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0106569C28DB2E8C00F2A9A6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0185C46328F6C04B006F9BDC;
+			remoteInfo = ExampleLibrary;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		0185C46B28F6C04B006F9BDC /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				0185C46C28F6C04B006F9BDC /* ExampleLibrary.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		010656A428DB2E8C00F2A9A6 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -26,6 +56,11 @@
 		010656B328DB2E8E00F2A9A6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		010656B528DB2E8E00F2A9A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		010656C028DB2F5E00F2A9A6 /* bugsnag-cocoa-performance */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "bugsnag-cocoa-performance"; path = ..; sourceTree = "<group>"; };
+		011C69DC28F5747200C5BA3C /* SomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomeView.swift; sourceTree = "<group>"; };
+		011C69DE28F57F1500C5BA3C /* AnotherViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnotherViewController.swift; sourceTree = "<group>"; };
+		011C69E028F5CA1E00C5BA3C /* IgnoredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoredViewController.swift; sourceTree = "<group>"; };
+		0185C46428F6C04B006F9BDC /* ExampleLibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ExampleLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0185C46628F6C04B006F9BDC /* ExampleLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExampleLibrary.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -34,6 +69,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				010656C328DB543B00F2A9A6 /* BugsnagPerformance in Frameworks */,
+				0185C46A28F6C04B006F9BDC /* ExampleLibrary.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0185C46128F6C04B006F9BDC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -44,6 +87,7 @@
 			isa = PBXGroup;
 			children = (
 				010656A628DB2E8C00F2A9A6 /* Example */,
+				0185C46528F6C04B006F9BDC /* ExampleLibrary */,
 				010656BF28DB2F5E00F2A9A6 /* Packages */,
 				010656A528DB2E8C00F2A9A6 /* Products */,
 				010656C128DB543B00F2A9A6 /* Frameworks */,
@@ -54,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				010656A428DB2E8C00F2A9A6 /* Example.app */,
+				0185C46428F6C04B006F9BDC /* ExampleLibrary.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -64,6 +109,8 @@
 				010656A728DB2E8C00F2A9A6 /* AppDelegate.swift */,
 				010656A928DB2E8C00F2A9A6 /* SceneDelegate.swift */,
 				010656AB28DB2E8C00F2A9A6 /* ViewController.swift */,
+				011C69E028F5CA1E00C5BA3C /* IgnoredViewController.swift */,
+				011C69DC28F5747200C5BA3C /* SomeView.swift */,
 				010656AD28DB2E8C00F2A9A6 /* Main.storyboard */,
 				010656B028DB2E8E00F2A9A6 /* Assets.xcassets */,
 				010656B228DB2E8E00F2A9A6 /* LaunchScreen.storyboard */,
@@ -87,7 +134,27 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		0185C46528F6C04B006F9BDC /* ExampleLibrary */ = {
+			isa = PBXGroup;
+			children = (
+				011C69DE28F57F1500C5BA3C /* AnotherViewController.swift */,
+				0185C46628F6C04B006F9BDC /* ExampleLibrary.h */,
+			);
+			path = ExampleLibrary;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		0185C45F28F6C04B006F9BDC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0185C46728F6C04B006F9BDC /* ExampleLibrary.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		010656A328DB2E8C00F2A9A6 /* Example */ = {
@@ -97,10 +164,12 @@
 				010656A028DB2E8C00F2A9A6 /* Sources */,
 				010656A128DB2E8C00F2A9A6 /* Frameworks */,
 				010656A228DB2E8C00F2A9A6 /* Resources */,
+				0185C46B28F6C04B006F9BDC /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				0185C46928F6C04B006F9BDC /* PBXTargetDependency */,
 			);
 			name = Example;
 			packageProductDependencies = (
@@ -109,6 +178,24 @@
 			productName = Example;
 			productReference = 010656A428DB2E8C00F2A9A6 /* Example.app */;
 			productType = "com.apple.product-type.application";
+		};
+		0185C46328F6C04B006F9BDC /* ExampleLibrary */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0185C46F28F6C04B006F9BDC /* Build configuration list for PBXNativeTarget "ExampleLibrary" */;
+			buildPhases = (
+				0185C45F28F6C04B006F9BDC /* Headers */,
+				0185C46028F6C04B006F9BDC /* Sources */,
+				0185C46128F6C04B006F9BDC /* Frameworks */,
+				0185C46228F6C04B006F9BDC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ExampleLibrary;
+			productName = ExampleLibrary;
+			productReference = 0185C46428F6C04B006F9BDC /* ExampleLibrary.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -122,6 +209,9 @@
 				TargetAttributes = {
 					010656A328DB2E8C00F2A9A6 = {
 						CreatedOnToolsVersion = 14.0;
+					};
+					0185C46328F6C04B006F9BDC = {
+						CreatedOnToolsVersion = 14.0.1;
 					};
 				};
 			};
@@ -139,6 +229,7 @@
 			projectRoot = "";
 			targets = (
 				010656A328DB2E8C00F2A9A6 /* Example */,
+				0185C46328F6C04B006F9BDC /* ExampleLibrary */,
 			);
 		};
 /* End PBXProject section */
@@ -154,6 +245,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		0185C46228F6C04B006F9BDC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -161,13 +259,31 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				011C69DD28F5747200C5BA3C /* SomeView.swift in Sources */,
 				010656AC28DB2E8C00F2A9A6 /* ViewController.swift in Sources */,
 				010656A828DB2E8C00F2A9A6 /* AppDelegate.swift in Sources */,
 				010656AA28DB2E8C00F2A9A6 /* SceneDelegate.swift in Sources */,
+				011C69E128F5CA1E00C5BA3C /* IgnoredViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0185C46028F6C04B006F9BDC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0185C47028F6C05D006F9BDC /* AnotherViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0185C46928F6C04B006F9BDC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0185C46328F6C04B006F9BDC /* ExampleLibrary */;
+			targetProxy = 0185C46828F6C04B006F9BDC /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		010656AD28DB2E8C00F2A9A6 /* Main.storyboard */ = {
@@ -306,6 +422,7 @@
 		010656B928DB2E8E00F2A9A6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -334,6 +451,7 @@
 		010656BA28DB2E8E00F2A9A6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -359,6 +477,68 @@
 			};
 			name = Release;
 		};
+		0185C46D28F6C04B006F9BDC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.ExampleLibrary;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		0185C46E28F6C04B006F9BDC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.ExampleLibrary;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -376,6 +556,15 @@
 			buildConfigurations = (
 				010656B928DB2E8E00F2A9A6 /* Debug */,
 				010656BA28DB2E8E00F2A9A6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0185C46F28F6C04B006F9BDC /* Build configuration list for PBXNativeTarget "ExampleLibrary" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0185C46D28F6C04B006F9BDC /* Debug */,
+				0185C46E28F6C04B006F9BDC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "010656A328DB2E8C00F2A9A6"
+               BuildableName = "Example.app"
+               BlueprintName = "Example"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "010656A328DB2E8C00F2A9A6"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "010656A328DB2E8C00F2A9A6"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -15,21 +15,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Spans can be started and ended before starting the SDK. They will be sent once the SDK has started.
-        let dflSpan = BugsnagPerformance.startSpan(name: "didFinishLaunchingWithOptions")
-        
         BugsnagPerformance.startSpan(name: "Before start").end()
-        
-        BugsnagPerformance.startSpan(name: "Another pre-start span").end()
-        
-        let startSpan = BugsnagPerformance.startSpan(name: "start")
         
         let config = BugsnagPerformanceConfiguration.loadConfig()
         // Inspect @ https://webhook.site/#!/14b03305-a46e-4e1f-b8b4-8434643631dc
         config.endpoint = URL(string: "https://webhook.site/14b03305-a46e-4e1f-b8b4-8434643631dc")!
-        BugsnagPerformance.start(configuration: config)
-        startSpan.end()
         
-        dflSpan.end()
+        // Disable automatic app startup instrumentation:
+        //config.autoInstrumentAppStarts = false
+        
+        // Disable automatic view controller instrumentation to prevent swizzling...
+        //config.autoInstrumentViewControllers = false
+        
+        // ... or control whether spans are created on a per-instance basis:
+        config.viewControllerInstrumentationCallback = {
+            !($0 is IgnoredViewController)
+        }
+        
+        BugsnagPerformance.start(configuration: config)
+        
         return true
     }
 }

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="yGw-kV-UMF">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="yGw-kV-UMF">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,8 +16,51 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="I5S-OR-fvf">
+                                <rect key="frame" x="101.5" y="355" width="211.5" height="186"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0ga-0O-hoa">
+                                        <rect key="frame" x="0.0" y="0.0" width="211.5" height="34.5"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="AnotherViewController &gt;"/>
+                                        <connections>
+                                            <segue destination="K5u-LY-aNB" kind="show" id="C85-Df-PBE"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jUe-GT-sTK">
+                                        <rect key="frame" x="38.5" y="50.5" width="134.5" height="34.5"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="SwiftUI View &gt;"/>
+                                        <connections>
+                                            <action selector="showSwiftUIView:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7Ab-Jo-wPm"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WB9-jo-IaN">
+                                        <rect key="frame" x="22" y="101" width="167" height="34.5"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="UIViewController &gt;"/>
+                                        <connections>
+                                            <segue destination="l9J-Wk-fsy" kind="show" id="aaN-Q5-KdO"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0dA-WH-9hh">
+                                        <rect key="frame" x="1" y="151.5" width="209" height="34.5"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="IgnoredViewController &gt;"/>
+                                        <connections>
+                                            <segue destination="V48-0c-1l8" kind="show" id="gAB-0C-fPE"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="I5S-OR-fvf" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="4Dd-ng-VLX"/>
+                            <constraint firstItem="I5S-OR-fvf" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="CxK-hS-5se"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="BugsnagPerformance Example" id="pNN-VF-4fz"/>
                 </viewController>
@@ -25,13 +68,61 @@
             </objects>
             <point key="canvasLocation" x="1042.0289855072465" y="115.84821428571428"/>
         </scene>
+        <!--UIViewController-->
+        <scene sceneID="xhN-fO-fmV">
+            <objects>
+                <viewController id="l9J-Wk-fsy" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Y2k-Wg-442">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="Kg8-IT-vq4"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="UIViewController" id="ksO-Tx-AoS"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="X50-XN-bsj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1958" y="844"/>
+        </scene>
+        <!--AnotherViewController-->
+        <scene sceneID="ZSZ-S0-tph">
+            <objects>
+                <viewController id="K5u-LY-aNB" customClass="AnotherViewController" customModule="ExampleLibrary" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="BKu-Iz-PQD">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="iso-Mg-Dre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="AnotherViewController" id="pFS-Q6-5ZR"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hbU-lu-QkT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1959" y="116"/>
+        </scene>
+        <!--IgnoredViewController-->
+        <scene sceneID="iq3-TT-nOa">
+            <objects>
+                <viewController id="V48-0c-1l8" customClass="IgnoredViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="tIX-aj-dii">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="NOk-u9-Jac"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="IgnoredViewController" id="cqj-3C-9Ge"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CSj-5p-6xg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2768" y="116"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="jrB-Aa-ftV">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="yGw-kV-UMF" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="OOJ-5c-3e1">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Example/Example/IgnoredViewController.swift
+++ b/Example/Example/IgnoredViewController.swift
@@ -1,0 +1,29 @@
+//
+//  IgnoredViewController.swift
+//  Example
+//
+//  Created by Nick Dowell on 11/10/2022.
+//
+
+import UIKit
+
+class IgnoredViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Example/Example/SomeView.swift
+++ b/Example/Example/SomeView.swift
@@ -1,0 +1,28 @@
+//
+//  SomeView.swift
+//  Example
+//
+//  Created by Nick Dowell on 11/10/2022.
+//
+
+import BugsnagPerformance
+import SwiftUI
+
+@available(iOS 13.0.0, *)
+struct SomeView: View {
+    var body: some View {
+        let span = BugsnagPerformance.startViewLoadSpan(
+            name: "SomeView", viewType: .swiftUI) 
+        Text("Hello from SwiftUI 🙃")
+            .onAppear {
+                span.end()
+            }
+    }
+}
+
+@available(iOS 13.0.0, *)
+struct SomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        SomeView()
+    }
+}

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -6,14 +6,18 @@
 //
 
 import UIKit
+import SwiftUI
 
 class ViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        // Do any additional setup after loading the view.
+    @IBAction func showSwiftUIView(_ sender: Any) {
+        if #available(iOS 13.0.0, *) {
+            show(UIHostingController(rootView: SomeView()), sender: sender)
+        } else {
+            present(UIAlertController(
+                title: "Error",
+                message: "SwiftUI is not available on this version of iOS",
+                preferredStyle: .alert), animated: true)
+        }
     }
-
-
 }
-

--- a/Example/ExampleLibrary/AnotherViewController.swift
+++ b/Example/ExampleLibrary/AnotherViewController.swift
@@ -1,0 +1,39 @@
+//
+//  AnotherViewController.swift
+//  ExampleLibrary
+//
+//  Created by Nick Dowell on 11/10/2022.
+//
+
+import UIKit
+
+class AnotherViewController: UIViewController {
+    
+    override func loadView() {
+        print("AnotherViewController", #function)
+        super.loadView()
+    }
+
+    override func viewDidLoad() {
+        print("AnotherViewController", #function)
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        print("AnotherViewController", #function)
+        super.viewDidAppear(animated)
+    }
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Example/ExampleLibrary/ExampleLibrary.h
+++ b/Example/ExampleLibrary/ExampleLibrary.h
@@ -1,0 +1,18 @@
+//
+//  ExampleLibrary.h
+//  ExampleLibrary
+//
+//  Created by Nick Dowell on 12/10/2022.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for ExampleLibrary.
+FOUNDATION_EXPORT double ExampleLibraryVersionNumber;
+
+//! Project version string for ExampleLibrary.
+FOUNDATION_EXPORT const unsigned char ExampleLibraryVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <ExampleLibrary/PublicHeader.h>
+
+

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,10 @@ let package = Package(
     targets: [
         .target(
             name: "BugsnagPerformance",
-            dependencies: []),
+            linkerSettings: [
+                .linkedFramework("UIKit")
+            ]
+        ),
         .testTarget(
             name: "BugsnagPerformanceTests",
             dependencies: ["BugsnagPerformance"]),

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -1,0 +1,37 @@
+//
+//  ViewLoadInstrumentation.h
+//  BugsnagPerformance
+//
+//  Created by Nick Dowell on 10/10/2022.
+//
+
+#import <UIKit/UIKit.h>
+
+#import <vector>
+
+namespace bugsnag {
+class ViewLoadInstrumentation {
+public:
+    ViewLoadInstrumentation(class Tracer &tracer, BOOL (^ callback)(UIViewController *)) noexcept
+    : tracer_(tracer)
+    , callback_(callback)
+    {}
+    
+    void start() noexcept;
+    
+private:
+    static std::vector<const char *> imagesToInstrument() noexcept;
+    static std::vector<Class> viewControllerSubclasses(const char *image) noexcept;
+    static bool isViewControllerSubclass(Class subclass) noexcept;
+    static IMP overrideImplementation(Class cls, SEL name, id block) noexcept;
+    
+    void instrument(Class cls) noexcept;
+    
+    void onLoadView(UIViewController *viewController) noexcept;
+    void onViewDidAppear(UIViewController *viewController) noexcept;
+    
+    class Tracer &tracer_;
+    BOOL (^ callback_)(UIViewController *viewController) = nullptr;
+    NSSet *observedClasses_ = nil;
+};
+}

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -1,0 +1,179 @@
+//
+//  ViewLoadInstrumentation.mm
+//  BugsnagPerformance
+//
+//  Created by Nick Dowell on 10/10/2022.
+//
+
+#import "ViewLoadInstrumentation.h"
+
+#import "../BugsnagPerformanceSpan+Private.h"
+#import "../Span.h"
+#import "../Tracer.h"
+
+#import <objc/runtime.h>
+
+#if 0
+#define Trace NSLog
+#else
+#define Trace(...)
+#endif
+
+using namespace bugsnag;
+
+static constexpr int kAssociatedSpan = 0;
+
+void
+ViewLoadInstrumentation::start() noexcept {
+    auto observedClasses = [NSMutableSet<Class> set];
+    
+    for (auto image : imagesToInstrument()) {
+        Trace(@"Instrumenting %s", image);
+        for (auto cls : viewControllerSubclasses(image)) {
+            Trace(@" - %s", class_getName(cls));
+            [observedClasses addObject:cls];
+            instrument(cls);
+        }
+    }
+    
+    observedClasses_ = observedClasses;
+    
+    // We need to instrument UIViewController because not all subclasses will
+    // override loadView and viewDidAppear:
+    instrument([UIViewController class]);
+}
+
+void
+ViewLoadInstrumentation::onLoadView(UIViewController *viewController) noexcept {
+    if (![observedClasses_ containsObject:[viewController class]]) {
+        return;
+    }
+    
+    // Allow customer code to prevent span creation for this view controller.
+    if (callback_ && !callback_(viewController)) {
+        return;
+    }
+    
+    // Prevent replacing an existing span for view controllers that override
+    // loadView and call through to superclass implementation(s).
+    if (objc_getAssociatedObject(viewController, &kAssociatedSpan)) {
+        return;
+    }
+    
+    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
+                 tracer_.startViewLoadedSpan(BugsnagPerformanceViewTypeUIKit,
+                                             NSStringFromClass([viewController class]),
+                                             CFAbsoluteTimeGetCurrent())];
+    
+    objc_setAssociatedObject(viewController, &kAssociatedSpan, span,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+void
+ViewLoadInstrumentation::onViewDidAppear(UIViewController *viewController) noexcept {
+    BugsnagPerformanceSpan *span = objc_getAssociatedObject(viewController, &kAssociatedSpan);
+    [span end];
+    
+    // Prevent calling -[BugsnagPerformanceSpan end] more than once.
+    objc_setAssociatedObject(viewController, &kAssociatedSpan, nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+// Suppress clang-tidy warnings about use of pointer arithmetic and free()
+// NOLINTBEGIN(cppcoreguidelines-*)
+
+std::vector<const char *>
+ViewLoadInstrumentation::imagesToInstrument() noexcept {
+    std::vector<const char *> images;
+    auto appPath = NSBundle.mainBundle.bundlePath.UTF8String;
+    auto count = 0U;
+    auto names = objc_copyImageNames(&count);
+    if (names) {
+        for (auto i = 0U; i < count; i++) {
+            // Instrument all images within the app bundle
+            if (strstr(names[i], appPath)
+#if TARGET_OS_SIMULATOR
+                // and those loaded from BUILT_PRODUCTS_DIR, because Xcode
+                // doesn't embed them when building for the Simulator.
+                || strstr(names[i], "/DerivedData/")
+#endif
+                ) {
+                images.push_back(names[i]);
+            }
+        }
+        free(names);
+    }
+    return images;
+}
+
+std::vector<Class>
+ViewLoadInstrumentation::viewControllerSubclasses(const char *image) noexcept {
+    std::vector<Class> classes;
+    auto count = 0U;
+    auto names = objc_copyClassNamesForImage(image, &count);
+    if (names) {
+        for (int i = 0; i < count; i++) {
+            auto cls = objc_getClass(names[i]);
+            if (isViewControllerSubclass(cls)) {
+                classes.push_back(cls);
+            }
+        }
+        free(names);
+    }
+    return classes;
+}
+
+bool
+ViewLoadInstrumentation::isViewControllerSubclass(Class cls) noexcept {
+    const auto root = [UIViewController class];
+    while (cls && cls != root) {
+        cls = class_getSuperclass(cls);
+    }
+    return cls != nil;
+}
+
+void
+ViewLoadInstrumentation::instrument(Class cls) noexcept {
+    SEL selector = @selector(loadView);
+    IMP loadView __block = nullptr;
+    loadView = overrideImplementation(cls, selector, ^(id self){
+        Trace(@"%@   -[%s %s]", self, class_getName(cls), sel_getName(selector));
+        onLoadView(self);
+        reinterpret_cast<void (*)(id, SEL)>(loadView)(self, selector);
+    });
+    
+    selector = @selector(viewDidAppear:);
+    IMP viewDidAppear __block = nullptr;
+    viewDidAppear = overrideImplementation(cls, selector, ^(id self, BOOL animated){
+        Trace(@"%@   -[%s %s]", self, class_getName(cls), sel_getName(selector));
+        reinterpret_cast<void (*)(id, SEL, BOOL)>(viewDidAppear)(self, selector, animated);
+        onViewDidAppear(self);
+    });
+}
+
+IMP
+ViewLoadInstrumentation::overrideImplementation(Class cls, SEL name, id block) noexcept {
+    Method method = nullptr;
+    
+    // Not using class_getInstanceMethod because we don't want to modify the
+    // superclass's implementation.
+    auto methodCount = 0U;
+    Method *methods = class_copyMethodList(cls, &methodCount);
+    if (methods) {
+        for (auto i = 0U; i < methodCount; i++) {
+            if (sel_isEqual(method_getName(methods[i]), name)) {
+                method = methods[i];
+                break;
+            }
+        }
+        free(methods);
+    }
+    
+    if (!method) {
+        return nullptr;
+    }
+    
+    return method_setImplementation(method, imp_implementationWithBlock(block));
+}
+
+// NOLINTEND(cppcoreguidelines-*)

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -5,6 +5,7 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
+#import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
 #import <memory>
 
@@ -16,8 +17,7 @@ public:
     
     ~Tracer() noexcept;
     
-    void start(NSURL *endpoint,
-               bool autoInstrumentAppStarts) noexcept;
+    void start(BugsnagPerformanceConfiguration *configuration) noexcept;
     
     std::unique_ptr<class Span> startSpan(NSString *name, CFAbsoluteTime startTime) noexcept;
     
@@ -28,5 +28,6 @@ public:
 private:
     std::shared_ptr<class SpanProcessor> spanProcessor_;
     std::unique_ptr<class AppStartupInstrumentation> appStartupInstrumentation_;
+    std::unique_ptr<class ViewLoadInstrumentation> viewLoadInstrumentation_;
 };
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -21,8 +21,7 @@ static Tracer tracer;
 }
 
 + (void)startWithConfiguration:(BugsnagPerformanceConfiguration *)configuration {
-    tracer.start(configuration.endpoint,
-                 configuration.autoInstrumentAppStarts);
+    tracer.start(configuration);
 }
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name {

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -12,6 +12,7 @@
 - (instancetype)init {
     if ((self = [super init])) {
         _autoInstrumentAppStarts = YES;
+        _autoInstrumentViewControllers = YES;
         _endpoint = [NSURL URLWithString:@"https://127.0.0.0"];
     }
     return self;

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -5,9 +5,11 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+typedef BOOL (^ BugsnagPerformanceViewControllerInstrumentationCallback)(UIViewController *viewController);
 
 @interface BugsnagPerformanceConfiguration : NSObject
 
@@ -17,7 +19,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL autoInstrumentAppStarts;
 
+@property (nonatomic) BOOL autoInstrumentViewControllers;
+
 @property (nonatomic) NSURL *endpoint;
+
+@property (nullable, nonatomic) BugsnagPerformanceViewControllerInstrumentationCallback viewControllerInstrumentationCallback;
 
 @end
 

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -15,3 +15,19 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.version" equals "0.0"
+
+  Scenario: AutoInstrumentViewLoadScenario
+    Given I run "AutoInstrumentViewLoadScenario"
+    And I wait to receive a trace
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ViewLoaded/UIKit/Fixture.AutoInstrumentViewLoadScenario_ViewController"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.span_category" equals "view_load"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.view_type" equals "UIKit"
+    * the trace payload field "resourceSpans.0.resource" attribute "service.name" equals "com.bugsnag.Fixture"
+    * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.version" equals "0.0"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0185C47228F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0185C47128F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift */; };
 		01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */; };
 		01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */; };
 		01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */; };
@@ -23,6 +24,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0185C47128F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentViewLoadScenario.swift; sourceTree = "<group>"; };
 		01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentAppStartsScenario.swift; sourceTree = "<group>"; };
 		01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualViewLoadScenario.swift; sourceTree = "<group>"; };
 		01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanBeforeStartScenario.swift; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 			isa = PBXGroup;
 			children = (
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
+				0185C47128F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
 				01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */,
@@ -152,7 +155,7 @@
 				};
 			};
 			buildConfigurationList = 01FE4DA028E1AEBD00D1F239 /* Build configuration list for PBXProject "Fixture" */;
-			compatibilityVersion = "Xcode 14.0";
+			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -187,6 +190,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0185C47228F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */,
 				01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */,

--- a/features/fixtures/ios/Fixture.xcodeproj/xcshareddata/xcschemes/Fixture.xcscheme
+++ b/features/fixtures/ios/Fixture.xcodeproj/xcshareddata/xcschemes/Fixture.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "01FE4DA428E1AEBD00D1F239"
+               BuildableName = "Fixture.app"
+               BlueprintName = "Fixture"
+               ReferencedContainer = "container:Fixture.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "01FE4DA428E1AEBD00D1F239"
+            BuildableName = "Fixture.app"
+            BlueprintName = "Fixture"
+            ReferencedContainer = "container:Fixture.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "01FE4DA428E1AEBD00D1F239"
+            BuildableName = "Fixture.app"
+            BlueprintName = "Fixture"
+            ReferencedContainer = "container:Fixture.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/features/fixtures/ios/Fixture/Fixture.swift
+++ b/features/fixtures/ios/Fixture/Fixture.swift
@@ -32,7 +32,9 @@ func fetchAndExecuteCommand() {
             return
         }
         
-        run(command: command)
+        DispatchQueue.main.async {
+            run(command: command)
+        }
     }.resume()
 }
 

--- a/features/fixtures/ios/Scenarios/AutoInstrumentViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentViewLoadScenario.swift
@@ -1,0 +1,32 @@
+//
+//  AutoInstrumentViewLoadScenario.swift
+//  Fixture
+//
+//  Created by Nick Dowell on 12/10/2022.
+//
+
+import UIKit
+
+class AutoInstrumentViewLoadScenario: Scenario {
+    
+    override func startBugsnag() {
+        config.autoInstrumentViewControllers = true
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        UIApplication.shared.windows[0].rootViewController!.present(
+            AutoInstrumentViewLoadScenario_ViewController(), animated: true)
+    }
+}
+
+class AutoInstrumentViewLoadScenario_ViewController: UIViewController {
+    
+    override func loadView() {
+        let label = UILabel()
+        label.backgroundColor = .white
+        label.textAlignment = .center
+        label.text = String(describing: type(of: self))
+        view = label
+    }
+}

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -15,6 +15,7 @@ class Scenario: NSObject {
     override init() {
         config = BugsnagPerformanceConfiguration.loadConfig()
         config.autoInstrumentAppStarts = false
+        config.autoInstrumentViewControllers = false
         config.endpoint = URL(string: "http://bs-local.com:9339/traces")!
     }
     


### PR DESCRIPTION
## Goal

Automatically create spans for app-defined `UIViewController` subclasses.

## Design

https://smartbear.atlassian.net/wiki/spaces/EN/pages/3312189550/ROAD-847+ED+-+Screen+Load+Instrumentation

## Changeset

Adds `configuration.autoInstrumentViewControllers` and `configuration.viewControllerInstrumentationCallback`.

Adds `ViewLoadInstrumentation` class which implements automatic spans by swizzling `loadView` and `viewDidAppear:`. Note: since each of the app's UIViewController subclasses need to be swizzled, the setup time will scale with the size of the app.

## Testing

Updates example app to facilitate manual testing.

Adds a simple E2E scenario for auto-instrumentation.