### PR TITLE
Automatic network performance for URLSession tasks

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -42,6 +42,10 @@
 		0122C26F29019CEF002D243C /* BugsnagPerformanceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0122C25F29019C05002D243C /* BugsnagPerformanceTests.mm */; };
 		0122C27029019CEF002D243C /* BatchSpanProcessorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0122C25D29019C05002D243C /* BatchSpanProcessorTests.mm */; };
 		0122C27129019CEF002D243C /* OtlpTraceEncodingTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0122C26029019C05002D243C /* OtlpTraceEncodingTests.mm */; };
+		CB34771E29068C350033759C /* NSURLSession+Instrumentation.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB34771A29068C350033759C /* NSURLSession+Instrumentation.mm */; };
+		CB34771F29068C350033759C /* BSGURLSessionPerformanceProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */; };
+		CB34772029068C350033759C /* BSGURLSessionPerformanceProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */; };
+		CB34772129068C350033759C /* NSURLSession+Instrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -92,6 +96,10 @@
 		0122C26529019CE1002D243C /* BugsnagPerformance-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagPerformance-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		01EF4A3E29067786003CC5A5 /* BugsnagPerformance.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BugsnagPerformance.xcconfig; sourceTree = "<group>"; };
 		72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformance.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB34771A29068C350033759C /* NSURLSession+Instrumentation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSURLSession+Instrumentation.mm"; sourceTree = "<group>"; };
+		CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGURLSessionPerformanceProxy.m; sourceTree = "<group>"; };
+		CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGURLSessionPerformanceProxy.h; sourceTree = "<group>"; };
+		CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSession+Instrumentation.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -189,6 +197,7 @@
 		0122C22929019770002D243C /* Instrumentation */ = {
 			isa = PBXGroup;
 			children = (
+				CB34771929068C350033759C /* NetworkInstrumentation */,
 				0122C22C29019770002D243C /* AppStartupInstrumentation.h */,
 				0122C22B29019770002D243C /* AppStartupInstrumentation.mm */,
 				0122C22E29019770002D243C /* NetworkInstrumentation.h */,
@@ -245,6 +254,17 @@
 			);
 			sourceTree = "<group>";
 		};
+		CB34771929068C350033759C /* NetworkInstrumentation */ = {
+			isa = PBXGroup;
+			children = (
+				CB34771A29068C350033759C /* NSURLSession+Instrumentation.mm */,
+				CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */,
+				CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */,
+				CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */,
+			);
+			path = NetworkInstrumentation;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -253,6 +273,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0122C25229019770002D243C /* OtlpTraceExporter.h in Headers */,
+				CB34772029068C350033759C /* BSGURLSessionPerformanceProxy.h in Headers */,
 				0122C24C29019770002D243C /* NetworkInstrumentation.h in Headers */,
 				0122C24729019770002D243C /* SpanData.h in Headers */,
 				0122C25429019770002D243C /* SpanExporter.h in Headers */,
@@ -270,6 +291,7 @@
 				0122C23B29019770002D243C /* BugsnagPerformance.h in Headers */,
 				0122C24629019770002D243C /* SpanProcessor.h in Headers */,
 				0122C24B29019770002D243C /* ViewLoadInstrumentation.h in Headers */,
+				CB34772129068C350033759C /* NSURLSession+Instrumentation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -383,12 +405,14 @@
 				0122C23D29019770002D243C /* BugsnagPerformance.mm in Sources */,
 				0122C24329019770002D243C /* BatchSpanProcessor.mm in Sources */,
 				0122C23E29019770002D243C /* BugsnagPerformanceSpan.mm in Sources */,
+				CB34771E29068C350033759C /* NSURLSession+Instrumentation.mm in Sources */,
 				0122C23C29019770002D243C /* BugsnagPerformanceConfiguration.mm in Sources */,
 				0122C25529019770002D243C /* OtlpTraceExporter.mm in Sources */,
 				0122C24529019770002D243C /* Span.mm in Sources */,
 				0122C24029019770002D243C /* SpanData.mm in Sources */,
 				0122C24829019770002D243C /* NetworkInstrumentation.mm in Sources */,
 				0122C24D29019770002D243C /* ViewLoadInstrumentation.mm in Sources */,
+				CB34771F29068C350033759C /* BSGURLSessionPerformanceProxy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -26,6 +26,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // Disable automatic view controller instrumentation to prevent swizzling...
         //config.autoInstrumentViewControllers = false
+
+        config.autoInstrumentNetwork = true
         
         // ... or control whether spans are created on a per-instance basis:
         config.viewControllerInstrumentationCallback = {

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="I5S-OR-fvf">
-                                <rect key="frame" x="101.5" y="355" width="211.5" height="186"/>
+                                <rect key="frame" x="101.5" y="330" width="211.5" height="236.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0ga-0O-hoa">
                                         <rect key="frame" x="0.0" y="0.0" width="211.5" height="34.5"/>
@@ -50,6 +50,14 @@
                                         <buttonConfiguration key="configuration" style="plain" title="IgnoredViewController &gt;"/>
                                         <connections>
                                             <segue destination="V48-0c-1l8" kind="show" id="gAB-0C-fPE"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WLB-9O-ylx">
+                                        <rect key="frame" x="28" y="202" width="155" height="34.5"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Network Request"/>
+                                        <connections>
+                                            <action selector="DoNetworkRequest:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Llg-LD-ytB"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -20,4 +20,20 @@ class ViewController: UIViewController {
                 preferredStyle: .alert), animated: true)
         }
     }
+
+    func query(string: String) {
+        let url = URL(string: "https://bugsnag.com")!
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let task = URLSession.shared.dataTask(with: url) {(data, response, error) in
+            semaphore.signal()
+        }
+        task.resume()
+        semaphore.wait()
+        Thread.sleep(forTimeInterval: 1)
+    }
+
+    @IBAction func DoNetworkRequest(_ sender: Any) {
+        query(string: "x")
+    }
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.h
@@ -5,20 +5,20 @@
 //  Created by Karl Stenerud on 14.10.22.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import "../Tracer.h"
 
-#import <vector>
+@interface BSGURLSessionPerformanceDelegate : NSObject
+@end
 
 namespace bugsnag {
 class NetworkInstrumentation {
 public:
-    NetworkInstrumentation(class Tracer &tracer) noexcept
-    : tracer_(tracer)
-    {}
-    
+    NetworkInstrumentation(Tracer &tracer, NSString * _Nonnull baseEndpoint) noexcept;
     void start() noexcept;
     
 private:
-    class Tracer &tracer_;
+    BSGURLSessionPerformanceDelegate * _Nonnull delegate_;
+    Tracer &tracer_;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
@@ -6,10 +6,9 @@
 //
 
 #import "NetworkInstrumentation.h"
+#import "NetworkInstrumentation/NSURLSession+Instrumentation.h"
 
-#import "../BugsnagPerformanceSpan+Private.h"
 #import "../Span.h"
-#import "../Tracer.h"
 
 #import <objc/runtime.h>
 
@@ -21,7 +20,45 @@
 
 using namespace bugsnag;
 
+@interface BSGURLSessionPerformanceDelegate () <NSURLSessionTaskDelegate>
+
+@property(readonly,nonatomic) Tracer *tracer;
+@property(readonly,strong,nonatomic) NSString * _Nonnull baseEndpoint;
+
+- (instancetype) initWithTracer:(Tracer *)tracer  baseEndpoint:(NSString * _Nonnull)baseEndpoint;
+
+@end
+
+@implementation BSGURLSessionPerformanceDelegate
+
+- (instancetype) initWithTracer:(Tracer *)tracer baseEndpoint:(NSString * _Nonnull)baseEndpoint {
+    if ((self = [super init]) != nil) {
+        _tracer = tracer;
+        _baseEndpoint = baseEndpoint;
+    }
+    return self;
+}
+
+- (void)URLSession:(__unused NSURLSession *)session task:(NSURLSessionTask *)task didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics
+API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0)) {
+
+    if (self.baseEndpoint.length > 0 && [task.originalRequest.URL.absoluteString hasPrefix:self.baseEndpoint]) {
+        return;
+    }
+
+    self.tracer->reportNetworkSpan(task, metrics);
+}
+
+@end
+
+
+NetworkInstrumentation::NetworkInstrumentation(Tracer &tracer, NSString * _Nonnull baseEndpoint) noexcept
+: tracer_(tracer)
+, delegate_([[BSGURLSessionPerformanceDelegate alloc] initWithTracer:&tracer baseEndpoint:baseEndpoint])
+{}
+
 void
 NetworkInstrumentation::start() noexcept {
     Trace(@"NetworkInstrumentation::start()");
+    bsg_installNSURLSessionPerformance(delegate_);
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGURLSessionPerformanceProxy.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGURLSessionPerformanceProxy.h
@@ -1,0 +1,23 @@
+//
+//  BSGURLSessionPerformanceProxy.h
+//
+//
+//  Created by Karl Stenerud on 20.10.22.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * BSGURLSessionPerformanceProxy sits in between an NSURLSession and NSURLSessionDelegate to also invoke the shared
+ * NSURLSessionTaskDelegate (which captures NSURLSessionTaskMetrics to gather performance data).
+ */
+@interface BSGURLSessionPerformanceProxy : NSProxy<NSURLSessionDelegate>
+
+- (instancetype)initWithSessionDelegate:(nonnull id<NSURLSessionDelegate>)sessionDelegate
+                           taskDelegate:(nonnull id<NSURLSessionTaskDelegate>)taskDelegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGURLSessionPerformanceProxy.m
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGURLSessionPerformanceProxy.m
@@ -1,0 +1,61 @@
+//
+//  BSGURLSessionPerformanceProxy.m
+//
+//
+//  Created by Karl Stenerud on 20.10.22.
+//
+
+#import "BSGURLSessionPerformanceProxy.h"
+#import <objc/runtime.h>
+
+
+@interface BSGURLSessionPerformanceProxy ()
+
+@property (nonatomic, strong, readonly, nonnull) id<NSURLSessionDelegate> sessionDelegate;
+@property (nonatomic, strong, readonly, nonnull) id<NSURLSessionTaskDelegate> taskDelegate;
+
+@end
+
+
+@implementation BSGURLSessionPerformanceProxy
+
+#define METRICS_SELECTOR @selector(URLSession:task:didFinishCollectingMetrics:)
+
+- (instancetype)initWithSessionDelegate:(nonnull id<NSURLSessionDelegate>)sessionDelegate
+                           taskDelegate:(nonnull id<NSURLSessionTaskDelegate>) taskDelegate {
+    _sessionDelegate = sessionDelegate;
+    _taskDelegate = taskDelegate;
+
+    return self;
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+    return [self.sessionDelegate respondsToSelector:aSelector];
+}
+
+// Implementing this method prevents a crash when used alongside NewRelic
+- (id)forwardingTargetForSelector:(__unused SEL)aSelector {
+    return self.sessionDelegate;
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+    [invocation invokeWithTarget:self.sessionDelegate];
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector {
+    if (sel_isEqual(aSelector, METRICS_SELECTOR)) {
+        return [(NSObject *)self.taskDelegate methodSignatureForSelector:aSelector];
+    }
+    return [(NSObject *)self.sessionDelegate methodSignatureForSelector:aSelector];
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics
+API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0)) {
+    [self.taskDelegate URLSession:session task:task didFinishCollectingMetrics:metrics];
+
+    if ([self.sessionDelegate respondsToSelector:METRICS_SELECTOR]) {
+        [(id)self.sessionDelegate URLSession:session task:task didFinishCollectingMetrics:metrics];
+    }
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSession+Instrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSession+Instrumentation.h
@@ -1,0 +1,18 @@
+//
+//  NSURLSession+Instrumentation.h
+//
+//
+//  Created by Karl Stenerud on 20.10.22.
+//
+
+#ifndef NSURLSession_Instrumentation_h
+#define NSURLSession_Instrumentation_h
+
+#import <Foundation/Foundation.h>
+
+/**
+ * Performs all swizzling necesary to install tracing for automatic network performance reporting.
+ */
+void bsg_installNSURLSessionPerformance(id<NSURLSessionTaskDelegate> taskDelegate);
+
+#endif /* NSURLSession_Instrumentation_h */

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSession+Instrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSession+Instrumentation.mm
@@ -1,0 +1,64 @@
+//
+//  NSURLSession+Instrumentation.m
+//
+//
+//  Created by Karl Stenerud on 20.10.22.
+//
+
+#import "NSURLSession+Instrumentation.h"
+#import "BSGURLSessionPerformanceProxy.h"
+#import <objc/runtime.h>
+
+
+static IMP set_class_imp(Class _Nonnull clazz, SEL selector, id _Nonnull implementationBlock) {
+    Method method = class_getClassMethod(clazz, selector);
+    if (method) {
+        return method_setImplementation(method, imp_implementationWithBlock(implementationBlock));
+    } else {
+        NSLog(@"WARNING: Could not set IMP for selector %s on class %@", sel_getName(selector), clazz);
+        return nil;
+    }
+}
+
+static void replace_NSURLSession_sessionWithConfigurationDelegateQueue(id<NSURLSessionTaskDelegate> taskDelegate) {
+    Class clazz = NSURLSession.class;
+    SEL selector = @selector(sessionWithConfiguration:delegate:delegateQueue:);
+    typedef NSURLSession *(*IMPPrototype)(id, SEL, NSURLSessionConfiguration *,
+                                          id<NSURLSessionDelegate>, NSOperationQueue *);
+    __block IMPPrototype originalIMP = (IMPPrototype)set_class_imp(clazz,
+                                                                   selector,
+                                                                   ^(id self,
+                                                                     NSURLSessionConfiguration *configuration,
+                                                                     id<NSURLSessionDelegate> sessionDelegate,
+                                                                     NSOperationQueue *queue) {
+        if (sessionDelegate) {
+            sessionDelegate = [[BSGURLSessionPerformanceProxy alloc] initWithSessionDelegate:sessionDelegate taskDelegate:taskDelegate];
+        } else {
+            sessionDelegate = taskDelegate;
+        }
+        return originalIMP(self, selector, configuration, sessionDelegate, queue);
+    });
+}
+
+static void replace_NSURLSession_sharedSession() {
+    set_class_imp(NSURLSession.class, @selector(sharedSession), ^(__unused id self) {
+        static NSURLSession *session;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            // The shared session uses the shared NSURLCache, NSHTTPCookieStorage,
+            // and NSURLCredentialStorage objects, uses a shared custom networking
+            // protocol list (configured with registerClass: and unregisterClass:),
+            // and is based on a default configuration.
+            // https://developer.apple.com/documentation/foundation/nsurlsession/1409000-sharedsession
+            session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
+                                                    delegate:nil delegateQueue:nil];
+        });
+
+        return session;
+    });
+}
+
+void bsg_installNSURLSessionPerformance(id<NSURLSessionTaskDelegate> taskDelegate) {
+    replace_NSURLSession_sessionWithConfigurationDelegateQueue(taskDelegate);
+    replace_NSURLSession_sharedSession();
+}

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -29,5 +29,6 @@ private:
     std::shared_ptr<class SpanProcessor> spanProcessor_;
     std::unique_ptr<class AppStartupInstrumentation> appStartupInstrumentation_;
     std::unique_ptr<class ViewLoadInstrumentation> viewLoadInstrumentation_;
+    std::unique_ptr<class NetworkInstrumentation> networkInstrumentation_;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -10,6 +10,7 @@
 #import "BatchSpanProcessor.h"
 #import "Instrumentation/AppStartupInstrumentation.h"
 #import "Instrumentation/ViewLoadInstrumentation.h"
+#import "Instrumentation/NetworkInstrumentation.h"
 #import "OtlpTraceExporter.h"
 #import "Span.h"
 
@@ -43,7 +44,11 @@ Tracer::start(BugsnagPerformanceConfiguration *configuration) noexcept {
         viewLoadInstrumentation_->start();
     }
     
-    NSLog(@"BugsnagPerformance started");
+    if (configuration.autoInstrumentNetwork) {
+        NSString *baseEndpoint = configuration.endpoint.absoluteString ?: @"";
+        networkInstrumentation_ = std::make_unique<NetworkInstrumentation>(*this, baseEndpoint);
+        networkInstrumentation_->start();
+    }
 }
 
 std::unique_ptr<Span>

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -45,7 +45,8 @@ static Tracer tracer;
             tracer.startViewLoadedSpan(viewType, name, startTime.timeIntervalSinceReferenceDate)];
 }
 
-+ (void)reportNetworkRequestSpanWithTask:(NSURLSessionTask *)task metrics:(NSURLSessionTaskMetrics *)metrics {
++ (void)reportNetworkRequestSpanWithTask:(NSURLSessionTask *)task
+                                 metrics:(NSURLSessionTaskMetrics *)metrics {
     tracer.reportNetworkSpan(task, metrics);
 }
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -22,6 +22,8 @@ OBJC_EXPORT
 
 @property (nonatomic) BOOL autoInstrumentViewControllers;
 
+@property (nonatomic) BOOL autoInstrumentNetwork;
+
 @property (nonatomic) NSURL *endpoint;
 
 @property (nullable, nonatomic) BugsnagPerformanceViewControllerInstrumentationCallback viewControllerInstrumentationCallback;

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -31,3 +31,23 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
+
+  Scenario: Automatically start a network span
+    Given I run "AutoInstrumentNetworkScenario"
+    And I wait to receive a trace
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.flavor" exists
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "http://.*:9340/reflect/"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "net.host.connection.type" equals "wifi"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */; };
 		01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC428E1AF9600D1F239 /* Scenario.swift */; };
 		01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC628E1D5A400D1F239 /* Fixture.swift */; };
+		CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
 /* End PBXBuildFile section */
 
@@ -41,6 +42,7 @@
 		01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanScenario.swift; sourceTree = "<group>"; };
 		01FE4DC428E1AF9600D1F239 /* Scenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scenario.swift; sourceTree = "<group>"; };
 		01FE4DC628E1D5A400D1F239 /* Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
+		CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -109,12 +111,13 @@
 			isa = PBXGroup;
 			children = (
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
+				CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */,
 				0185C47128F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift */,
+				CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
 				01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
-				CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -199,6 +202,7 @@
 				01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */,
 				01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */,
 				01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */,
+				CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */,
 				CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */,
 				01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkScenario.swift
@@ -1,0 +1,38 @@
+//
+//  AutoInstrumentNetworkScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 20.10.22.
+//
+
+import Foundation
+
+class AutoInstrumentNetworkScenario: Scenario {
+
+    lazy var baseURL: URL = {
+        var components = URLComponents(string: Scenario.mazeRunnerURL.absoluteString)!
+        components.port = 9340 // `/reflect` listens on a different port :-((
+        return components.url!
+    }()
+
+    override func startBugsnag() {
+        config.autoInstrumentNetwork = true
+        super.startBugsnag()
+    }
+
+    func query(string: String) {
+        let url = URL(string: string, relativeTo: baseURL)!
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let task = URLSession.shared.dataTask(with: url) {(data, response, error) in
+            semaphore.signal()
+        }
+        task.resume()
+        semaphore.wait()
+        Thread.sleep(forTimeInterval: 1)
+    }
+
+    override func run() {
+        query(string: "/reflect/?status=200")
+    }
+}


### PR DESCRIPTION
## Goal

Add automatic network performance for URLSession tasks.

## Design

Network requests will be captured for performance measurement from the point that Bugsnag starts.

Requests to the same base URL as the reporter itself will not be captured (to avoid an endless loop).

## Testing

Added e2e test
