### PR TITLE
Fix build error on GitHub Actions

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -323,11 +323,6 @@
 				TargetAttributes = {
 					0122C26429019CE1002D243C = {
 						CreatedOnToolsVersion = 14.0.1;
-						DevelopmentTeam = 372ZUL2ZB7;
-						ProvisioningStyle = Automatic;
-					};
-					B4A4A4DE1EA43C6C4D6D3894 = {
-						DevelopmentTeam = 372ZUL2ZB7;
 					};
 				};
 			};


### PR DESCRIPTION
## Goal

Fixes a build error on GitHub Actions (and for any developers not belonging to the Bugsnag dev team) due to code signing settings.

## Changeset

Remove code signing settings from Xcode project.

## Testing

Verified here - https://github.com/bugsnag/bugsnag-cocoa-performance/actions/runs/3313363853