### PR TITLE
Remove Bugsnag-Sampling-Probability-Duration header

### DIFF
--- a/Sources/BugsnagPerformance/Private/Sampler.h
+++ b/Sources/BugsnagPerformance/Private/Sampler.h
@@ -20,7 +20,7 @@ public:
         fallbackProbability_ = value;
     }
     
-    void setProbability(double probability, CFAbsoluteTime expiry) noexcept;
+    void setProbability(double probability) noexcept;
     
     struct Decision {
         /// Whether this span should be included in data sent to the back-end.

--- a/Sources/BugsnagPerformance/Private/Sampler.mm
+++ b/Sources/BugsnagPerformance/Private/Sampler.mm
@@ -9,6 +9,8 @@
 
 using namespace bugsnag;
 
+static const CFTimeInterval kProbabilityDuration = 24 * 3600;
+
 static NSString *kUserDefaultsKey = @"BugsnagPerformanceSampler";
 static NSString *kProbabilityKey = @"p";
 static NSString *kExpiryKey = @"e";
@@ -38,7 +40,8 @@ Sampler::getProbability() noexcept {
 }
 
 void
-Sampler::setProbability(double probability, CFAbsoluteTime expiry) noexcept {
+Sampler::setProbability(double probability) noexcept {
+    auto expiry = CFAbsoluteTimeGetCurrent() + kProbabilityDuration;
     probability_ = probability;
     probabilityExpiry_ = expiry;
     
@@ -52,12 +55,8 @@ Sampler::setProbability(double probability, CFAbsoluteTime expiry) noexcept {
 void
 Sampler::setProbabilityFromResponseHeaders(NSDictionary *headers) noexcept {
     NSString *probability = headers[@"Bugsnag-Sampling-Probability"];
-    NSString *duration    = headers[@"Bugsnag-Sampling-Probability-Duration"];
-    if (probability && duration) {
-        auto expiry = [[NSDate dateWithTimeIntervalSinceNow:
-                        [duration doubleValue]]
-                       timeIntervalSinceReferenceDate];
-        setProbability([probability doubleValue], expiry);
+    if (probability) {
+        setProbability([probability doubleValue]);
     }
 }
 

--- a/Tests/BugsnagPerformanceTests/SamplerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SamplerTests.mm
@@ -36,21 +36,12 @@ using namespace bugsnag;
     }
 }
 
-- (void)testProbabilityExpiry {
-    auto defaultProbability = 1.0;
-    Sampler sampler(defaultProbability);
-    XCTAssertEqual(sampler.getProbability(), defaultProbability);
-    
-    sampler.setProbability(0.1, 123.0);
-    XCTAssertEqual(sampler.getProbability(), defaultProbability);
-}
-
 - (void)testProbabilityPersistence {
     auto defaultProbability = 1.0;
     Sampler sampler(defaultProbability);
     XCTAssertEqual(sampler.getProbability(), defaultProbability);
     
-    sampler.setProbability(0.5, [NSDate distantFuture].timeIntervalSinceReferenceDate);
+    sampler.setProbability(0.5);
     XCTAssertEqual(Sampler(1.0).getProbability(), 0.5);
 }
 


### PR DESCRIPTION
## Goal

Remove support for `Bugsnag-Sampling-Probability-Duration` header that has now been dropped from the design.

Relates to https://github.com/bugsnag/bugsnag-cocoa-performance/pull/16