### PR TITLE
Add batching support

### DIFF
--- a/Sources/BugsnagPerformance/Private/BatchSpanProcessor.h
+++ b/Sources/BugsnagPerformance/Private/BatchSpanProcessor.h
@@ -17,19 +17,32 @@ namespace bugsnag {
 class BatchSpanProcessor: public SpanProcessor {
 public:
     BatchSpanProcessor(std::shared_ptr<class Sampler> sampler) noexcept;
-    
+    ~BatchSpanProcessor() noexcept;
+
     void onEnd(std::unique_ptr<SpanData> span) noexcept override;
     
     void setSpanExporter(std::shared_ptr<SpanExporter> exporter) noexcept;
     
 private:
     bool shouldSample(std::unique_ptr<SpanData> &span) noexcept;
-    
+
+    static void notificationCallback(CFNotificationCenterRef center,
+                                     void *observer,
+                                     CFNotificationName name,
+                                     const void *object,
+                                     CFDictionaryRef userInfo) noexcept;
+
+    bool tryExportSpans() noexcept;
     void exportSpans() noexcept;
-    
+
+    void startTimer() noexcept;
+    void stopTimer() noexcept;
+
+    void(^timerCallback)();
     std::mutex mutex_;
     std::shared_ptr<SpanExporter> exporter_;
     std::shared_ptr<class Sampler> sampler_;
     std::vector<std::unique_ptr<SpanData>> spans_;
+    NSMutableData *timerCallbackValidityMarker;
 };
 }

--- a/Sources/BugsnagPerformance/Private/BatchSpanProcessor.mm
+++ b/Sources/BugsnagPerformance/Private/BatchSpanProcessor.mm
@@ -8,12 +8,51 @@
 #import "BatchSpanProcessor.h"
 
 #import "Sampler.h"
+#import <time.h>
+
+// Exposed internally for unit tests
+extern uint64_t bsg_autoTriggerExportOnBatchSize;
+extern dispatch_time_t bsg_autoTriggerExportOnTimeDuration;
+
+uint64_t bsg_autoTriggerExportOnBatchSize = 100;
+dispatch_time_t bsg_autoTriggerExportOnTimeDuration = 30 * NSEC_PER_SEC;
 
 using namespace bugsnag;
 
+
 BatchSpanProcessor::BatchSpanProcessor(std::shared_ptr<class Sampler> sampler) noexcept
 : sampler_(sampler)
-{}
+, timerCallbackValidityMarker([NSMutableData dataWithLength:0])
+{
+    CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(),
+                                    this,
+                                    notificationCallback,
+                                    CFSTR("UIApplicationDidEnterBackgroundNotification"),
+                                    nullptr,
+                                    CFNotificationSuspensionBehaviorDeliverImmediately);
+}
+
+BatchSpanProcessor::~BatchSpanProcessor() noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    CFNotificationCenterRemoveObserver(CFNotificationCenterGetLocalCenter(),
+                                       this,
+                                       CFSTR("UIApplicationDidEnterBackgroundNotification"),
+                                       nullptr);
+    stopTimer();
+}
+
+void
+BatchSpanProcessor::notificationCallback(__unused CFNotificationCenterRef center,
+                                         __unused void *observer,
+                                         __unused CFNotificationName name,
+                                         __unused const void *object,
+                                         __unused CFDictionaryRef userInfo) noexcept {
+    auto this_ = (BatchSpanProcessor *)observer;
+    if (this_ != nullptr) {
+        std::lock_guard<std::mutex> guard(this_->mutex_);
+        this_->exportSpans();
+    }
+}
 
 void
 BatchSpanProcessor::onEnd(std::unique_ptr<SpanData> span) noexcept {
@@ -23,8 +62,9 @@ BatchSpanProcessor::onEnd(std::unique_ptr<SpanData> span) noexcept {
         return;
     }
     spans_.push_back(std::move(span));
-    // TODO: batch up spans until a flush trigger is reached
-    exportSpans();
+    if (!tryExportSpans()) {
+        startTimer();
+    }
 }
 
 void
@@ -44,8 +84,23 @@ BatchSpanProcessor::shouldSample(std::unique_ptr<SpanData> &span) noexcept {
     return true;
 }
 
+bool
+BatchSpanProcessor::tryExportSpans() noexcept {
+    stopTimer();
+
+    // Try all conditions to automatically export the current batch
+
+    if (spans_.size() >= bsg_autoTriggerExportOnBatchSize) {
+        exportSpans();
+        return true;
+    }
+
+    return false;
+}
+
 void
 BatchSpanProcessor::exportSpans() noexcept {
+    stopTimer();
     // Resample in case probability changed
     std::remove_if(std::begin(spans_), std::end(spans_), [&](auto &span){
         return !shouldSample(span);
@@ -56,3 +111,52 @@ BatchSpanProcessor::exportSpans() noexcept {
     exporter_->exportSpans(std::move(spans_));
     NSCParameterAssert(spans_.empty());
 }
+
+void
+BatchSpanProcessor::startTimer() noexcept {
+    /* The dispatched callback's block can outlive BatchSpanProcessor, resulting in a
+     * crash when the block tries to call methods on it. Normally you get around this by
+     * keeping a __weak copy of the caller object, but ARC semantics don't work for a C++
+     * caller, and you can't count on destructor timing.
+     *
+     * As a workaround, we create a mutable object whose sole purpose is to signal the
+     * callback block. We can't rely on __weak alone to clear a sentinel's pointer to nil
+     * because BatchSpanProcessor could be deallocated before the current autorelease pool
+     * ends.
+     *
+     * I'm using NSMutableData as a signaling mechanism, using a length of 0 to mean
+     * "do not execute the callback block" (we also get 0 if called on a nil object, which
+     * will happen after BatchSpanProcessor drops its reference due to the __weak modifier).
+     * The __weak modifier ensures that ARC handles the lifetime properly.
+     *
+     * To cancel an outstanding operation, set the NSMutableData object's length to 0
+     * and then create a new one to break the link to the dispatch queue callback.
+     * See stopTimer()
+     */
+    [timerCallbackValidityMarker setLength:1];
+    __weak auto validityMarker = timerCallbackValidityMarker;
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, int64_t(bsg_autoTriggerExportOnTimeDuration)),
+                   dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
+                   ^(void){
+#pragma GCC diagnostic ignored "-Warc-repeated-use-of-weak"
+        // We want repeated use of weak here to catch race conditions.
+        if (validityMarker.length > 0) {
+            std::lock_guard<std::mutex> guard(this->mutex_);
+            if (validityMarker.length > 0) {
+                this->exportSpans();
+            }
+        }
+    });
+}
+
+void
+BatchSpanProcessor::stopTimer() noexcept {
+    /* Set timerCallbackValidityMarker's length to 0 as a signal to any outstanding
+     * callbacks that they should not execute.
+     * Then, create a new NSMutableData object to break the link to any dispatch queue callback.
+     * See startTimer()
+     */
+    [timerCallbackValidityMarker setLength:0];
+    timerCallbackValidityMarker = [NSMutableData dataWithLength:0];
+};

--- a/Tests/BugsnagPerformanceTests/BatchSpanProcessorTests.mm
+++ b/Tests/BugsnagPerformanceTests/BatchSpanProcessorTests.mm
@@ -11,6 +11,9 @@
 #import "../../Sources/BugsnagPerformance/Private/Sampler.h"
 #import "../../Sources/BugsnagPerformance/Private/Span.h"
 
+extern uint64_t bsg_autoTriggerExportOnBatchSize;
+extern dispatch_time_t bsg_autoTriggerExportOnTimeDuration;
+
 using namespace bugsnag;
 
 class StubSpanExporter : public SpanExporter {
@@ -38,6 +41,56 @@ public:
     XCTAssertEqual(exporter->collected.size(), 2);
     XCTAssertEqualObjects(exporter->collected[0]->name, @"First");
     XCTAssertEqualObjects(exporter->collected[1]->name, @"Second");
+}
+
+- (void)testAutoSendOnBatchFull {
+    const int entriesBeforeForcedExport = 20;
+    bsg_autoTriggerExportOnBatchSize = entriesBeforeForcedExport;
+
+    BatchSpanProcessor processor(std::make_shared<Sampler>(1.0));
+    auto exporter = std::make_shared<StubSpanExporter>();
+    processor.setSpanExporter(exporter);
+
+    int i;
+    for (i = 1; i <= entriesBeforeForcedExport-1; i++) {
+        processor.onEnd(std::make_unique<SpanData>([NSString stringWithFormat:@"#%d", i], CFAbsoluteTimeGetCurrent()));
+        XCTAssertEqual(exporter->collected.size(), 0);
+    }
+    processor.onEnd(std::make_unique<SpanData>([NSString stringWithFormat:@"#%d", i], CFAbsoluteTimeGetCurrent()));
+
+    XCTAssertEqual(exporter->collected.size(), entriesBeforeForcedExport);
+    if (exporter->collected.size() == entriesBeforeForcedExport) {
+        XCTAssertEqualObjects(exporter->collected[0]->name, @"#1");
+        XCTAssertEqualObjects(exporter->collected[i-1]->name, @"#20");
+    }
+}
+
+- (void)testAutoSendOnTimeout {
+    bsg_autoTriggerExportOnTimeDuration = 10 * NSEC_PER_MSEC;
+    BatchSpanProcessor processor(std::make_shared<Sampler>(1.0));
+    auto exporter = std::make_shared<StubSpanExporter>();
+    processor.setSpanExporter(exporter);
+
+    processor.onEnd(std::make_unique<SpanData>(@"First", CFAbsoluteTimeGetCurrent()));
+    XCTAssertEqual(exporter->collected.size(), 0);
+    sleep(1);
+
+    XCTAssertEqual(exporter->collected.size(), 1);
+    if (exporter->collected.size() == 2) {
+        XCTAssertEqualObjects(exporter->collected[0]->name, @"First");
+    }
+}
+
+- (void)testAutoSendNoTimeout {
+    bsg_autoTriggerExportOnTimeDuration = 10 * NSEC_PER_MSEC;
+    BatchSpanProcessor processor(std::make_shared<Sampler>(1.0));
+    auto exporter = std::make_shared<StubSpanExporter>();
+    processor.setSpanExporter(exporter);
+
+    processor.onEnd(std::make_unique<SpanData>(@"First", CFAbsoluteTimeGetCurrent()));
+    processor.onEnd(std::make_unique<SpanData>(@"Second", CFAbsoluteTimeGetCurrent()));
+
+    XCTAssertEqual(exporter->collected.size(), 0);
 }
 
 @end

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -22,7 +22,9 @@
 		01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */; };
 		01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC428E1AF9600D1F239 /* Scenario.swift */; };
 		01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC628E1D5A400D1F239 /* Fixture.swift */; };
+		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */; };
+		CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
 /* End PBXBuildFile section */
 
@@ -44,7 +46,10 @@
 		01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanScenario.swift; sourceTree = "<group>"; };
 		01FE4DC428E1AF9600D1F239 /* Scenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scenario.swift; sourceTree = "<group>"; };
 		01FE4DC628E1D5A400D1F239 /* Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
+		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkScenario.swift; sourceTree = "<group>"; };
+		CBAAE25429125F5F006D4AA0 /* Fixture-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fixture-Bridging-Header.h"; sourceTree = "<group>"; };
+		CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -90,6 +95,7 @@
 				01FE4DB128E1AEBF00D1F239 /* Assets.xcassets */,
 				01FE4DB328E1AEBF00D1F239 /* LaunchScreen.storyboard */,
 				01FE4DB628E1AEBF00D1F239 /* Info.plist */,
+				CBAAE25429125F5F006D4AA0 /* Fixture-Bridging-Header.h */,
 			);
 			path = Fixture;
 			sourceTree = "<group>";
@@ -115,6 +121,8 @@
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */,
 				0185C47128F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift */,
+				CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */,
+				CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */,
 				CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
@@ -160,6 +168,7 @@
 				TargetAttributes = {
 					01FE4DA428E1AEBD00D1F239 = {
 						CreatedOnToolsVersion = 14.0;
+						LastSwiftMigration = 1400;
 					};
 				};
 			};
@@ -202,6 +211,7 @@
 				0185C47228F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */,
+				CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */,
 				01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */,
 				01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */,
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
@@ -209,6 +219,7 @@
 				CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */,
 				CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */,
 				01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */,
+				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,
 				01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */,
 				01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */,
@@ -356,6 +367,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 372ZUL2ZB7;
@@ -375,6 +387,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.Fixture;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Fixture/Fixture-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -385,6 +399,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 372ZUL2ZB7;
@@ -404,6 +419,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.Fixture;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Fixture/Fixture-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/features/fixtures/ios/Fixture/Fixture-Bridging-Header.h
+++ b/features/fixtures/ios/Fixture/Fixture-Bridging-Header.h
@@ -1,0 +1,9 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import <stdint.h>
+#import <Foundation/Foundation.h>
+
+extern uint64_t bsg_autoTriggerExportOnBatchSize;
+extern dispatch_time_t bsg_autoTriggerExportOnTimeDuration;

--- a/features/fixtures/ios/Scenarios/BatchingScenario.swift
+++ b/features/fixtures/ios/Scenarios/BatchingScenario.swift
@@ -1,0 +1,22 @@
+//
+//  BatchingScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 02.11.22.
+//
+
+import BugsnagPerformance
+
+class BatchingScenario: Scenario {
+    
+    override func startBugsnag() {
+        clearPersistentData()
+        super.startBugsnag()
+        bsg_autoTriggerExportOnBatchSize = 2
+    }
+    
+    override func run() {
+        BugsnagPerformance.startSpan(name: "Span1").end()
+        BugsnagPerformance.startSpan(name: "Span2").end()
+    }
+}

--- a/features/fixtures/ios/Scenarios/BatchingWithTimeoutScenario.swift
+++ b/features/fixtures/ios/Scenarios/BatchingWithTimeoutScenario.swift
@@ -1,0 +1,22 @@
+//
+//  BatchingScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 02.11.22.
+//
+
+import BugsnagPerformance
+
+class BatchingWithTimeoutScenario: Scenario {
+    
+    override func startBugsnag() {
+        clearPersistentData()
+        super.startBugsnag()
+        bsg_autoTriggerExportOnTimeDuration = 10 * NSEC_PER_MSEC
+    }
+    
+    override func run() {
+        BugsnagPerformance.startSpan(name: "Span1").end()
+        sleep(1)
+    }
+}

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -15,6 +15,7 @@ class Scenario: NSObject {
     let config: BugsnagPerformanceConfiguration
     
     override init() {
+        bsg_autoTriggerExportOnBatchSize = 1;
         config = BugsnagPerformanceConfiguration.loadConfig()
         config.autoInstrumentAppStarts = false
         config.autoInstrumentNetwork = false

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -63,3 +63,37 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
+
+  Scenario: Manually start and end a span with batching
+    Given I run "BatchingScenario"
+    And I wait to receive a trace
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Span1"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "Span2"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.kind" equals "SPAN_KIND_INTERNAL"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.startTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
+
+  Scenario: Manually start and end a span with batching
+    Given I run "BatchingScenario"
+    And I wait to receive a trace
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Span1"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"


### PR DESCRIPTION
Adds in-memory batching support for spans.

Thresholds can be controlled via the internally exposed values `bsg_autoTriggerExportOnBatchSize` and `bsg_autoTriggerExportOnTimeDuration` for unit tests and e2e tests.

Uses `dispatch_after ` to run on a BG thread, and uses a sentry NSNumber to take advantage of ARC for ownership direction for proper order-of-destruction.

Background detection is done via `CFNotificationCenterAddObserver`.

`BatchSpanProcessor` now checks how many instances are being created, and logs a warning if more than one exists. There can be only one because it must be triggered on a notification.

The default scenario has been updated to set the max batch size to 1 so that existing e2e tests function as before.
