### PR TITLE
[PLAT-9247] Add integrity header

### DIFF
--- a/Sources/BugsnagPerformance/Private/OtlpPackage.h
+++ b/Sources/BugsnagPerformance/Private/OtlpPackage.h
@@ -15,10 +15,7 @@ namespace bugsnag {
  */
 class OtlpPackage {
 public:
-    OtlpPackage(const NSData *payload, const NSDictionary *headers) noexcept
-    : payload_(payload)
-    , headers_(headers)
-    {}
+    OtlpPackage(const NSData *payload, const NSDictionary *headers) noexcept;
 
     /**
      * Fill a request with everything necessary to send to the server.

--- a/Sources/BugsnagPerformance/Private/OtlpPackage.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpPackage.mm
@@ -8,7 +8,33 @@
 
 #import "OtlpPackage.h"
 
+#import <CommonCrypto/CommonCrypto.h>
+
 using namespace bugsnag;
+
+static NSDictionary * headersWithIntegrityDigest(const NSData *payload, const NSDictionary *headers) {
+    if (!payload) {
+        return nil;
+    }
+
+    unsigned char md[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1(payload.bytes, (CC_LONG)payload.length, md);
+    auto digest = [NSString stringWithFormat:@"sha1 %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+                   md[0], md[1], md[2], md[3], md[4],
+                   md[5], md[6], md[7], md[8], md[9],
+                   md[10], md[11], md[12], md[13], md[14],
+                   md[15], md[16], md[17], md[18], md[19]];
+
+    NSMutableDictionary *mutableHeaders = headers.mutableCopy;
+    mutableHeaders[@"Bugsnag-Integrity"] = digest;
+
+    return mutableHeaders;
+}
+
+OtlpPackage::OtlpPackage(const NSData *payload, const NSDictionary *headers) noexcept
+: payload_(payload)
+, headers_(headersWithIntegrityDigest(payload, headers))
+{}
 
 void OtlpPackage::fillURLRequest(NSMutableURLRequest *request) const noexcept {
     request.HTTPMethod = @"POST";

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -1,6 +1,6 @@
 Feature: Manual creation of spans
 
-  Scenario: X
+  Scenario: Retry a manual span
     Given I set the HTTP status code for the next request to 500
     And I run "RetryScenario"
     And I wait to receive 3 traces
@@ -16,6 +16,7 @@ Feature: Manual creation of spans
     And the error payload field "events.0.device.id" is stored as the value "bugsnag_device_id"
     And I wait to receive a trace
     Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ManualSpanScenario"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"


### PR DESCRIPTION
## Goal

Add a Bugsnag integrity header for the payload, same as what we do in bugsnag-cocoa.

## Testing

Modified an e2e test to check for the header.
