### PR TITLE
Performance impl

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -74,6 +74,8 @@
 		CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */; };
 		CBE8EA09294A20ED00702950 /* BSGInternalConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */; };
 		CBE8EA0A294A20ED00702950 /* BSGInternalConfig.c in Sources */ = {isa = PBXBuildFile; fileRef = CBE8EA08294A20ED00702950 /* BSGInternalConfig.c */; };
+		CBE8EA16294B528100702950 /* BugsnagPerformanceImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */; };
+		CBE8EA17294B528100702950 /* BugsnagPerformanceImpl.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */; };
 		CBF6210729194543004BEE0B /* OtlpTraceExporterTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBF6210629194543004BEE0B /* OtlpTraceExporterTests.mm */; };
 /* End PBXBuildFile section */
 
@@ -164,6 +166,8 @@
 		CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCUtils.mm; sourceTree = "<group>"; };
 		CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGInternalConfig.h; sourceTree = "<group>"; };
 		CBE8EA08294A20ED00702950 /* BSGInternalConfig.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BSGInternalConfig.c; sourceTree = "<group>"; };
+		CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceImpl.h; sourceTree = "<group>"; };
+		CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceImpl.mm; sourceTree = "<group>"; };
 		CBF621052919418F004BEE0B /* Uploader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Uploader.h; sourceTree = "<group>"; };
 		CBF6210629194543004BEE0B /* OtlpTraceExporterTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OtlpTraceExporterTests.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -249,13 +253,15 @@
 		0122C21F29019770002D243C /* Private */ = {
 			isa = PBXGroup;
 			children = (
-				0122C22929019770002D243C /* Instrumentation */,
 				0122C23129019770002D243C /* BatchSpanProcessor.h */,
 				0122C22429019770002D243C /* BatchSpanProcessor.mm */,
 				CBE8EA08294A20ED00702950 /* BSGInternalConfig.c */,
 				CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */,
+				CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */,
+				CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */,
 				0122C23229019770002D243C /* BugsnagPerformanceSpan+Private.h */,
 				0122C22229019770002D243C /* IdGenerator.h */,
+				0122C22929019770002D243C /* Instrumentation */,
 				CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */,
 				CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */,
 				CB04969529150D860097E526 /* OtlpPackage.h */,
@@ -295,9 +301,9 @@
 		0122C22929019770002D243C /* Instrumentation */ = {
 			isa = PBXGroup;
 			children = (
-				CB34771929068C350033759C /* NetworkInstrumentation */,
 				0122C22C29019770002D243C /* AppStartupInstrumentation.h */,
 				0122C22B29019770002D243C /* AppStartupInstrumentation.mm */,
+				CB34771929068C350033759C /* NetworkInstrumentation */,
 				0122C22E29019770002D243C /* NetworkInstrumentation.h */,
 				0122C22A29019770002D243C /* NetworkInstrumentation.mm */,
 				0122C22D29019770002D243C /* ViewLoadInstrumentation.h */,
@@ -331,9 +337,9 @@
 				CB0AD76B296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm */,
 				0122C25F29019C05002D243C /* BugsnagPerformanceTests.mm */,
 				0122C26029019C05002D243C /* OtlpTraceEncodingTests.mm */,
+				CBF6210629194543004BEE0B /* OtlpTraceExporterTests.mm */,
 				01A414C42912B93F003152A4 /* ResourceAttributesTests.mm */,
 				01A58C10290931A5006E4DF7 /* SamplerTests.mm */,
-				CBF6210629194543004BEE0B /* OtlpTraceExporterTests.mm */,
 			);
 			path = BugsnagPerformanceTests;
 			sourceTree = "<group>";
@@ -370,10 +376,10 @@
 		CB34771929068C350033759C /* NetworkInstrumentation */ = {
 			isa = PBXGroup;
 			children = (
-				CB34771A29068C350033759C /* NSURLSession+Instrumentation.mm */,
-				CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */,
 				CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */,
+				CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */,
 				CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */,
+				CB34771A29068C350033759C /* NSURLSession+Instrumentation.mm */,
 			);
 			path = NetworkInstrumentation;
 			sourceTree = "<group>";
@@ -410,6 +416,7 @@
 				CBB48A3C295EE1E10044E9AC /* ObjCUtils.h in Headers */,
 				015836C129125E7A002F54C8 /* ResourceAttributes.h in Headers */,
 				CB04969F29154FD50097E526 /* OtlpSendQueue.h in Headers */,
+				CBE8EA16294B528100702950 /* BugsnagPerformanceImpl.h in Headers */,
 				0122C24129019770002D243C /* IdGenerator.h in Headers */,
 				0122C23829019770002D243C /* BugsnagPerformanceSpan.h in Headers */,
 				CB0AD76A296573FC002A3FB6 /* BugsnagPerformanceErrors.h in Headers */,
@@ -568,6 +575,7 @@
 				CB0496A029154FD50097E526 /* OtlpSendQueue.mm in Sources */,
 				CB04969829150D860097E526 /* OtlpPackage.mm in Sources */,
 				0122C23D29019770002D243C /* BugsnagPerformance.mm in Sources */,
+				CBE8EA17294B528100702950 /* BugsnagPerformanceImpl.mm in Sources */,
 				0122C24329019770002D243C /* BatchSpanProcessor.mm in Sources */,
 				0122C23E29019770002D243C /* BugsnagPerformanceSpan.mm in Sources */,
 				01A414CE2913C0F0003152A4 /* SpanAttributes.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -1,0 +1,53 @@
+//
+//  BugsnagPerformanceImpl.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 15.12.22.
+//  Copyright © 2022 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
+#import <BugsnagPerformance/BugsnagPerformanceViewType.h>
+#import "Tracer.h"
+#import "BugsnagPerformanceSpan+Private.h"
+
+namespace bugsnag {
+class BugsnagPerformanceImpl {
+public:
+    BugsnagPerformanceImpl() noexcept {};
+    
+    bool start(BugsnagPerformanceConfiguration *configuration, NSError **error) noexcept;
+    
+    void reportNetworkSpan(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept {
+        tracer.reportNetworkSpan(task, metrics);
+    }
+
+    BugsnagPerformanceSpan *startSpan(NSString *name) {
+        return [[BugsnagPerformanceSpan alloc] initWithSpan:
+                tracer.startSpan(name, CFAbsoluteTimeGetCurrent())];
+    }
+
+    BugsnagPerformanceSpan *startSpan(NSString *name, NSDate *startTime) {
+        return [[BugsnagPerformanceSpan alloc] initWithSpan:
+                tracer.startSpan(name, startTime.timeIntervalSinceReferenceDate)];
+    }
+
+    BugsnagPerformanceSpan *startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType) {
+        return [[BugsnagPerformanceSpan alloc] initWithSpan:
+                tracer.startViewLoadedSpan(viewType, name, CFAbsoluteTimeGetCurrent())];
+    }
+
+    BugsnagPerformanceSpan *startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType, NSDate *startTime) {
+        return [[BugsnagPerformanceSpan alloc] initWithSpan:
+                tracer.startViewLoadedSpan(viewType, name, startTime.timeIntervalSinceReferenceDate)];
+    }
+
+    void reportNetworkRequestSpan(NSURLSessionTask * task, NSURLSessionTaskMetrics *metrics) {
+        tracer.reportNetworkSpan(task, metrics);
+    }
+
+
+private:
+    Tracer tracer;
+};
+}

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -1,0 +1,19 @@
+//
+//  BugsnagPerformanceImpl.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 15.12.22.
+//  Copyright © 2022 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagPerformanceImpl.h"
+
+using namespace bugsnag;
+
+bool BugsnagPerformanceImpl::start(BugsnagPerformanceConfiguration *configuration, NSError **error) noexcept {
+    if (![configuration validate:error]) {
+        return false;
+    }
+    tracer.start(configuration);
+    return true;
+}

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -7,8 +7,13 @@
 
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
-#import <memory>
+#import "Instrumentation/AppStartupInstrumentation.h"
+#import "Instrumentation/NetworkInstrumentation.h"
+#import "Instrumentation/ViewLoadInstrumentation.h"
+#import "Span.h"
 #import "OtlpUploader.h"
+
+#import <memory>
 
 namespace bugsnag {
 // https://opentelemetry.io/docs/reference/specification/trace/api/#tracer

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -8,9 +8,6 @@
 #import "Tracer.h"
 
 #import "BatchSpanProcessor.h"
-#import "Instrumentation/AppStartupInstrumentation.h"
-#import "Instrumentation/NetworkInstrumentation.h"
-#import "Instrumentation/ViewLoadInstrumentation.h"
 #import "OtlpTraceExporter.h"
 #import "OtlpUploader.h"
 #import "Reachability.h"

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -7,17 +7,16 @@
 
 #import <BugsnagPerformance/BugsnagPerformance.h>
 
-#import "../Private/BugsnagPerformanceSpan+Private.h"
-#import "../Private/Tracer.h"
+#import "../Private/BugsnagPerformanceImpl.h"
 
 using namespace bugsnag;
 
 @implementation BugsnagPerformance
 
-static Tracer& getTracer() {
+static BugsnagPerformanceImpl& getImpl() {
     [[clang::no_destroy]]
-    static Tracer tracer;
-    return tracer;
+    static BugsnagPerformanceImpl impl;
+    return impl;
 }
 
 + (BOOL)start:(NSError * __autoreleasing _Nullable *)error {
@@ -33,33 +32,28 @@ static Tracer& getTracer() {
         return NO;
     }
 
-    getTracer().start(configuration);
-    return YES;
+    return getImpl().start(configuration, error);
 }
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name {
-    return [[BugsnagPerformanceSpan alloc] initWithSpan:
-            getTracer().startSpan(name, CFAbsoluteTimeGetCurrent())];
+    return getImpl().startSpan(name);
 }
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name startTime:(NSDate *)startTime {
-    return [[BugsnagPerformanceSpan alloc] initWithSpan:
-            getTracer().startSpan(name, startTime.timeIntervalSinceReferenceDate)];
+    return getImpl().startSpan(name, startTime);
 }
 
 + (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name viewType:(BugsnagPerformanceViewType)viewType {
-    return [[BugsnagPerformanceSpan alloc] initWithSpan:
-            getTracer().startViewLoadedSpan(viewType, name, CFAbsoluteTimeGetCurrent())];
+    return getImpl().startViewLoadSpan(name, viewType);
 }
 
 + (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name viewType:(BugsnagPerformanceViewType)viewType startTime:(NSDate *)startTime {
-    return [[BugsnagPerformanceSpan alloc] initWithSpan:
-            getTracer().startViewLoadedSpan(viewType, name, startTime.timeIntervalSinceReferenceDate)];
+    return getImpl().startViewLoadSpan(name, viewType, startTime);
 }
 
 + (void)reportNetworkRequestSpanWithTask:(NSURLSessionTask *)task
                                  metrics:(NSURLSessionTaskMetrics *)metrics {
-    getTracer().reportNetworkSpan(task, metrics);
+    getImpl().reportNetworkSpan(task, metrics);
 }
 
 @end


### PR DESCRIPTION
Review after https://github.com/bugsnag/bugsnag-cocoa-performance/pull/30

## Goal

The next PRs will add more components that need to reside in the top-level bugsnag-performance object. As this is currently implemented as static methods that call a global Tracer, we need to move it all one level deeper into a BugsnagPerformanceImpl object.

## Testing

Reran all tests
