### PR TITLE
pragma once on all headers, and clean up namespace

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
+#pragma once
+
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
 #import "Tracer.h"

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -5,6 +5,8 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
+#pragma once
+
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
 
 #import "Span.h"

--- a/Sources/BugsnagPerformance/Private/IdGenerator.h
+++ b/Sources/BugsnagPerformance/Private/IdGenerator.h
@@ -5,6 +5,8 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
+#pragma once
+
 #import <array>
 #import <stdlib.h>
 

--- a/Sources/BugsnagPerformance/Private/ObjCUtils.h
+++ b/Sources/BugsnagPerformance/Private/ObjCUtils.h
@@ -6,6 +6,13 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 
+namespace bugsnag {
+
 NSURL * _Nullable nsurlWithString(NSString * _Nonnull str, NSError * __autoreleasing _Nullable * _Nullable error);
+
+}
+

--- a/Sources/BugsnagPerformance/Private/ObjCUtils.mm
+++ b/Sources/BugsnagPerformance/Private/ObjCUtils.mm
@@ -8,6 +8,8 @@
 
 #import "ObjCUtils.h"
 
+namespace bugsnag {
+
 NSURL * _Nullable nsurlWithString(NSString * _Nonnull str, NSError * __autoreleasing _Nullable * _Nullable error) {
     if (error != nil) {
         *error = nil;
@@ -19,5 +21,7 @@ NSURL * _Nullable nsurlWithString(NSString * _Nonnull str, NSError * __autorelea
         }];
     }
     return url;
+}
+
 }
 

--- a/Sources/BugsnagPerformance/Private/OtlpPackage.h
+++ b/Sources/BugsnagPerformance/Private/OtlpPackage.h
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 namespace bugsnag {

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.h
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.h
@@ -5,6 +5,8 @@
 //  Created by Nick Dowell on 27/09/2022.
 //
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 #import "Span.h"

--- a/Sources/BugsnagPerformance/Private/OtlpUploader.h
+++ b/Sources/BugsnagPerformance/Private/OtlpUploader.h
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 #import "Uploader.h"

--- a/Sources/BugsnagPerformance/Private/Reachability.h
+++ b/Sources/BugsnagPerformance/Private/Reachability.h
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 #import <vector>

--- a/Sources/BugsnagPerformance/Private/ResourceAttributes.h
+++ b/Sources/BugsnagPerformance/Private/ResourceAttributes.h
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
+#pragma once
+
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 
 namespace bugsnag {

--- a/Sources/BugsnagPerformance/Private/Sampler.h
+++ b/Sources/BugsnagPerformance/Private/Sampler.h
@@ -5,6 +5,8 @@
 //  Created by Nick Dowell on 26/10/2022.
 //
 
+#pragma once
+
 #import "IdGenerator.h"
 
 #import <Foundation/Foundation.h>

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -5,6 +5,8 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 #import "SpanData.h"

--- a/Sources/BugsnagPerformance/Private/SpanAttributes.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributes.h
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 namespace bugsnag {

--- a/Sources/BugsnagPerformance/Private/SpanData.h
+++ b/Sources/BugsnagPerformance/Private/SpanData.h
@@ -5,6 +5,8 @@
 //  Created by Nick Dowell on 06/10/2022.
 //
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 #import "IdGenerator.h"

--- a/Sources/BugsnagPerformance/Private/SpanKind.h
+++ b/Sources/BugsnagPerformance/Private/SpanKind.h
@@ -5,6 +5,8 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
+#pragma once
+
 namespace bugsnag {
 enum SpanKind {
     // Unspecified. Do NOT use as default.

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -5,6 +5,8 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
+#pragma once
+
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
 #import "Instrumentation/AppStartupInstrumentation.h"

--- a/Sources/BugsnagPerformance/Private/Uploader.h
+++ b/Sources/BugsnagPerformance/Private/Uploader.h
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
+#pragma once
+
 #import "OtlpPackage.h"
 #import <memory>
 

--- a/Sources/BugsnagPerformance/Private/Utils.h
+++ b/Sources/BugsnagPerformance/Private/Utils.h
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 #define BSG_LOGLEVEL_NONE 0

--- a/Sources/BugsnagPerformance/Private/Version.h
+++ b/Sources/BugsnagPerformance/Private/Version.h
@@ -6,5 +6,7 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
+#pragma once
+
 #define TELEMETRY_SDK_NAME "bugsnag.performance.cocoa"
 #define TELEMETRY_SDK_VERSION "0.0"


### PR DESCRIPTION
## Goal

Add `#pragma once` to all headers (except those removed in https://github.com/bugsnag/bugsnag-cocoa-performance/pull/32) to prevent them from being included multiple times.

Put `nsurlWithString` into the bugsnag namespace.
