### PR TITLE
Run most e2e tests at span granularity instead of trace granularity

### DIFF
--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -2,32 +2,32 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentAppStartsScenario
     Given I run "AutoInstrumentAppStartsScenario" and discard the initial p-value request
-    And I wait to receive a trace
+    And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "AppStart/Cold"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.app_start.type" equals "cold"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span_category" equals "app_start"
+    * every span field "name" equals "AppStart/Cold"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span string attribute "bugsnag.app_start.type" equals "cold"
+    * every span string attribute "bugsnag.span_category" equals "app_start"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
 
   Scenario: AutoInstrumentViewLoadScenario
     Given I run "AutoInstrumentViewLoadScenario" and discard the initial p-value request
-    And I wait to receive a trace
+    And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ViewLoaded/UIKit/Fixture.AutoInstrumentViewLoadScenario_ViewController"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span_category" equals "view_load"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.name" equals "Fixture.AutoInstrumentViewLoadScenario_ViewController"
+    * every span field "name" equals "ViewLoaded/UIKit/Fixture.AutoInstrumentViewLoadScenario_ViewController"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span string attribute "bugsnag.span_category" equals "view_load"
+    * every span string attribute "bugsnag.view.name" equals "Fixture.AutoInstrumentViewLoadScenario_ViewController"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.type" equals "UIKit"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
@@ -35,20 +35,20 @@ Feature: Automatic instrumentation spans
 
   Scenario: Automatically start a network span
     Given I run "AutoInstrumentNetworkScenario" and discard the initial p-value request
-    And I wait to receive a trace
+    And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.flavor" exists
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "http://.*:9340/reflect/"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "net.host.connection.type" equals "wifi"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "name" equals "HTTP/GET"
+    * every span string attribute "http.flavor" exists
+    * every span string attribute "http.url" matches the regex "http://.*:9340/reflect/"
+    * every span string attribute "http.method" equals "GET"
+    * every span integer attribute "http.status_code" is greater than 0
+    * every span integer attribute "http.response_content_length" is greater than 0
+    * every span string attribute "net.host.connection.type" equals "wifi"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC428E1AF9600D1F239 /* Scenario.swift */; };
 		01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC628E1D5A400D1F239 /* Fixture.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
+		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
 		CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */; };
 		CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
@@ -49,6 +50,7 @@
 		01FE4DC428E1AF9600D1F239 /* Scenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scenario.swift; sourceTree = "<group>"; };
 		01FE4DC628E1D5A400D1F239 /* Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
+		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
 		CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkScenario.swift; sourceTree = "<group>"; };
 		CBAAE25429125F5F006D4AA0 /* Fixture-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fixture-Bridging-Header.h"; sourceTree = "<group>"; };
 		CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingScenario.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 				0185C47128F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift */,
 				CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */,
 				CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */,
+				CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */,
 				CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
@@ -226,6 +229,7 @@
 				01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */,
 				01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */,
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
+				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
 				01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */,
 				CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */,
 				CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/BatchingScenario.swift
+++ b/features/fixtures/ios/Scenarios/BatchingScenario.swift
@@ -15,6 +15,7 @@ class BatchingScenario: Scenario {
     }
     
     override func run() {
+        waitForCurrentBatch()
         BugsnagPerformance.startSpan(name: "Span1").end()
         BugsnagPerformance.startSpan(name: "Span2").end()
     }

--- a/features/fixtures/ios/Scenarios/InitialPScenario.swift
+++ b/features/fixtures/ios/Scenarios/InitialPScenario.swift
@@ -1,0 +1,18 @@
+//
+//  InitialPScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 04.01.23.
+//
+
+import BugsnagPerformance
+
+class InitialPScenario: Scenario {
+    
+    override func run() {
+        waitForInitialPResponse()
+        BugsnagPerformance.startSpan(name: "First").end()
+        waitForCurrentBatch()
+        BugsnagPerformance.startSpan(name: "Second").end()
+    }
+}

--- a/features/fixtures/ios/Scenarios/ManualSpanScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualSpanScenario.swift
@@ -23,6 +23,7 @@ class ManualSpanScenario: Scenario {
     }
     
     override func run() {
+        waitForCurrentBatch()
         let span = BugsnagPerformance.startSpan(name: "ManualSpanScenario")
         Bugsnag.notifyError(NSError(domain: "Test", code: 0))
         span.end()

--- a/features/fixtures/ios/Scenarios/ManualViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualViewLoadScenario.swift
@@ -11,7 +11,7 @@ class ManualViewLoadScenario: Scenario {
     
     override func run() {
         BugsnagPerformance.startViewLoadSpan(name: "ManualViewController", viewType: .uiKit).end()
-        
+        waitForCurrentBatch()
         BugsnagPerformance.startViewLoadSpan(name: "ManualView", viewType: .swiftUI, startTime: Date()).end()
     }
 }

--- a/features/fixtures/ios/Scenarios/RetryScenario.swift
+++ b/features/fixtures/ios/Scenarios/RetryScenario.swift
@@ -10,9 +10,9 @@ import BugsnagPerformance
 class RetryScenario: Scenario {
     
     override func run() {
-        Thread.sleep(forTimeInterval: 0.5)
+        waitForCurrentBatch()
         BugsnagPerformance.startSpan(name: "WillRetry").end()
-        Thread.sleep(forTimeInterval: 0.5)
+        waitForCurrentBatch()
         BugsnagPerformance.startSpan(name: "Success").end()
     }
 }

--- a/features/fixtures/ios/Scenarios/SamplingProbabilityZeroScenario.swift
+++ b/features/fixtures/ios/Scenarios/SamplingProbabilityZeroScenario.swift
@@ -23,8 +23,7 @@ class SamplingProbabilityZeroScenario: Scenario {
     }
     
     override func run() {
-        // Make sure this happens after the app start span
-        Thread.sleep(forTimeInterval: 0.1)
+        waitForCurrentBatch()
         BugsnagPerformance.startSpan(name: "Post-start").end()
     }
 }

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -37,4 +37,14 @@ class Scenario: NSObject {
     func run() {
         fatalError("To be implemented by subclass")
     }
+
+    func waitForInitialPResponse() {
+        // Guess that it won't take longer than 2 seconds
+        Thread.sleep(forTimeInterval: 2.0)
+    }
+
+    func waitForCurrentBatch() {
+        // Wait long enough to allow the current batch to be packaged and sent
+        Thread.sleep(forTimeInterval: 0.5)
+    }
 }

--- a/features/initial-p-value.feature
+++ b/features/initial-p-value.feature
@@ -2,13 +2,18 @@ Feature: Initial P values
 
   Scenario: Initial P value of 0
     Given I set the sampling probability for the next traces to "0"
-    And I run "RetryScenario"
+    And I run "InitialPScenario"
     And I wait to receive 1 traces
     * the trace payload field "resourceSpans" is an array with 0 elements
 
   Scenario: Initial P value of 1
     Given I set the sampling probability for the next traces to "1"
-    And I run "RetryScenario"
-    And I wait to receive 3 traces
-    * the trace payload field "resourceSpans" is an array with 0 elements
-
+    And I run "InitialPScenario"
+    And I wait for 2 spans
+    * a span field "name" equals "First"
+    * a span field "name" equals "Second"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -18,17 +18,17 @@ Feature: Manual creation of spans
     Given I run "ManualSpanScenario" and discard the initial p-value request
     And I wait to receive an error
     And the error payload field "events.0.device.id" is stored as the value "bugsnag_device_id"
-    And I wait to receive a trace
+    And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ManualSpanScenario"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" bool attribute "bugsnag.app.in_foreground" is true
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "net.host.connection.type" equals "wifi"
+    * every span field "name" equals "ManualSpanScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.app.in_foreground" is true
+    * every span string attribute "net.host.connection.type" equals "wifi"
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" equals "1"
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"
     * the trace payload field "resourceSpans.0.resource" string attribute "device.id" equals the stored value "bugsnag_device_id"
@@ -45,86 +45,77 @@ Feature: Manual creation of spans
 
   Scenario: Starting and ending a span before starting the SDK
     Given I run "ManualSpanBeforeStartScenario" and discard the initial p-value request
-    And I wait to receive a trace
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "BeforeStart"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    And I wait for 1 span
+    * every span field "name" equals "BeforeStart"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
 
   Scenario: Manually report a view load span
     Given I run "ManualViewLoadScenario" and discard the initial p-value request
-    And I wait to receive 2 traces
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ViewLoaded/UIKit/ManualViewController"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span_category" equals "view_load"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.name" equals "ManualViewController"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.type" equals "UIKit"
-    And I discard the oldest trace
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ViewLoaded/SwiftUI/ManualView"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span_category" equals "view_load"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.name" equals "ManualView"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.type" equals "SwiftUI"
+    And I wait for 2 spans
+    * a span field "name" equals "ViewLoaded/UIKit/ManualViewController"
+    * a span string attribute "bugsnag.view.name" equals "ManualViewController"
+    * a span string attribute "bugsnag.view.type" equals "UIKit"
+    * a span field "name" equals "ViewLoaded/SwiftUI/ManualView"
+    * a span string attribute "bugsnag.view.name" equals "ManualView"
+    * a span string attribute "bugsnag.view.type" equals "SwiftUI"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span string attribute "bugsnag.span_category" equals "view_load"
 
   Scenario: Manually start a network span
     Given I run "ManualNetworkSpanScenario" and discard the initial p-value request
-    And I wait to receive a trace
+    And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.flavor" exists
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "http://.*:9340/reflect/"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "net.host.connection.type" equals "wifi"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
+    * every span field "name" equals "HTTP/GET"
+    * every span string attribute "http.flavor" exists
+    * every span string attribute "http.url" matches the regex "http://.*:9340/reflect/"
+    * every span string attribute "http.method" equals "GET"
+    * every span integer attribute "http.status_code" is greater than 0
+    * every span integer attribute "http.response_content_length" is greater than 0
+    * every span string attribute "net.host.connection.type" equals "wifi"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
-  Scenario: Manually start and end a span with batching
+  Scenario: Manually start and end a span field "with" batching
     Given I run "BatchingScenario" and discard the initial p-value request
-    And I wait to receive a trace
+    And I wait for 2 spans
     Then the trace "Content-Type" header equals "application/json"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Span1"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "Span2"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
+    * a span field "name" equals "Span1"
+    * a span field "name" equals "Span2"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
-  Scenario: Manually start and end a span with batching
+  Scenario: Manually start and end a span field "with" batching
     Given I run "BatchingScenario" and discard the initial p-value request
-    And I wait to receive a trace
+    And I wait for 2 spans
     Then the trace "Content-Type" header equals "application/json"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Span1"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span field "name" equals "Span1"
+    * a span field "name" equals "Span2"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"

--- a/features/sampling.feature
+++ b/features/sampling.feature
@@ -8,9 +8,7 @@ Feature: Sampling
   Scenario: But if the server changes the probability, we must honor that
     Given I set the sampling probability to "1.0"
     And I run "SamplingProbabilityZeroScenario" and discard the initial p-value request
-    And I wait to receive 3 traces
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Pre-start"
-    And I discard the oldest trace
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "AppStart/Cold"
-    And I discard the oldest trace
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Post-start"
+    And I wait for 3 spans
+    * a span field "name" equals "Pre-start"
+    * a span field "name" equals "AppStart/Cold"
+    * a span field "name" equals "Post-start"

--- a/features/steps/trace_steps.rb
+++ b/features/steps/trace_steps.rb
@@ -43,10 +43,74 @@ end
 Then("I run {string} and discard the initial p-value request") do |scenario|
   steps %Q{
     When I run "#{scenario}"
-    And I wait to receive a trace
+    And I wait to receive at least 1 trace
     And the trace payload field "resourceSpans" is an array with 0 elements
     And I discard the oldest trace
   }
+end
+
+When('I wait for {int} span(s)') do |span_count|
+  assert_received_spans span_count, Maze::Server.list_for('traces')
+end
+
+Then('every span field {string} equals {string}') do |key, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_keys = spans.map { |span| span[key] == expected }
+  Maze.check.not_includes selected_keys, false
+end
+
+Then('every span field {string} matches the regex {string}') do |key, pattern|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze.check.match pattern, span[key] }
+end
+
+Then('every span string attribute {string} exists') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze.check.not_nil span['attributes'].find { |a| a['key'] == attribute }['value']['stringValue'] }
+end
+
+Then('every span string attribute {string} equals {string}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze.check.equal expected, span['attributes'].find { |a| a['key'] == attribute }['value']['stringValue'] }
+end
+
+Then('every span string attribute {string} matches the regex {string}') do |attribute, pattern|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze.check.match pattern, span['attributes'].find { |a| a['key'] == attribute }['value']['stringValue'] }
+end
+
+Then('every span integer attribute {string} is greater than {int}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze::check.true span['attributes'].find { |a| a['key'] == attribute }['value']['intValue'].to_i > expected }
+end
+
+Then('every span bool attribute {string} is true') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze::check.true span['attributes'].find { |a| a['key'] == attribute }['value']['boolValue'] }
+end
+
+Then('a span string attribute {string} exists') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'] == attribute }['value']['stringValue'] }
+  Maze.check.false(selected_attributes.empty?)
+end
+
+Then('a span string attribute {string} equals {string}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'] == attribute }['value']['stringValue'] }
+  Maze.check.includes selected_attributes, expected
+end
+
+Then('a span field {string} equals {string}') do |key, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_keys = spans.map { |span| span[key] }
+  Maze.check.includes selected_keys, expected
+end
+
+Then('a span field {string} matches the regex {string}') do |attribute, pattern|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| Maze.check.match pattern, span[attribute] }
+  Maze.check.false(selected_attributes.empty?)
 end
 
 def get_attribute_value(field, attribute, attr_type)
@@ -60,4 +124,34 @@ end
 def check_attribute_equal(field, attribute, attr_type, expected)
   value = get_attribute_value field, attribute, attr_type
   Maze.check.equal value, expected
+end
+
+def assert_received_spans(span_count, list)
+  timeout = Maze.config.receive_requests_wait
+  wait = Maze::Wait.new(timeout: timeout)
+
+  received = wait.until { spans_from_request_list(list).size >= span_count }
+  received_count = spans_from_request_list(list).size
+
+  unless received_count == span_count
+    raise Test::Unit::AssertionFailedError.new <<-MESSAGE
+    Expected #{span_count} spans but received #{received_count} within the #{timeout}s timeout.
+    This could indicate that:
+    - Bugsnag crashed with a fatal error.
+    - Bugsnag did not make the requests that it should have done.
+    - The requests were made, but not deemed to be valid (e.g. missing integrity header).
+    - The requests made were prevented from being received due to a network or other infrastructure issue.
+    Please check the Maze Runner and device logs to confirm.)
+    MESSAGE
+  end
+
+  Maze.check.operator(span_count, :<=, received_count, "#{received_count} spans received")
+end
+
+def spans_from_request_list list
+  return list.remaining
+             .flat_map { |req| req[:body]['resourceSpans'] }
+             .flat_map { |r| r['scopeSpans'] }
+             .flat_map { |s| s['spans'] }
+             .select { |s| !s.nil? }
 end


### PR DESCRIPTION
## Goal

Split out from https://github.com/bugsnag/bugsnag-cocoa-performance/pull/32

Running e2e tests at trace level granularity can be flaky because batching may cause spans to be sent in a single trace or multiple traces.

This PR converts e2e tests to use span-level checks instead.
