### PR TITLE
[PLAT-9358] Add general persistence and persistent state.

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -71,6 +71,19 @@
 		CBE8EA1A294B5AB800702950 /* Worker.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA18294B5AB800702950 /* Worker.h */; };
 		CBE8EA1B294B5AB800702950 /* Worker.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBE8EA19294B5AB800702950 /* Worker.mm */; };
 		CBE8EA1E294B5E1500702950 /* Batch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA1C294B5E1500702950 /* Batch.h */; };
+		CBEC51B8296D8386009C0CE3 /* Persistence.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEC51B6296D8386009C0CE3 /* Persistence.h */; };
+		CBEC51B9296D8386009C0CE3 /* Persistence.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51B7296D8386009C0CE3 /* Persistence.mm */; };
+		CBEC51BC296D9EEE009C0CE3 /* PersistentState.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEC51BA296D9EED009C0CE3 /* PersistentState.h */; };
+		CBEC51BD296D9EEE009C0CE3 /* PersistentState.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51BB296D9EED009C0CE3 /* PersistentState.mm */; };
+		CBEC51C0296DB312009C0CE3 /* JSON.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEC51BE296DB311009C0CE3 /* JSON.h */; };
+		CBEC51C1296DB312009C0CE3 /* JSON.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51BF296DB311009C0CE3 /* JSON.mm */; };
+		CBEC51C3296EC0AC009C0CE3 /* JSONTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51C2296EC0AC009C0CE3 /* JSONTests.mm */; };
+		CBEC51C5296ED8BA009C0CE3 /* PersistentStateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51C4296ED8BA009C0CE3 /* PersistentStateTests.mm */; };
+		CBEC51CC296EDA2D009C0CE3 /* FileBasedTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51C9296ED98F009C0CE3 /* FileBasedTest.m */; };
+		CBEC51CE296EEF52009C0CE3 /* PersistenceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51CD296EEF52009C0CE3 /* PersistenceTests.mm */; };
+		CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEC51D42976BCAD009C0CE3 /* Filesystem.h */; };
+		CBEC51D72976BCAD009C0CE3 /* Filesystem.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51D52976BCAD009C0CE3 /* Filesystem.m */; };
+		CBEC51D92976D54B009C0CE3 /* FilesystemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51D82976D54B009C0CE3 /* FilesystemTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -157,6 +170,20 @@
 		CBE8EA18294B5AB800702950 /* Worker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Worker.h; sourceTree = "<group>"; };
 		CBE8EA19294B5AB800702950 /* Worker.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Worker.mm; sourceTree = "<group>"; };
 		CBE8EA1C294B5E1500702950 /* Batch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Batch.h; sourceTree = "<group>"; };
+		CBEC51B6296D8386009C0CE3 /* Persistence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Persistence.h; sourceTree = "<group>"; };
+		CBEC51B7296D8386009C0CE3 /* Persistence.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Persistence.mm; sourceTree = "<group>"; };
+		CBEC51BA296D9EED009C0CE3 /* PersistentState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PersistentState.h; sourceTree = "<group>"; };
+		CBEC51BB296D9EED009C0CE3 /* PersistentState.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PersistentState.mm; sourceTree = "<group>"; };
+		CBEC51BE296DB311009C0CE3 /* JSON.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSON.h; sourceTree = "<group>"; };
+		CBEC51BF296DB311009C0CE3 /* JSON.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSON.mm; sourceTree = "<group>"; };
+		CBEC51C2296EC0AC009C0CE3 /* JSONTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSONTests.mm; sourceTree = "<group>"; };
+		CBEC51C4296ED8BA009C0CE3 /* PersistentStateTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PersistentStateTests.mm; sourceTree = "<group>"; };
+		CBEC51C8296ED98F009C0CE3 /* FileBasedTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileBasedTest.h; sourceTree = "<group>"; };
+		CBEC51C9296ED98F009C0CE3 /* FileBasedTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FileBasedTest.m; sourceTree = "<group>"; };
+		CBEC51CD296EEF52009C0CE3 /* PersistenceTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PersistenceTests.mm; sourceTree = "<group>"; };
+		CBEC51D42976BCAD009C0CE3 /* Filesystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Filesystem.h; sourceTree = "<group>"; };
+		CBEC51D52976BCAD009C0CE3 /* Filesystem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Filesystem.m; sourceTree = "<group>"; };
+		CBEC51D82976D54B009C0CE3 /* FilesystemTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FilesystemTests.m; sourceTree = "<group>"; };
 		CBF621052919418F004BEE0B /* Uploader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Uploader.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -241,14 +268,18 @@
 		0122C21F29019770002D243C /* Private */ = {
 			isa = PBXGroup;
 			children = (
-				0122C22929019770002D243C /* Instrumentation */,
 				CBE8EA1C294B5E1500702950 /* Batch.h */,
 				CBE8EA08294A20ED00702950 /* BSGInternalConfig.c */,
 				CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */,
 				CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */,
 				CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */,
 				0122C23229019770002D243C /* BugsnagPerformanceSpan+Private.h */,
+				CBEC51D42976BCAD009C0CE3 /* Filesystem.h */,
+				CBEC51D52976BCAD009C0CE3 /* Filesystem.m */,
 				0122C22229019770002D243C /* IdGenerator.h */,
+				0122C22929019770002D243C /* Instrumentation */,
+				CBEC51BE296DB311009C0CE3 /* JSON.h */,
+				CBEC51BF296DB311009C0CE3 /* JSON.mm */,
 				CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */,
 				CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */,
 				CB04969529150D860097E526 /* OtlpPackage.h */,
@@ -257,6 +288,10 @@
 				0122C23029019770002D243C /* OtlpTraceEncoding.mm */,
 				CB0496992915194E0097E526 /* OtlpUploader.h */,
 				CB04969A2915194E0097E526 /* OtlpUploader.mm */,
+				CBEC51B6296D8386009C0CE3 /* Persistence.h */,
+				CBEC51B7296D8386009C0CE3 /* Persistence.mm */,
+				CBEC51BA296D9EED009C0CE3 /* PersistentState.h */,
+				CBEC51BB296D9EED009C0CE3 /* PersistentState.mm */,
 				01A414CF2913C238003152A4 /* Reachability.h */,
 				01A414D02913C238003152A4 /* Reachability.mm */,
 				015836BF29125E7A002F54C8 /* ResourceAttributes.h */,
@@ -315,10 +350,16 @@
 		0122C25C29019C05002D243C /* BugsnagPerformanceTests */ = {
 			isa = PBXGroup;
 			children = (
-				CB0AD76B296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm */,
 				CB0AD75C29641B59002A3FB6 /* BatchTests.mm */,
+				CB0AD76B296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm */,
 				0122C25F29019C05002D243C /* BugsnagPerformanceTests.mm */,
+				CBEC51C8296ED98F009C0CE3 /* FileBasedTest.h */,
+				CBEC51C9296ED98F009C0CE3 /* FileBasedTest.m */,
+				CBEC51D82976D54B009C0CE3 /* FilesystemTests.m */,
+				CBEC51C2296EC0AC009C0CE3 /* JSONTests.mm */,
 				0122C26029019C05002D243C /* OtlpTraceEncodingTests.mm */,
+				CBEC51CD296EEF52009C0CE3 /* PersistenceTests.mm */,
+				CBEC51C4296ED8BA009C0CE3 /* PersistentStateTests.mm */,
 				01A414C42912B93F003152A4 /* ResourceAttributesTests.mm */,
 				01A58C10290931A5006E4DF7 /* SamplerTests.mm */,
 				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
@@ -384,7 +425,9 @@
 				0122C23929019770002D243C /* BugsnagPerformanceViewType.h in Headers */,
 				0122C23A29019770002D243C /* BugsnagPerformanceConfiguration.h in Headers */,
 				0122C25329019770002D243C /* Span.h in Headers */,
+				CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */,
 				CBE8EA09294A20ED00702950 /* BSGInternalConfig.h in Headers */,
+				CBEC51C0296DB312009C0CE3 /* JSON.h in Headers */,
 				0122C24A29019770002D243C /* AppStartupInstrumentation.h in Headers */,
 				CB04969B2915194E0097E526 /* OtlpUploader.h in Headers */,
 				0122C25029019770002D243C /* BugsnagPerformanceSpan+Private.h in Headers */,
@@ -398,10 +441,12 @@
 				CBE8EA16294B528100702950 /* BugsnagPerformanceImpl.h in Headers */,
 				0122C24129019770002D243C /* IdGenerator.h in Headers */,
 				CBE8EA1E294B5E1500702950 /* Batch.h in Headers */,
+				CBEC51BC296D9EEE009C0CE3 /* PersistentState.h in Headers */,
 				0122C23829019770002D243C /* BugsnagPerformanceSpan.h in Headers */,
 				CB0AD76A296573FC002A3FB6 /* BugsnagPerformanceErrors.h in Headers */,
 				0122C23B29019770002D243C /* BugsnagPerformance.h in Headers */,
 				0122C24B29019770002D243C /* ViewLoadInstrumentation.h in Headers */,
+				CBEC51B8296D8386009C0CE3 /* Persistence.h in Headers */,
 				CB34772129068C350033759C /* NSURLSession+Instrumentation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -534,9 +579,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				01A58C11290931A5006E4DF7 /* SamplerTests.mm in Sources */,
+				CBEC51C5296ED8BA009C0CE3 /* PersistentStateTests.mm in Sources */,
 				0122C26F29019CEF002D243C /* BugsnagPerformanceTests.mm in Sources */,
+				CBEC51CC296EDA2D009C0CE3 /* FileBasedTest.m in Sources */,
 				CB0AD75B295F27DD002A3FB6 /* WorkerTests.mm in Sources */,
+				CBEC51C3296EC0AC009C0CE3 /* JSONTests.mm in Sources */,
 				01A414C52912B93F003152A4 /* ResourceAttributesTests.mm in Sources */,
+				CBEC51CE296EEF52009C0CE3 /* PersistenceTests.mm in Sources */,
+				CBEC51D92976D54B009C0CE3 /* FilesystemTests.m in Sources */,
 				CB0AD75D29641B59002A3FB6 /* BatchTests.mm in Sources */,
 				0122C27129019CEF002D243C /* OtlpTraceEncodingTests.mm in Sources */,
 				CB0AD76C296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm in Sources */,
@@ -553,6 +603,9 @@
 				0122C24429019770002D243C /* Tracer.mm in Sources */,
 				CB04969829150D860097E526 /* OtlpPackage.mm in Sources */,
 				0122C23D29019770002D243C /* BugsnagPerformance.mm in Sources */,
+				CBEC51D72976BCAD009C0CE3 /* Filesystem.m in Sources */,
+				CBEC51BD296D9EEE009C0CE3 /* PersistentState.mm in Sources */,
+				CBEC51B9296D8386009C0CE3 /* Persistence.mm in Sources */,
 				CBE8EA17294B528100702950 /* BugsnagPerformanceImpl.mm in Sources */,
 				0122C23E29019770002D243C /* BugsnagPerformanceSpan.mm in Sources */,
 				01A414CE2913C0F0003152A4 /* SpanAttributes.mm in Sources */,
@@ -560,6 +613,7 @@
 				CBE8EA1B294B5AB800702950 /* Worker.mm in Sources */,
 				0122C23C29019770002D243C /* BugsnagPerformanceConfiguration.mm in Sources */,
 				01A58C0F29092D25006E4DF7 /* Sampler.mm in Sources */,
+				CBEC51C1296DB312009C0CE3 /* JSON.mm in Sources */,
 				0122C24029019770002D243C /* SpanData.mm in Sources */,
 				0122C24829019770002D243C /* NetworkInstrumentation.mm in Sources */,
 				0122C24D29019770002D243C /* ViewLoadInstrumentation.mm in Sources */,

--- a/BugsnagPerformance.xcodeproj/xcshareddata/xcschemes/BugsnagPerformance-iOS.xcscheme
+++ b/BugsnagPerformance.xcodeproj/xcshareddata/xcschemes/BugsnagPerformance-iOS.xcscheme
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8A80DA862966CE940035BDA9"
-               BuildableName = "BugsnagPerformanceTestsSwift.xctest"
+               BuildableName = "BugsnagPerformance-SwiftTests.xctest"
                BlueprintName = "BugsnagPerformance-SwiftTests"
                ReferencedContainer = "container:BugsnagPerformance.xcodeproj">
             </BuildableReference>

--- a/BugsnagPerformance.xcodeproj/xcshareddata/xcschemes/BugsnagPerformanceTestsSwift.xcscheme
+++ b/BugsnagPerformance.xcodeproj/xcshareddata/xcschemes/BugsnagPerformanceTestsSwift.xcscheme
@@ -17,7 +17,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8A80DA862966CE940035BDA9"
-               BuildableName = "BugsnagPerformanceTestsSwift.xctest"
+               BuildableName = "BugsnagPerformance-SwiftTests.xctest"
                BlueprintName = "BugsnagPerformance-SwiftTests"
                ReferencedContainer = "container:BugsnagPerformance.xcodeproj">
             </BuildableReference>

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -16,6 +16,9 @@
 #import "Sampler.h"
 #import "Tracer.h"
 #import "Worker.h"
+#import "Persistence.h"
+#import "PersistentState.h"
+#import "Reachability.h"
 
 #import <mutex>
 
@@ -62,17 +65,29 @@ private:
     std::shared_ptr<class Sampler> sampler_;
     Tracer tracer_;
     Worker *worker_;
+    std::shared_ptr<Persistence> persistence_;
+    std::shared_ptr<PersistentState> persistentState_;
     std::shared_ptr<OtlpUploader> uploader_;
     std::vector<std::unique_ptr<OtlpPackage>> retryQueue_;
     NSDictionary *resourceAttributes_;
+    bool shouldPersistState_;
 
+    // Tasks
     NSArray<Task> *buildInitialTasks();
     NSArray<Task> *buildRecurringTasks();
     bool sendCurrentBatchTask();
     bool sendCurrentBatchAndRetriesTask();
     bool sendInitialPValueRequestTask();
+    bool maybePersistStateTask();
 
+    // Event reactions
+    void onBatchFull() noexcept;
+    void onConnectivityChanged(Reachability::Connectivity connectivity) noexcept;
     void onProbabilityChanged(double newProbability) noexcept;
+    void onPersistentStateChanged() noexcept;
+
+    // Utility
+    void wakeWorker() noexcept;
     void uploadPackage(std::unique_ptr<OtlpPackage> package) noexcept;
     void queueRetry(std::unique_ptr<OtlpPackage> package) noexcept;
     std::unique_ptr<OtlpPackage> buildPackage(const std::vector<std::unique_ptr<SpanData>> &spans) const noexcept;

--- a/Sources/BugsnagPerformance/Private/Filesystem.h
+++ b/Sources/BugsnagPerformance/Private/Filesystem.h
@@ -1,0 +1,27 @@
+//
+//  Filesystem.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 17.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Filesystem : NSObject
+
+/**
+ * Builds all necessary intervening directories to make the given directory path exist.
+ */
++ (NSError *)ensurePathExists:(NSString *)path;
+
+/**
+ * Deletes the given path and recreates it (as a directory).
+ */
++ (NSError *)rebuildPath:(NSString *)path;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/Filesystem.m
+++ b/Sources/BugsnagPerformance/Private/Filesystem.m
@@ -1,0 +1,32 @@
+//
+//  Filesystem.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 17.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "Filesystem.h"
+
+@implementation Filesystem
+
++ (NSError *)ensurePathExists:(NSString *)path {
+    NSError *error = nil;
+    NSFileManager *fm = [NSFileManager defaultManager];
+    [fm createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:&error];
+    return error;
+}
+
++ (NSError *)rebuildPath:(NSString *)path {
+    NSError *error = nil;
+    NSFileManager *fm = [NSFileManager defaultManager];
+    if ([fm fileExistsAtPath:path]) {
+        [fm removeItemAtPath:path error:&error];
+        if (error != nil) {
+            return error;
+        }
+    }
+    return [self ensurePathExists:path];
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/JSON.h
+++ b/Sources/BugsnagPerformance/Private/JSON.h
@@ -1,0 +1,23 @@
+//
+//  JSON.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 10.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+namespace bugsnag {
+
+class JSON {
+public:
+    static NSDictionary *dataToDictionary(NSData *json, NSError **error) noexcept;
+    static NSData *dictionaryToData(NSDictionary *dict, NSError **error) noexcept;
+    static NSError *dictionaryToFile(NSString *path, NSDictionary *dict) noexcept;
+    static NSDictionary *fileToDictionary(NSString *path, NSError **error) noexcept;
+};
+
+}

--- a/Sources/BugsnagPerformance/Private/JSON.mm
+++ b/Sources/BugsnagPerformance/Private/JSON.mm
@@ -1,0 +1,87 @@
+//
+//  JSON.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 10.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "JSON.h"
+
+using namespace bugsnag;
+
+static NSString *errorDomain = @"bugsnag::JSONErrorDomain";
+
+static NSError* wrapException(NSException* exception) {
+    return [NSError errorWithDomain:errorDomain code:1 userInfo:@{
+        NSLocalizedDescriptionKey: [NSString stringWithFormat:@"%@: %@", exception.name, exception.reason]
+    }];
+}
+
+static BOOL isValidForJson(NSDictionary *obj, NSError **error) {
+    @try {
+        if (![obj isKindOfClass:[NSDictionary class]] ||
+            ![NSJSONSerialization isValidJSONObject:(id _Nonnull)obj]) {
+            if (error) {
+                *error = [NSError errorWithDomain:errorDomain code:0 userInfo:@{
+                    NSLocalizedDescriptionKey: @"Not a valid JSON object"}];
+            }
+            return NO;
+        }
+        return YES;
+    } @catch (NSException *exception) {
+        if (error) {
+            *error = wrapException(exception);
+        }
+        return NO;
+    }
+}
+
+NSDictionary *JSON::dataToDictionary(NSData *json, NSError **error) noexcept {
+    @try {
+        id obj = [NSJSONSerialization JSONObjectWithData:json options:0 error:error];
+        if ([obj isKindOfClass:[NSDictionary class]]) {
+            return obj;
+        }
+
+        if (error) {
+            NSString *msg = [NSString stringWithFormat:@"Expected NSDictionary but got %@", [obj class]];
+            *error = [NSError errorWithDomain:errorDomain code:0 userInfo:@{
+                NSLocalizedDescriptionKey:msg}];
+        }
+        return nil;
+    } @catch (NSException *exception) {
+        if (error) {
+            *error = wrapException(exception);
+        }
+        return nil;
+    }
+    return nil;
+}
+
+NSData *JSON::dictionaryToData(NSDictionary *dict, NSError **error) noexcept {
+    if (!isValidForJson(dict, error)) {
+        return nil;
+    }
+    return [NSJSONSerialization dataWithJSONObject:dict options:0 error:error];
+}
+
+NSError *JSON::dictionaryToFile(NSString *path, NSDictionary *dict) noexcept {
+    NSError *error = nil;
+    NSData *data = JSON::dictionaryToData(dict, &error);
+    if (data == nil) {
+        return error;
+    }
+    if (![data writeToFile:path options:NSDataWritingAtomic error:&error]) {
+        return error;
+    }
+    return nil;
+}
+
+NSDictionary *JSON::fileToDictionary(NSString *path, NSError **error) noexcept {
+    NSData *data = [NSData dataWithContentsOfFile:path options:0 error:error];
+    if (data == nil) {
+        return nil;
+    }
+    return JSON::dataToDictionary(data, error);
+}

--- a/Sources/BugsnagPerformance/Private/Persistence.h
+++ b/Sources/BugsnagPerformance/Private/Persistence.h
@@ -1,0 +1,26 @@
+//
+//  Persistence.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 10.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+namespace bugsnag {
+
+class Persistence {
+public:
+    Persistence() = delete;
+    Persistence(NSString *topLevelDir) noexcept;
+    NSError *start(void) noexcept;
+    NSError *clear(void) noexcept;
+    NSString *topLevelDirectory(void) noexcept;
+private:
+    NSString *topLevelDir_;
+};
+
+}

--- a/Sources/BugsnagPerformance/Private/Persistence.mm
+++ b/Sources/BugsnagPerformance/Private/Persistence.mm
@@ -1,0 +1,31 @@
+//
+//  Persistence.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 10.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#define PERSISTENCE_VERSION @"v1"
+
+#import "Persistence.h"
+#import "Filesystem.h"
+
+using namespace bugsnag;
+
+Persistence::Persistence(NSString *topLevelDir) noexcept
+: topLevelDir_(topLevelDir)
+{
+}
+
+NSString *Persistence::topLevelDirectory(void) noexcept {
+    return [topLevelDir_ stringByAppendingPathComponent:PERSISTENCE_VERSION];
+}
+
+NSError *Persistence::start(void) noexcept {
+    return clear();
+}
+
+NSError *Persistence::clear(void) noexcept {
+    return [Filesystem rebuildPath:topLevelDir_];
+}

--- a/Sources/BugsnagPerformance/Private/PersistentState.h
+++ b/Sources/BugsnagPerformance/Private/PersistentState.h
@@ -1,0 +1,41 @@
+//
+//  PersistentState.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 10.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+namespace bugsnag {
+
+class PersistentState {
+public:
+    PersistentState(NSString *jsonFilePath, void (^onPersistenceNeeded)()) noexcept;
+    PersistentState() = delete;
+
+    void setProbability(double probability) noexcept;
+    double probability(void) noexcept {return probability_;};
+
+    /**
+     * Save this object to persistent storage.
+     * This method should only be called from the worker thread.
+     */
+    NSError *persist() noexcept;
+
+    /**
+     * Load this object from persistent storage.
+     * This method should only be called once at startup.
+     */
+    NSError *load() noexcept;
+private:
+    NSString *jsonFilePath_;
+    NSString *persistentStateDir_;
+    double probability_;
+    void (^onPersistenceNeeded_)();
+};
+
+}

--- a/Sources/BugsnagPerformance/Private/PersistentState.mm
+++ b/Sources/BugsnagPerformance/Private/PersistentState.mm
@@ -1,0 +1,58 @@
+//
+//  PersistentState.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 10.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "PersistentState.h"
+#import "JSON.h"
+#import "Filesystem.h"
+
+using namespace bugsnag;
+
+static NSNumber *getNumber(NSDictionary* dict, NSString *key) {
+    NSNumber *value = dict[key];
+    return [value isKindOfClass:[NSNumber class]] ? value : nil;
+}
+
+PersistentState::PersistentState(NSString *jsonFilePath, void (^onPersistenceNeeded)()) noexcept
+: jsonFilePath_(jsonFilePath)
+, persistentStateDir_([jsonFilePath_ stringByDeletingLastPathComponent])
+, probability_(0)
+, onPersistenceNeeded_(onPersistenceNeeded)
+{
+}
+
+void PersistentState::setProbability(double probability) noexcept {
+    probability_ = probability;
+    onPersistenceNeeded_();
+}
+
+NSError *PersistentState::persist() noexcept {
+    NSError *error = [Filesystem ensurePathExists:persistentStateDir_];
+    if (error != nil) {
+        return error;
+    }
+
+    return JSON::dictionaryToFile(jsonFilePath_, @{
+        @"probability": @(probability_)
+    });
+}
+
+NSError *PersistentState::load() noexcept {
+    NSError *error = nil;
+    NSDictionary *dict = JSON::fileToDictionary(jsonFilePath_, &error);
+    if (dict == nil) {
+        return error;
+    }
+
+    NSNumber *probability = getNumber(dict, @"probability");
+    if (probability != nil) {
+        probability_ = probability.doubleValue;
+    }
+
+    return nil;
+}
+

--- a/Tests/BugsnagPerformanceTests/FileBasedTest.h
+++ b/Tests/BugsnagPerformanceTests/FileBasedTest.h
@@ -1,0 +1,17 @@
+//
+//  FileBasedTest.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 11.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface FileBasedTest : XCTestCase
+
+@property(readwrite, nonatomic) NSString *filePath;
+
+- (NSString *)newPath;
+
+@end

--- a/Tests/BugsnagPerformanceTests/FileBasedTest.m
+++ b/Tests/BugsnagPerformanceTests/FileBasedTest.m
@@ -1,0 +1,25 @@
+//
+//  FileBasedTest.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 11.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "FileBasedTest.h"
+
+@implementation FileBasedTest
+
+- (NSString *)newPath {
+    return [NSTemporaryDirectory() stringByAppendingPathComponent:[NSUUID UUID].UUIDString];
+}
+
+- (void)setUp {
+    self.filePath = [self newPath];
+}
+
+- (void)tearDown {
+    [[NSFileManager defaultManager] removeItemAtPath:self.filePath error:nil];
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/FilesystemTests.m
+++ b/Tests/BugsnagPerformanceTests/FilesystemTests.m
@@ -1,0 +1,80 @@
+//
+//  FilesystemTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 17.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "FileBasedTest.h"
+#import "Filesystem.h"
+
+@interface FilesystemTests : FileBasedTest
+
+@end
+
+@implementation FilesystemTests
+
+- (void)testFilesystem {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSError *error = nil;
+    BOOL isDir = false;
+    NSString *subdir = [self.filePath stringByAppendingPathComponent:@"subdir"];
+
+    
+    XCTAssertFalse([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertFalse([fm fileExistsAtPath:subdir isDirectory:&isDir]);
+    XCTAssertNil([Filesystem ensurePathExists:self.filePath]);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+    XCTAssertFalse([fm fileExistsAtPath:subdir isDirectory:&isDir]);
+    XCTAssertNil([Filesystem ensurePathExists:subdir]);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+    XCTAssertTrue([fm fileExistsAtPath:subdir isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+
+    XCTAssertNil([Filesystem rebuildPath:self.filePath]);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+    XCTAssertFalse([fm fileExistsAtPath:subdir isDirectory:&isDir]);
+
+    XCTAssertNil([Filesystem ensurePathExists:subdir]);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+    XCTAssertTrue([fm fileExistsAtPath:subdir isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+
+    XCTAssertEqual(1, [fm contentsOfDirectoryAtPath:self.filePath error:&error].count);
+    XCTAssertNil(error);
+    XCTAssertEqual(0, [fm contentsOfDirectoryAtPath:subdir error:&error].count);
+    XCTAssertNil(error);
+
+    NSString *internalFile = [subdir stringByAppendingPathComponent:@"a"];
+    XCTAssertTrue([[@"a" dataUsingEncoding:NSUTF8StringEncoding]
+                   writeToFile:internalFile
+                   atomically:YES]);
+    XCTAssertTrue([fm fileExistsAtPath:internalFile isDirectory:&isDir]);
+    XCTAssertFalse(isDir);
+
+    XCTAssertNil([Filesystem rebuildPath:self.filePath]);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+    XCTAssertFalse([fm fileExistsAtPath:subdir isDirectory:&isDir]);
+    XCTAssertFalse([fm fileExistsAtPath:internalFile isDirectory:&isDir]);
+}
+
+- (void)testRebuild {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    BOOL isDir = false;
+    NSString *subdir = [self.filePath stringByAppendingPathComponent:@"subdir"];
+    
+    
+    XCTAssertFalse([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertFalse([fm fileExistsAtPath:subdir isDirectory:&isDir]);
+    
+    XCTAssertNil([Filesystem rebuildPath:self.filePath]);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/JSONTests.mm
+++ b/Tests/BugsnagPerformanceTests/JSONTests.mm
@@ -1,0 +1,63 @@
+//
+//  JSONTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 11.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "FileBasedTest.h"
+
+#import "JSON.h"
+
+using namespace bugsnag;
+
+@interface JSONTests : FileBasedTest
+
+@end
+
+@implementation JSONTests
+
+- (void)testData {
+    auto expected = @{
+        @"a": @(1),
+        @"b": @(true),
+        @"c": @"string",
+        @"d": @(1.5),
+        @"e": @{@"a": @"x"},
+        @"f": @[@"1", @"2"],
+    };
+    NSError *error = nil;
+    auto data = JSON::dictionaryToData(expected, &error);
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+    auto actual = JSON::dataToDictionary(data, &error);
+    XCTAssertNil(error);
+    XCTAssertNotNil(actual);
+    XCTAssertEqualObjects(expected, actual);
+
+    // Make sure NSJSONSerialization agrees
+    actual = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(actual);
+    XCTAssertEqualObjects(expected, actual);
+}
+
+- (void)testFiles {
+    auto expected = @{
+        @"a": @(1),
+        @"b": @(true),
+        @"c": @"string",
+        @"d": @(1.5),
+        @"e": @{@"a": @"x"},
+        @"f": @[@"1", @"2"],
+    };
+    NSError *error = JSON::dictionaryToFile(self.filePath, expected);
+    XCTAssertNil(error);
+    auto actual = JSON::fileToDictionary(self.filePath, &error);
+    XCTAssertNil(error);
+    XCTAssertNotNil(actual);
+    XCTAssertEqualObjects(expected, actual);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/PersistenceTests.mm
+++ b/Tests/BugsnagPerformanceTests/PersistenceTests.mm
@@ -1,0 +1,49 @@
+//
+//  PersistenceTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 11.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "FileBasedTest.h"
+#import "Persistence.h"
+
+using namespace bugsnag;
+
+@interface PersistenceTests : FileBasedTest
+
+@end
+
+@implementation PersistenceTests
+
+- (void)testPersistence {
+    auto fm = [NSFileManager defaultManager];
+    BOOL isDir = false;
+    NSError *error = nil;
+    auto persistence = Persistence(self.filePath);
+    XCTAssertFalse([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertEqualObjects([self.filePath stringByAppendingPathComponent:@"v1"], persistence.topLevelDirectory());
+
+    XCTAssertNil(persistence.start());
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+    XCTAssertEqual(0, [fm contentsOfDirectoryAtPath:self.filePath error:&error].count);
+    XCTAssertNil(error);
+
+    auto internalFile = [self.filePath stringByAppendingPathComponent:@"a"];
+    XCTAssertTrue([[@"a" dataUsingEncoding:NSUTF8StringEncoding]
+                   writeToFile:internalFile
+                   atomically:YES]);
+    XCTAssertTrue([fm fileExistsAtPath:internalFile isDirectory:&isDir]);
+    XCTAssertFalse(isDir);
+
+    persistence.clear();
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+    XCTAssertEqual(0, [fm contentsOfDirectoryAtPath:self.filePath error:&error].count);
+    XCTAssertNil(error);
+    XCTAssertFalse([fm fileExistsAtPath:internalFile isDirectory:&isDir]);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/PersistentStateTests.mm
+++ b/Tests/BugsnagPerformanceTests/PersistentStateTests.mm
@@ -1,0 +1,57 @@
+//
+//  PersistentStateTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 11.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "FileBasedTest.h"
+
+#import "PersistentState.h"
+
+using namespace bugsnag;
+
+@interface PersistentStateTests : FileBasedTest
+
+@end
+
+@implementation PersistentStateTests
+
+- (void)testPersistentState {
+    auto fm = [NSFileManager defaultManager];
+    __block int callbackCallCount = false;
+
+    auto state = PersistentState(self.filePath, ^{
+        callbackCallCount++;
+    });
+
+    XCTAssertEqual(0, state.probability());
+    XCTAssertFalse([fm fileExistsAtPath:self.filePath]);
+    XCTAssertEqual(0, callbackCallCount);
+
+    state.setProbability(0.5);
+    XCTAssertEqual(0.5, state.probability());
+    XCTAssertFalse([fm fileExistsAtPath:self.filePath]);
+    XCTAssertEqual(1, callbackCallCount);
+
+    state.setProbability(0.6);
+    XCTAssertEqual(0.6, state.probability());
+    XCTAssertFalse([fm fileExistsAtPath:self.filePath]);
+    XCTAssertEqual(2, callbackCallCount);
+
+    state.persist();
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath]);
+
+    callbackCallCount = 0;
+    state = PersistentState(self.filePath, ^{
+        callbackCallCount++;
+    });
+    XCTAssertEqual(0, state.probability());
+    XCTAssertNil(state.load());
+    XCTAssertEqual(0.6, state.probability());
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath]);
+    XCTAssertEqual(0, callbackCallCount);
+}
+
+@end

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -5,14 +5,9 @@ Feature: Manual creation of spans
   Scenario: Retry a manual span
     Given I set the HTTP status code for the next requests to "200,500,200,200"
     And I run "RetryScenario"
-    And I wait to receive 4 traces
-    And the trace payload field "resourceSpans" is an array with 0 elements
-    And I discard the oldest trace
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "WillRetry"
-    And I discard the oldest trace
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Success"
-    And I discard the oldest trace
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "WillRetry"
+    And I wait for 3 spans
+    * a span field "name" equals "WillRetry"
+    * a span field "name" equals "Success"
 
   Scenario: Manually start and end a span
     Given I run "ManualSpanScenario" and discard the initial p-value request


### PR DESCRIPTION
## Goal

Adds a top-level persistence handling mechanism, and a persistent state object that uses it.

## Design

* `JSON` handles all JSON serialization and JSON-related file IO.
* `Filesystem` has some common file & directory based operations.
* `Persistence` manages a top-level persistence directory, clearing it when necessary.
* `PersistentState` keeps track of the updated P value for now, and will record other discrete persisted data in future.

## Testing

New unit tests for all new classes.
