### PR TITLE
[PLAT-9359] Switch to on-disk retry queue

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -84,6 +84,10 @@
 		CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEC51D42976BCAD009C0CE3 /* Filesystem.h */; };
 		CBEC51D72976BCAD009C0CE3 /* Filesystem.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51D52976BCAD009C0CE3 /* Filesystem.m */; };
 		CBEC51D92976D54B009C0CE3 /* FilesystemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51D82976D54B009C0CE3 /* FilesystemTests.m */; };
+		CBEC51DC2976F1F9009C0CE3 /* RetryQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEC51DA2976F1F9009C0CE3 /* RetryQueue.h */; };
+		CBEC51DD2976F1F9009C0CE3 /* RetryQueue.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51DB2976F1F9009C0CE3 /* RetryQueue.mm */; };
+		CBEC51DF29782471009C0CE3 /* OtlpPackageTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51DE29782471009C0CE3 /* OtlpPackageTests.mm */; };
+		CBEC51E129793B1E009C0CE3 /* RetryQueueTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -184,6 +188,10 @@
 		CBEC51D42976BCAD009C0CE3 /* Filesystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Filesystem.h; sourceTree = "<group>"; };
 		CBEC51D52976BCAD009C0CE3 /* Filesystem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Filesystem.m; sourceTree = "<group>"; };
 		CBEC51D82976D54B009C0CE3 /* FilesystemTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FilesystemTests.m; sourceTree = "<group>"; };
+		CBEC51DA2976F1F9009C0CE3 /* RetryQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RetryQueue.h; sourceTree = "<group>"; };
+		CBEC51DB2976F1F9009C0CE3 /* RetryQueue.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RetryQueue.mm; sourceTree = "<group>"; };
+		CBEC51DE29782471009C0CE3 /* OtlpPackageTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OtlpPackageTests.mm; sourceTree = "<group>"; };
+		CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RetryQueueTests.mm; sourceTree = "<group>"; };
 		CBF621052919418F004BEE0B /* Uploader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Uploader.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -296,6 +304,8 @@
 				01A414D02913C238003152A4 /* Reachability.mm */,
 				015836BF29125E7A002F54C8 /* ResourceAttributes.h */,
 				015836C029125E7A002F54C8 /* ResourceAttributes.mm */,
+				CBEC51DA2976F1F9009C0CE3 /* RetryQueue.h */,
+				CBEC51DB2976F1F9009C0CE3 /* RetryQueue.mm */,
 				01A58C0C29092D25006E4DF7 /* Sampler.h */,
 				01A58C0D29092D25006E4DF7 /* Sampler.mm */,
 				0122C23529019770002D243C /* Span.h */,
@@ -357,10 +367,12 @@
 				CBEC51C9296ED98F009C0CE3 /* FileBasedTest.m */,
 				CBEC51D82976D54B009C0CE3 /* FilesystemTests.m */,
 				CBEC51C2296EC0AC009C0CE3 /* JSONTests.mm */,
+				CBEC51DE29782471009C0CE3 /* OtlpPackageTests.mm */,
 				0122C26029019C05002D243C /* OtlpTraceEncodingTests.mm */,
 				CBEC51CD296EEF52009C0CE3 /* PersistenceTests.mm */,
 				CBEC51C4296ED8BA009C0CE3 /* PersistentStateTests.mm */,
 				01A414C42912B93F003152A4 /* ResourceAttributesTests.mm */,
+				CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */,
 				01A58C10290931A5006E4DF7 /* SamplerTests.mm */,
 				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
 			);
@@ -433,6 +445,7 @@
 				0122C25029019770002D243C /* BugsnagPerformanceSpan+Private.h in Headers */,
 				0122C23F29019770002D243C /* OtlpTraceEncoding.h in Headers */,
 				0122C24229019770002D243C /* SpanKind.h in Headers */,
+				CBEC51DC2976F1F9009C0CE3 /* RetryQueue.h in Headers */,
 				01A414CD2913C0F0003152A4 /* SpanAttributes.h in Headers */,
 				0122C25129019770002D243C /* Tracer.h in Headers */,
 				CBB48A3C295EE1E10044E9AC /* ObjCUtils.h in Headers */,
@@ -578,10 +591,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CBEC51E129793B1E009C0CE3 /* RetryQueueTests.mm in Sources */,
 				01A58C11290931A5006E4DF7 /* SamplerTests.mm in Sources */,
 				CBEC51C5296ED8BA009C0CE3 /* PersistentStateTests.mm in Sources */,
 				0122C26F29019CEF002D243C /* BugsnagPerformanceTests.mm in Sources */,
 				CBEC51CC296EDA2D009C0CE3 /* FileBasedTest.m in Sources */,
+				CBEC51DF29782471009C0CE3 /* OtlpPackageTests.mm in Sources */,
 				CB0AD75B295F27DD002A3FB6 /* WorkerTests.mm in Sources */,
 				CBEC51C3296EC0AC009C0CE3 /* JSONTests.mm in Sources */,
 				01A414C52912B93F003152A4 /* ResourceAttributesTests.mm in Sources */,
@@ -608,6 +623,7 @@
 				CBEC51B9296D8386009C0CE3 /* Persistence.mm in Sources */,
 				CBE8EA17294B528100702950 /* BugsnagPerformanceImpl.mm in Sources */,
 				0122C23E29019770002D243C /* BugsnagPerformanceSpan.mm in Sources */,
+				CBEC51DD2976F1F9009C0CE3 /* RetryQueue.mm in Sources */,
 				01A414CE2913C0F0003152A4 /* SpanAttributes.mm in Sources */,
 				CB34771E29068C350033759C /* NSURLSession+Instrumentation.mm in Sources */,
 				CBE8EA1B294B5AB800702950 /* Worker.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/BSGInternalConfig.c
+++ b/Sources/BugsnagPerformance/Private/BSGInternalConfig.c
@@ -13,3 +13,5 @@ uint64_t bsgp_autoTriggerExportOnBatchSize = 100;
 dispatch_time_t bsgp_autoTriggerExportOnTimeDuration = 30 * NSEC_PER_SEC;
 
 NSTimeInterval bsgp_performWorkInterval = 30;
+
+NSTimeInterval bsgp_maxRetryAge = 24 * 60 * 60;

--- a/Sources/BugsnagPerformance/Private/BSGInternalConfig.h
+++ b/Sources/BugsnagPerformance/Private/BSGInternalConfig.h
@@ -26,4 +26,6 @@ extern dispatch_time_t bsgp_autoTriggerExportOnTimeDuration;
 
 extern NSTimeInterval bsgp_performWorkInterval;
 
+extern NSTimeInterval bsgp_maxRetryAge;
+
 #endif /* BSGInternalConfig_h */

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -19,6 +19,7 @@
 #import "Persistence.h"
 #import "PersistentState.h"
 #import "Reachability.h"
+#import "RetryQueue.h"
 
 #import <mutex>
 
@@ -68,7 +69,7 @@ private:
     std::shared_ptr<Persistence> persistence_;
     std::shared_ptr<PersistentState> persistentState_;
     std::shared_ptr<OtlpUploader> uploader_;
-    std::vector<std::unique_ptr<OtlpPackage>> retryQueue_;
+    std::unique_ptr<RetryQueue> retryQueue_;
     NSDictionary *resourceAttributes_;
     bool shouldPersistState_;
 
@@ -76,7 +77,7 @@ private:
     NSArray<Task> *buildInitialTasks();
     NSArray<Task> *buildRecurringTasks();
     bool sendCurrentBatchTask();
-    bool sendCurrentBatchAndRetriesTask();
+    bool sendRetriesTask();
     bool sendInitialPValueRequestTask();
     bool maybePersistStateTask();
 
@@ -85,11 +86,11 @@ private:
     void onConnectivityChanged(Reachability::Connectivity connectivity) noexcept;
     void onProbabilityChanged(double newProbability) noexcept;
     void onPersistentStateChanged() noexcept;
+    void onFilesystemError() noexcept;
 
     // Utility
     void wakeWorker() noexcept;
-    void uploadPackage(std::unique_ptr<OtlpPackage> package) noexcept;
-    void queueRetry(std::unique_ptr<OtlpPackage> package) noexcept;
+    void uploadPackage(std::unique_ptr<OtlpPackage> package, bool isRetry) noexcept;
     std::unique_ptr<OtlpPackage> buildPackage(const std::vector<std::unique_ptr<SpanData>> &spans) const noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Private/OtlpPackage.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpPackage.mm
@@ -31,10 +31,64 @@ static NSDictionary * headersWithIntegrityDigest(const NSData *payload, const NS
     return mutableHeaders;
 }
 
-OtlpPackage::OtlpPackage(const NSData *payload, const NSDictionary *headers) noexcept
-: payload_(payload)
+OtlpPackage::OtlpPackage(const dispatch_time_t ts,
+                         const NSData *payload,
+                         const NSDictionary *headers) noexcept
+: timestamp(ts)
+, payload_(payload)
 , headers_(headersWithIntegrityDigest(payload, headers))
 {}
+
+static int getPayloadOffset(const NSData *data) {
+    auto endOfHeaders = [@"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+    auto range = [data rangeOfData:endOfHeaders options:0 range:NSMakeRange(0, data.length)];
+    if (range.location == NSNotFound) {
+        return -1;
+    }
+    return (int)(range.location + range.length);
+}
+
+static NSData *deserializePayload(const NSData *data) {
+    auto payloadOffset = getPayloadOffset(data);
+    if (payloadOffset < 0) {
+        return nullptr;
+    }
+    auto offset = (NSUInteger)payloadOffset;
+    return [data subdataWithRange:NSMakeRange(offset, data.length - offset)];
+}
+
+static NSDictionary *deserializeHeaders(const NSData *data) {
+    auto payloadOffset = getPayloadOffset(data);
+    if (payloadOffset < 0) {
+        return nullptr;
+    }
+    auto headerStr = [[NSString alloc] initWithData:[data subdataWithRange:NSMakeRange(0, (NSUInteger)payloadOffset)]
+                                           encoding:NSUTF8StringEncoding];
+    auto headers = [NSMutableDictionary new];
+
+    NSError *error;
+    NSString *pattern = @"(\\S+)\\s*:\\s*(\\S+)";
+    NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
+
+    NSArray<NSTextCheckingResult *> *matches = [regex matchesInString:headerStr options:0 range:NSMakeRange(0, headerStr.length)];
+
+    for (NSTextCheckingResult *match in matches) {
+        headers[[headerStr substringWithRange:[match rangeAtIndex:1]]] = [headerStr substringWithRange:[match rangeAtIndex:2]];
+    }
+
+    return headers;
+}
+
+std::unique_ptr<OtlpPackage> bugsnag::deserializeOtlpPackage(const dispatch_time_t ts, const NSData *fileContents) noexcept {
+    auto headers = deserializeHeaders(fileContents);
+    auto payload = deserializePayload(fileContents);
+
+    if (headers == nullptr || payload == nullptr) {
+        return nullptr;
+    }
+
+    return std::make_unique<OtlpPackage>(ts, payload, headers);
+}
 
 void OtlpPackage::fillURLRequest(NSMutableURLRequest *request) const noexcept {
     request.HTTPMethod = @"POST";
@@ -42,4 +96,15 @@ void OtlpPackage::fillURLRequest(NSMutableURLRequest *request) const noexcept {
     for (NSString *key in headers_) {
         [request setValue:headers_[key] forHTTPHeaderField:key];
     }
+}
+
+NSData *OtlpPackage::serialize() noexcept {
+    NSMutableString *buffer = [NSMutableString new];
+    for (id key in headers_) {
+        [buffer appendFormat:@"%@: %@\r\n", key, headers_[key]];
+    }
+    [buffer appendString:@"\r\n"];
+    NSMutableData *data = [[buffer dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+    [data appendData:(NSData * _Nonnull)payload_];
+    return data;
 }

--- a/Sources/BugsnagPerformance/Private/RetryQueue.h
+++ b/Sources/BugsnagPerformance/Private/RetryQueue.h
@@ -1,0 +1,66 @@
+//
+//  RetryQueue.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 17.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import "OtlpPackage.h"
+#import <vector>
+#import <memory>
+
+namespace bugsnag {
+
+
+class RetryQueue {
+public:
+    RetryQueue(NSString *path) noexcept;
+    RetryQueue() = delete;
+
+    /**
+     * Sweep the retry queue, deleting any non-retry files and retries that are older than 24 hours.
+     */
+    void sweep() noexcept;
+
+    /**
+     * List the timestamps of all retries in the queue, listing newest first.
+     */
+    std::vector<dispatch_time_t> list() noexcept;
+
+    /**
+     * Get a retry by its timestamp.
+     * Returns nullptr if no such retry exists.
+     */
+    std::unique_ptr<OtlpPackage> get(dispatch_time_t ts) noexcept;
+
+    /**
+     * Add a package to the retry queue.
+     */
+    void add(OtlpPackage &package) noexcept;
+
+    /**
+     * Remove a retry.
+     * Note: Does not call onFilesystemError.
+     */
+    void remove(dispatch_time_t ts) noexcept;
+
+    /**
+     * Set a callback to call on any unexpected filesystem error.
+     */
+    void setOnFilesystemError(void (^onFilesystemErrorCallback)()) {
+        onFilesystemError = onFilesystemErrorCallback;
+    }
+
+private:
+    NSString *baseDir_;
+    void (^onFilesystemError)();
+
+    void remove(NSString *filename) noexcept;
+    NSString *fullPath(NSString *filename) noexcept;
+    void ensureBaseDirExists() noexcept;
+};
+
+}

--- a/Sources/BugsnagPerformance/Private/RetryQueue.mm
+++ b/Sources/BugsnagPerformance/Private/RetryQueue.mm
@@ -1,0 +1,142 @@
+//
+//  RetryQueue.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 17.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "RetryQueue.h"
+#import "Filesystem.h"
+#import "BSGInternalConfig.h"
+#import "Utils.h"
+#import <cstdlib>
+
+// No valid file < 24h old will ever have a timestamp of 0.
+static const dispatch_time_t INVALID_TIMESTAMP = 0;
+
+using namespace bugsnag;
+
+static NSString *filenameFromTimestamp(dispatch_time_t ts) {
+    return [NSString stringWithFormat:@"retry-%019llu.json", ts];
+}
+
+/**
+ * Get the timestamp that is encoded into a filename.
+ * Returns INVALID_TIMESTAMP if the timestamp format is invalid.
+ */
+static dispatch_time_t timestampFromFilename(NSString *filename) {
+    NSError *error = nil;
+    NSString *pattern = @"^retry-([0-9]+)\\.json$";
+    NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern: pattern options:0 error:&error];
+
+    auto match = [regex firstMatchInString:filename options:0 range:NSMakeRange(0, filename.length)];
+    if (match.range.location == NSNotFound) {
+        return INVALID_TIMESTAMP;
+    }
+    NSRange group1 = [match rangeAtIndex:1];
+    NSString *str = [filename substringWithRange:group1];
+    return strtoull(str.UTF8String, 0, 10);
+}
+
+RetryQueue::RetryQueue(NSString *path) noexcept
+: baseDir_(path)
+{
+    onFilesystemError = ^void() {};
+    [Filesystem ensurePathExists:path];
+}
+
+void RetryQueue::sweep() noexcept {
+    ensureBaseDirExists();
+    NSError *error = nil;
+    auto contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:baseDir_ error:&error];
+    if (contents == nil) {
+        BSGLogError(@"error while fetching retry queue contents: %@", error);
+        onFilesystemError();
+        return;
+    }
+
+    const dispatch_time_t currentTime = absoluteTimeToNanoseconds(CFAbsoluteTimeGetCurrent());
+    const dispatch_time_t maxAge = intervalToNanoseconds(bsgp_maxRetryAge);
+
+    for (NSString *filename in contents) {
+        auto ts = timestampFromFilename(filename);
+        // If it's too old or the filename is not what we expect, delete it.
+        if (ts == INVALID_TIMESTAMP || ts > currentTime || ts < currentTime - maxAge) {
+            remove(filename);
+        }
+    }
+}
+
+std::vector<dispatch_time_t> RetryQueue::list() noexcept {
+    ensureBaseDirExists();
+    NSError *error = nil;
+    std::vector<dispatch_time_t> timestamps;
+    auto contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:baseDir_ error:&error];
+    if (contents == nil) {
+        BSGLogError(@"error while fetching retry queue contents: %@", error);
+        onFilesystemError();
+    } else {
+        for (NSString *filename in contents) {
+            auto ts = timestampFromFilename(filename);
+            if (ts == INVALID_TIMESTAMP) {
+                // Unexpected file. Delete it and carry on.
+                remove(filename);
+            } else {
+                timestamps.push_back(ts);
+            }
+        }
+    }
+    std::sort(timestamps.begin(), timestamps.end(), std::greater<>());
+    return timestamps;
+}
+
+std::unique_ptr<OtlpPackage> RetryQueue::get(dispatch_time_t ts) noexcept {
+    // If this fails, we don't care why. Just delete the file.
+    NSData *contents = [NSData dataWithContentsOfFile:fullPath(filenameFromTimestamp(ts))
+                                              options:0 error:nil];
+    if (contents == nil) {
+        remove(ts);
+        return nullptr;
+    }
+
+    // If it's corrupt, just delete the file.
+    auto package = deserializeOtlpPackage(ts, contents);
+    if (package == nullptr) {
+        remove(ts);
+    }
+
+    return package;
+}
+
+void RetryQueue::add(OtlpPackage &package) noexcept {
+    ensureBaseDirExists();
+    auto data = package.serialize();
+    NSError *error = nil;
+    NSString *filePath = fullPath(filenameFromTimestamp(package.timestamp));
+    if (![data writeToFile:filePath options:NSDataWritingAtomic error:&error]) {
+        BSGLogError(@"error while writing retry file %@: %@", filePath, error);
+        onFilesystemError();
+    }
+}
+
+void RetryQueue::remove(dispatch_time_t ts) noexcept {
+    remove(filenameFromTimestamp(ts));
+}
+
+void RetryQueue::remove(NSString *filename) noexcept {
+    // We don't care if this fails.
+    [[NSFileManager defaultManager] removeItemAtPath:fullPath(filename) error:nil];
+}
+
+NSString * RetryQueue::fullPath(NSString *filename) noexcept {
+    return [baseDir_ stringByAppendingPathComponent:filename];
+}
+
+void RetryQueue::ensureBaseDirExists() noexcept {
+    NSError *error = [Filesystem ensurePathExists:baseDir_];
+    if (error != nil) {
+        BSGLogError(@"error while creating base dir %@: %@", baseDir_, error);
+        onFilesystemError();
+    }
+}

--- a/Sources/BugsnagPerformance/Private/Utils.h
+++ b/Sources/BugsnagPerformance/Private/Utils.h
@@ -54,4 +54,13 @@ static inline T *BSGDynamicCast(__unsafe_unretained id obj) {
     }
     return nil;
 }
+
+static inline dispatch_time_t absoluteTimeToNanoseconds(CFAbsoluteTime time) {
+    return (dispatch_time_t) ((time + kCFAbsoluteTimeIntervalSince1970) * NSEC_PER_SEC);
+}
+
+static inline dispatch_time_t intervalToNanoseconds(NSTimeInterval interval) {
+    return (dispatch_time_t) (interval * NSEC_PER_SEC);
+}
+
 }

--- a/Tests/BugsnagPerformanceTests/OtlpPackageTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpPackageTests.mm
@@ -1,0 +1,53 @@
+//
+//  OtlpPackageTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 18.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "OtlpPackage.h"
+
+using namespace bugsnag;
+
+@interface OtlpPackageTests : XCTestCase
+
+@end
+
+@implementation OtlpPackageTests
+
+- (void)testEncoding {
+    NSDictionary *headers = @{
+        @"a": @"b",
+        @"c": @"d",
+    };
+    NSData *payload = [@"blah" dataUsingEncoding:NSUTF8StringEncoding];
+    dispatch_time_t ts = 1000;
+
+    OtlpPackage package(ts, payload, headers);
+    XCTAssertTrue(package == package);
+
+    NSData *serialized = package.serialize();
+    XCTAssertEqualObjects(@"a: b\r\nc: d\r\nBugsnag-Integrity: sha1 5bf1fd927dfb8679496a2e6cf00cbe50c1c87145\r\n\r\nblah",
+                          [[NSString alloc] initWithData:serialized encoding:NSUTF8StringEncoding]);
+
+    auto deserialized = deserializeOtlpPackage(ts, serialized);
+    XCTAssertTrue(package == *deserialized);
+}
+
+- (void)testOperatorEquals {
+    OtlpPackage baseline(1, [@"a" dataUsingEncoding:NSUTF8StringEncoding], @{@"a": @"b"});
+    XCTAssertTrue(baseline == baseline);
+    XCTAssertTrue(baseline == OtlpPackage(1, [@"a" dataUsingEncoding:NSUTF8StringEncoding], @{@"a": @"b"}));
+    XCTAssertFalse(baseline == OtlpPackage(2, [@"a" dataUsingEncoding:NSUTF8StringEncoding], @{@"a": @"b"}));
+    XCTAssertFalse(baseline == OtlpPackage(1, [@"b" dataUsingEncoding:NSUTF8StringEncoding], @{@"a": @"b"}));
+    XCTAssertFalse(baseline == OtlpPackage(1, [@"a" dataUsingEncoding:NSUTF8StringEncoding], @{@"b": @"b"}));
+}
+
+- (void)testCorruptedData {
+    NSData *payload = [@"blah" dataUsingEncoding:NSUTF8StringEncoding];
+    XCTAssertEqual(nullptr, deserializeOtlpPackage(1000, payload));
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/RetryQueueTests.mm
+++ b/Tests/BugsnagPerformanceTests/RetryQueueTests.mm
@@ -1,0 +1,171 @@
+//
+//  RetryQueueTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 19.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "FileBasedTest.h"
+#import "RetryQueue.h"
+
+using namespace bugsnag;
+
+@interface RetryQueueTests : FileBasedTest
+
+@end
+
+@implementation RetryQueueTests
+
+static inline dispatch_time_t currentTimeMinusNanoseconds(dispatch_time_t nanoseconds) {
+    return (dispatch_time_t)((CFAbsoluteTimeGetCurrent() + kCFAbsoluteTimeIntervalSince1970) * NSEC_PER_SEC) - nanoseconds;
+}
+
+- (void)testAddListGetRemove {
+    RetryQueue queue(self.filePath);
+    __block int errorCallCount = 0;
+    queue.setOnFilesystemError(^{
+        errorCallCount++;
+    });
+
+    OtlpPackage package1(1000, [NSData dataWithBytes:"aaa" length:3], @{@"x": @"y"});
+    OtlpPackage package2(1100, [NSData dataWithBytes:"bbb" length:3], @{@"a": @"b"});
+    OtlpPackage package3(1110, [NSData dataWithBytes:"ccc" length:3], @{@"1": @"2"});
+    queue.add(package1);
+    queue.add(package3);
+    queue.add(package2);
+    // Adding the same timestamp package just overwrites the old one.
+    queue.add(package2);
+    auto list = queue.list();
+    XCTAssertEqual(3, list.size());
+    // List always lists newest to oldest
+    XCTAssertEqual(1110, list[0]);
+    XCTAssertEqual(1100, list[1]);
+    XCTAssertEqual(1000, list[2]);
+
+    auto get1 = queue.get(1000);
+    auto get2 = queue.get(1100);
+    auto get3 = queue.get(1110);
+    XCTAssertTrue(package1 == *get1);
+    XCTAssertTrue(package2 == *get2);
+    XCTAssertTrue(package3 == *get3);
+
+    queue.remove(1100);
+    list = queue.list();
+    XCTAssertEqual(2, list.size());
+    XCTAssertEqual(1110, list[0]);
+    XCTAssertEqual(1000, list[1]);
+
+    // Removing a nonexistent entry is a no-op and does not trigger an error
+    queue.remove(1100);
+    list = queue.list();
+    XCTAssertEqual(2, list.size());
+    XCTAssertEqual(1110, list[0]);
+    XCTAssertEqual(1000, list[1]);
+    XCTAssertEqual(0, errorCallCount);
+
+    queue.remove(1000);
+    list = queue.list();
+    XCTAssertEqual(1, list.size());
+    XCTAssertEqual(1110, list[0]);
+
+    queue.remove(1110);
+    list = queue.list();
+    XCTAssertEqual(0, list.size());
+
+    XCTAssertEqual(0, errorCallCount);
+}
+
+- (void)testCreation {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    BOOL isDir = false;
+
+    XCTAssertFalse([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+
+    RetryQueue queue(self.filePath);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+}
+
+- (void)testSweep {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    BOOL isDir = false;
+
+    RetryQueue queue(self.filePath);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+    __block int callCount = 0;
+    queue.setOnFilesystemError(^{
+        callCount++;
+    });
+
+    XCTAssertTrue([[NSData new] writeToFile:[self.filePath stringByAppendingPathComponent:@"xyz.json"] atomically:YES]);
+    XCTAssertEqual(1, [fm contentsOfDirectoryAtPath:self.filePath error:nil].count);
+    OtlpPackage package(1, [NSData new], @{});
+    queue.add(package);
+    XCTAssertEqual(2, [fm contentsOfDirectoryAtPath:self.filePath error:nil].count);
+    OtlpPackage package2(currentTimeMinusNanoseconds(1000), [NSData new], @{});
+    queue.add(package2);
+    XCTAssertEqual(3, [fm contentsOfDirectoryAtPath:self.filePath error:nil].count);
+    OtlpPackage package3(currentTimeMinusNanoseconds(24*60*60*NSEC_PER_SEC)+10000000, [NSData new], @{});
+    queue.add(package3);
+    XCTAssertEqual(4, [fm contentsOfDirectoryAtPath:self.filePath error:nil].count);
+    OtlpPackage package4(currentTimeMinusNanoseconds(24*60*60*NSEC_PER_SEC)-1, [NSData new], @{});
+    queue.add(package4);
+    XCTAssertEqual(5, [fm contentsOfDirectoryAtPath:self.filePath error:nil].count);
+
+    queue.sweep();
+    XCTAssertEqual(0, callCount);
+    XCTAssertEqual(2, [fm contentsOfDirectoryAtPath:self.filePath error:nil].count);
+}
+
+- (void)testCreationTopLevelDirAlreadyExists {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    BOOL isDir = false;
+
+    XCTAssertTrue([fm createDirectoryAtPath:self.filePath withIntermediateDirectories:YES attributes:nil error:nil]);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+
+    RetryQueue queue(self.filePath);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir);
+}
+
+- (void)testFilesystemErrorCallback {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    BOOL isDir = false;
+
+    // Put a file in place of where RetryQueue will try to create a directory.
+    XCTAssertTrue([[NSData new] writeToFile:self.filePath atomically:YES]);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertFalse(isDir);
+
+    RetryQueue queue(self.filePath);
+    XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+    XCTAssertFalse(isDir);
+
+    __block int callCount = 0;
+    queue.setOnFilesystemError(^{
+        callCount++;
+    });
+
+    callCount = 0;
+    queue.sweep();
+    XCTAssertNotEqual(0, callCount);
+
+    callCount = 0;
+    queue.list();
+    XCTAssertNotEqual(0, callCount);
+
+    callCount = 0;
+    OtlpPackage package(1, [NSData new], @{});
+    queue.add(package);
+    XCTAssertNotEqual(0, callCount);
+
+    callCount = 0;
+    queue.remove(1);
+    XCTAssertEqual(0, callCount);
+}
+
+@end


### PR DESCRIPTION
## Goal

Replace the in-memory retry queue with a disk based one.

## Design

* The linked list version of RetryQueue has been replaced with a disk-persisted implementation.
* The marshalling code was added to `OtlpPackage`.
* Uploading now happens serially rather than in parallel.

## Testing

This is a straight refactoring, so existing tests must pass.

Added unit tests for packaging and the retry queue.
