### PR TITLE
[PLAT-9424] GZip encode HTTP payloads

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -88,6 +88,9 @@
 		CBEC51DD2976F1F9009C0CE3 /* RetryQueue.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51DB2976F1F9009C0CE3 /* RetryQueue.mm */; };
 		CBEC51DF29782471009C0CE3 /* OtlpPackageTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51DE29782471009C0CE3 /* OtlpPackageTests.mm */; };
 		CBEC51E129793B1E009C0CE3 /* RetryQueueTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */; };
+		CBF7C5E1297A8E9100D47719 /* Gzip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF7C5DF297A8E9100D47719 /* Gzip.h */; };
+		CBF7C5E2297A8E9100D47719 /* Gzip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF7C5E0297A8E9100D47719 /* Gzip.m */; };
+		CBF7C5E4297A964900D47719 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CBF7C5E3297A963A00D47719 /* libz.tbd */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -193,6 +196,9 @@
 		CBEC51DE29782471009C0CE3 /* OtlpPackageTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OtlpPackageTests.mm; sourceTree = "<group>"; };
 		CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RetryQueueTests.mm; sourceTree = "<group>"; };
 		CBF621052919418F004BEE0B /* Uploader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Uploader.h; sourceTree = "<group>"; };
+		CBF7C5DF297A8E9100D47719 /* Gzip.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Gzip.h; sourceTree = "<group>"; };
+		CBF7C5E0297A8E9100D47719 /* Gzip.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Gzip.m; sourceTree = "<group>"; };
+		CBF7C5E3297A963A00D47719 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -209,6 +215,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				01A414D42913CAE7003152A4 /* SystemConfiguration.framework in Frameworks */,
+				CBF7C5E4297A964900D47719 /* libz.tbd in Frameworks */,
 				0122C25829019904002D243C /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -321,6 +328,8 @@
 				015836C3291264E0002F54C8 /* Version.h */,
 				CBE8EA18294B5AB800702950 /* Worker.h */,
 				CBE8EA19294B5AB800702950 /* Worker.mm */,
+				CBF7C5DF297A8E9100D47719 /* Gzip.h */,
+				CBF7C5E0297A8E9100D47719 /* Gzip.m */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -342,6 +351,7 @@
 		0122C25629019904002D243C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				CBF7C5E3297A963A00D47719 /* libz.tbd */,
 				01A414D32913CAE7003152A4 /* SystemConfiguration.framework */,
 				0122C25729019904002D243C /* UIKit.framework */,
 			);
@@ -436,6 +446,7 @@
 				01A58C0E29092D25006E4DF7 /* Sampler.h in Headers */,
 				0122C23929019770002D243C /* BugsnagPerformanceViewType.h in Headers */,
 				0122C23A29019770002D243C /* BugsnagPerformanceConfiguration.h in Headers */,
+				CBF7C5E1297A8E9100D47719 /* Gzip.h in Headers */,
 				0122C25329019770002D243C /* Span.h in Headers */,
 				CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */,
 				CBE8EA09294A20ED00702950 /* BSGInternalConfig.h in Headers */,
@@ -631,6 +642,7 @@
 				01A58C0F29092D25006E4DF7 /* Sampler.mm in Sources */,
 				CBEC51C1296DB312009C0CE3 /* JSON.mm in Sources */,
 				0122C24029019770002D243C /* SpanData.mm in Sources */,
+				CBF7C5E2297A8E9100D47719 /* Gzip.m in Sources */,
 				0122C24829019770002D243C /* NetworkInstrumentation.mm in Sources */,
 				0122C24D29019770002D243C /* ViewLoadInstrumentation.mm in Sources */,
 				015836C229125E7A002F54C8 /* ResourceAttributes.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -78,7 +78,7 @@ private:
     NSArray<Task> *buildRecurringTasks();
     bool sendCurrentBatchTask();
     bool sendRetriesTask();
-    bool sendInitialPValueRequestTask();
+    bool sendPValueRequestTask();
     bool maybePersistStateTask();
 
     // Event reactions
@@ -91,6 +91,5 @@ private:
     // Utility
     void wakeWorker() noexcept;
     void uploadPackage(std::unique_ptr<OtlpPackage> package, bool isRetry) noexcept;
-    std::unique_ptr<OtlpPackage> buildPackage(const std::vector<std::unique_ptr<SpanData>> &spans) const noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Gzip.h
+++ b/Sources/BugsnagPerformance/Private/Gzip.h
@@ -1,0 +1,19 @@
+//
+//  Gzip.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 20.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Gzip : NSObject
+
++ (NSData *_Nullable)gzipped:(NSData *)data error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/Gzip.m
+++ b/Sources/BugsnagPerformance/Private/Gzip.m
@@ -1,0 +1,91 @@
+//
+//  Gzip.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 20.01.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "Gzip.h"
+#import <zlib.h>
+
+@implementation Gzip
+
+static const int kChunkSize = 1024;
+static const int kMemoryLevel = 8;
+static const int kWindowBits = 15;
+static const int kWindowBitsWithGZipHeader = 16 + kWindowBits;
+
+#define ERROR_DOMAIN @"com.bugsnag.performance.gzip"
+
++ (NSData *_Nullable)gzipped:(NSData *)data error:(NSError * __autoreleasing*)error {
+    if (data.length == 0) {
+        return data;
+    }
+
+    // Adapted from https://github.com/mattt/Godzippa/blob/master/Sources/NSData%2BGodzippa.m
+
+// (z_const Bytef *) isn't actually const, which causes a loss-of-const warning.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
+    z_stream zStream = {
+        .zalloc = Z_NULL,
+        .zfree = Z_NULL,
+        .opaque = Z_NULL,
+        .next_in = (z_const Bytef *)data.bytes,
+        .avail_in = (unsigned int)data.length,
+        .total_out = 0,
+    };
+#pragma clang diagnostic pop
+
+    OSStatus status = deflateInit2(&zStream,
+                                   Z_DEFAULT_COMPRESSION,
+                                   Z_DEFLATED,
+                                   kWindowBitsWithGZipHeader,
+                                   kMemoryLevel,
+                                   Z_DEFAULT_STRATEGY);
+    if (status != Z_OK) {
+        if (error != nil) {
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:NSLocalizedString(@"deflateInit2 failed", nil)
+                                                                 forKey:NSLocalizedDescriptionKey];
+            *error = [[NSError alloc] initWithDomain:ERROR_DOMAIN code:status userInfo:userInfo];
+        }
+        return nil;
+    }
+
+    NSMutableData *deflated = [NSMutableData dataWithLength:kChunkSize];
+
+    do {
+        if ((status == Z_BUF_ERROR) || (zStream.total_out == [deflated length])) {
+            [deflated increaseLengthBy:kChunkSize];
+        }
+
+        zStream.next_out = (Bytef*)[deflated mutableBytes] + zStream.total_out;
+        zStream.avail_out = (unsigned int)([deflated length] - zStream.total_out);
+        status = deflate(&zStream, Z_FINISH);
+    } while ((status == Z_OK) || (status == Z_BUF_ERROR));
+
+    if ((status != Z_OK) && (status != Z_STREAM_END)) {
+        if (error != nil) {
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:NSLocalizedString(@"deflate failed", nil)
+                                                                 forKey:NSLocalizedDescriptionKey];
+            *error = [[NSError alloc] initWithDomain:ERROR_DOMAIN code:status userInfo:userInfo];
+        }
+        return nil;
+    }
+
+    status = deflateEnd(&zStream);
+    if (status != Z_OK) {
+        if (error != nil) {
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:NSLocalizedString(@"deflateEnd failed", nil)
+                                                                 forKey:NSLocalizedDescriptionKey];
+            *error = [[NSError alloc] initWithDomain:ERROR_DOMAIN code:status userInfo:userInfo];
+        }
+        return nil;
+    }
+
+    [deflated setLength:zStream.total_out];
+    return deflated;
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/OtlpPackage.h
+++ b/Sources/BugsnagPerformance/Private/OtlpPackage.h
@@ -20,7 +20,11 @@ namespace bugsnag {
  */
 class OtlpPackage {
 public:
-    OtlpPackage(const dispatch_time_t ts, const NSData *payload, const NSDictionary *headers) noexcept;
+    OtlpPackage(const dispatch_time_t ts, const NSData *payload, const NSDictionary *headers) noexcept
+    : timestamp(ts)
+    , payload_(payload)
+    , headers_(headers)
+    {}
 
     /**
      * Fill a request with everything necessary to send to the server.
@@ -38,6 +42,10 @@ private:
 
     const NSData *payload_;
     const NSDictionary *headers_;
+
+public: // For testing only
+    const NSData *getPayloadForUnitTest() {return payload_;}
+    const NSDictionary *getHeadersForUnitTest() {return headers_;}
 };
 
 inline bool operator==(const OtlpPackage &lhs, const OtlpPackage &rhs) {

--- a/Sources/BugsnagPerformance/Private/OtlpPackage.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpPackage.mm
@@ -12,33 +12,6 @@
 
 using namespace bugsnag;
 
-static NSDictionary * headersWithIntegrityDigest(const NSData *payload, const NSDictionary *headers) {
-    if (!payload) {
-        return nil;
-    }
-
-    unsigned char md[CC_SHA1_DIGEST_LENGTH];
-    CC_SHA1(payload.bytes, (CC_LONG)payload.length, md);
-    auto digest = [NSString stringWithFormat:@"sha1 %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
-                   md[0], md[1], md[2], md[3], md[4],
-                   md[5], md[6], md[7], md[8], md[9],
-                   md[10], md[11], md[12], md[13], md[14],
-                   md[15], md[16], md[17], md[18], md[19]];
-
-    NSMutableDictionary *mutableHeaders = headers.mutableCopy;
-    mutableHeaders[@"Bugsnag-Integrity"] = digest;
-
-    return mutableHeaders;
-}
-
-OtlpPackage::OtlpPackage(const dispatch_time_t ts,
-                         const NSData *payload,
-                         const NSDictionary *headers) noexcept
-: timestamp(ts)
-, payload_(payload)
-, headers_(headersWithIntegrityDigest(payload, headers))
-{}
-
 static int getPayloadOffset(const NSData *data) {
     auto endOfHeaders = [@"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding];
     auto range = [data rangeOfData:endOfHeaders options:0 range:NSMakeRange(0, data.length)];
@@ -67,7 +40,7 @@ static NSDictionary *deserializeHeaders(const NSData *data) {
     auto headers = [NSMutableDictionary new];
 
     NSError *error;
-    NSString *pattern = @"(\\S+)\\s*:\\s*(\\S+)";
+    NSString *pattern = @"(\\S+)\\s*:\\s*(\\S.*)";
     NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
 
     NSArray<NSTextCheckingResult *> *matches = [regex matchesInString:headerStr options:0 range:NSMakeRange(0, headerStr.length)];

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.h
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.h
@@ -23,6 +23,8 @@ public:
      */
     static std::unique_ptr<OtlpPackage> buildUploadPackage(const std::vector<std::unique_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept;
 
+    static std::unique_ptr<OtlpPackage> buildPValueRequestPackage() noexcept;
+
 public: // Public for testing only
     static NSDictionary * encode(const SpanData &span) noexcept;
     

--- a/Tests/BugsnagPerformanceTests/OtlpPackageTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpPackageTests.mm
@@ -29,7 +29,7 @@ using namespace bugsnag;
     XCTAssertTrue(package == package);
 
     NSData *serialized = package.serialize();
-    XCTAssertEqualObjects(@"a: b\r\nc: d\r\nBugsnag-Integrity: sha1 5bf1fd927dfb8679496a2e6cf00cbe50c1c87145\r\n\r\nblah",
+    XCTAssertEqualObjects(@"a: b\r\nc: d\r\n\r\nblah",
                           [[NSString alloc] initWithData:serialized encoding:NSUTF8StringEncoding]);
 
     auto deserialized = deserializeOtlpPackage(ts, serialized);


### PR DESCRIPTION
## Goal

PLAT-9424: Gzip encode backend payloads

## Design

Foundation doesn't include gzip encoding, so we must roll our own using zlib.

All encoding operations have been moved into `OtlpTraceEncoding`, including Bugsnag-Integrity calculation. This ensures that the digest is never created post-compression.

## Testing

Added some more unit tests to verify new encoding methods. Gzip encoding is validated in the e2e tests.
