### PR TITLE
Point config in unit tests to localhost so they don't go to the live server

### DIFF
--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceTests.mm
@@ -18,6 +18,7 @@
 - (void)setUp {
     NSError *error = nil;
     auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef" error:&error];
+    config.endpoint = [NSURL URLWithString:@"http://localhost"];
     XCTAssertNil(error);
     XCTAssertTrue([BugsnagPerformance startWithConfiguration:config error:&error]);
     XCTAssertNil(error);


### PR DESCRIPTION
## Goal

One of the unit tests initializes the entire library, which triggers a send to the backend server. Point it to localhost so that it doesn't ping the live server.

## Testing

Reran unit tests.