### PR TITLE
[PLAT-9526] Add missing UIViewController span methods

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		CB34771F29068C350033759C /* BSGURLSessionPerformanceProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */; };
 		CB34772029068C350033759C /* BSGURLSessionPerformanceProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */; };
 		CB34772129068C350033759C /* NSURLSession+Instrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */; };
+		CB7FD929299BA5AD00499E13 /* ViewControllerSpanTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD928299BA5AD00499E13 /* ViewControllerSpanTests.mm */; };
 		CBB48A3C295EE1E10044E9AC /* ObjCUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */; };
 		CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */; };
 		CBE8EA09294A20ED00702950 /* BSGInternalConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */; };
@@ -168,6 +169,7 @@
 		CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGURLSessionPerformanceProxy.m; sourceTree = "<group>"; };
 		CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGURLSessionPerformanceProxy.h; sourceTree = "<group>"; };
 		CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSession+Instrumentation.h"; sourceTree = "<group>"; };
+		CB7FD928299BA5AD00499E13 /* ViewControllerSpanTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ViewControllerSpanTests.mm; sourceTree = "<group>"; };
 		CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCUtils.h; sourceTree = "<group>"; };
 		CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCUtils.mm; sourceTree = "<group>"; };
 		CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGInternalConfig.h; sourceTree = "<group>"; };
@@ -385,6 +387,7 @@
 				CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */,
 				01A58C10290931A5006E4DF7 /* SamplerTests.mm */,
 				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
+				CB7FD928299BA5AD00499E13 /* ViewControllerSpanTests.mm */,
 			);
 			path = BugsnagPerformanceTests;
 			sourceTree = "<group>";
@@ -607,6 +610,7 @@
 				CBEC51C5296ED8BA009C0CE3 /* PersistentStateTests.mm in Sources */,
 				0122C26F29019CEF002D243C /* BugsnagPerformanceTests.mm in Sources */,
 				CBEC51CC296EDA2D009C0CE3 /* FileBasedTest.m in Sources */,
+				CB7FD929299BA5AD00499E13 /* ViewControllerSpanTests.mm in Sources */,
 				CBEC51DF29782471009C0CE3 /* OtlpPackageTests.mm in Sources */,
 				CB0AD75B295F27DD002A3FB6 /* WorkerTests.mm in Sources */,
 				CBEC51C3296EC0AC009C0CE3 /* JSONTests.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -54,14 +54,17 @@ public:
                 tracer_.startViewLoadedSpan(viewType, name, startTime.timeIntervalSinceReferenceDate)];
     }
 
+    void startViewLoadSpan(UIViewController *controller, NSDate *startTime);
+
+    void endViewLoadSpan(UIViewController *controller, NSDate *endTime);
+
     void reportNetworkRequestSpan(NSURLSessionTask * task, NSURLSessionTaskMetrics *metrics) {
         tracer_.reportNetworkSpan(task, metrics);
     }
 
-
 private:
     bool started_;
-    std::mutex mutex_;
+    std::mutex instanceMutex_;
     std::shared_ptr<Batch> batch_;
     std::shared_ptr<class Sampler> sampler_;
     Tracer tracer_;
@@ -72,6 +75,8 @@ private:
     std::unique_ptr<RetryQueue> retryQueue_;
     NSDictionary *resourceAttributes_;
     bool shouldPersistState_;
+    std::mutex viewControllersToSpansMutex_;
+    NSMapTable<UIViewController *, BugsnagPerformanceSpan *> *viewControllersToSpans_;
 
     // Tasks
     NSArray<Task> *buildInitialTasks();
@@ -91,5 +96,8 @@ private:
     // Utility
     void wakeWorker() noexcept;
     void uploadPackage(std::unique_ptr<OtlpPackage> package, bool isRetry) noexcept;
+
+public: // For testing
+    NSUInteger testing_getViewControllersToSpansCount() { return viewControllersToSpans_.count; };
 };
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -51,6 +51,16 @@ static BugsnagPerformanceImpl& getImpl() {
     return getImpl().startViewLoadSpan(name, viewType, startTime);
 }
 
++ (void)startViewLoadSpanWithController:(UIViewController *)controller
+                              startTime:(NSDate *)startTime {
+    getImpl().startViewLoadSpan(controller, startTime);
+}
+
++ (void)endViewLoadSpanWithController:(UIViewController *)controller
+                              endTime:(NSDate *)endTime {
+    getImpl().endViewLoadSpan(controller, endTime);
+}
+
 + (void)reportNetworkRequestSpanWithTask:(NSURLSessionTask *)task
                                  metrics:(NSURLSessionTaskMetrics *)metrics {
     getImpl().reportNetworkSpan(task, metrics);

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -38,6 +38,14 @@ OBJC_EXPORT
                                             startTime:(NSDate *)startTime
   NS_SWIFT_NAME(startViewLoadSpan(name:viewType:startTime:));
 
++ (void)startViewLoadSpanWithController:(UIViewController *)controller
+                              startTime:(NSDate *)startTime
+  NS_SWIFT_NAME(startViewLoadSpan(controller:startTime:));
+
++ (void)endViewLoadSpanWithController:(UIViewController *)controller
+                              endTime:(NSDate *)endTime
+  NS_SWIFT_NAME(endViewLoadSpan(controller:endTime:));
+
 @end
 
 @interface BugsnagPerformance (/* Manual network spans */)

--- a/Tests/BugsnagPerformanceTests/ViewControllerSpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/ViewControllerSpanTests.mm
@@ -1,0 +1,57 @@
+//
+//  ViewControllerSpanTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 14.02.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BugsnagPerformanceImpl.h"
+
+using namespace bugsnag;
+
+@interface ViewControllerSpanTests : XCTestCase
+
+@end
+
+@implementation ViewControllerSpanTests
+
+- (void)testNormalUsage {
+    BugsnagPerformanceImpl perf;
+    @autoreleasepool {
+        UIViewController *controller = [UIViewController new];
+        perf.startViewLoadSpan(controller, [NSDate date]);
+        XCTAssertEqual(1, perf.testing_getViewControllersToSpansCount());
+        perf.endViewLoadSpan(controller, [NSDate date]);
+        XCTAssertEqual(0, perf.testing_getViewControllersToSpansCount());
+    }
+}
+
+- (void)testForgotToEnd {
+    BugsnagPerformanceImpl perf;
+
+    @autoreleasepool {
+        UIViewController *controller = [UIViewController new];
+        perf.startViewLoadSpan(controller, [NSDate date]);
+        XCTAssertEqual(1, perf.testing_getViewControllersToSpansCount());
+    }
+
+    /* NSMapTable doesn't actually remove values the moment a weak key is deallocated;
+     * it does a sweep during certain operations, such as when the map has to resize.
+     * http://cocoamine.net/blog/2013/12/13/nsmaptable-and-zeroing-weak-references/
+     */
+    XCTAssertEqual(1, perf.testing_getViewControllersToSpansCount());
+
+    // To test removal, we make a bunch more entries to force the map to resize.
+    @autoreleasepool {
+        for (int i = 0; i < 100; i++) {
+            UIViewController *controller = [UIViewController new];
+            perf.startViewLoadSpan(controller, [NSDate date]);
+        }
+
+        XCTAssertLessThan(perf.testing_getViewControllersToSpansCount(), 100);
+    }
+}
+
+@end

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
 		CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */; };
+		CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */; };
 		CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
@@ -52,6 +53,7 @@
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
 		CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkScenario.swift; sourceTree = "<group>"; };
+		CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualUIViewLoadScenario.swift; sourceTree = "<group>"; };
 		CBAAE25429125F5F006D4AA0 /* Fixture-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fixture-Bridging-Header.h"; sourceTree = "<group>"; };
 		CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 				CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
+				CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */,
 				01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */,
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
@@ -232,6 +235,7 @@
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
 				01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */,
 				CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */,
+				CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */,
 				CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */,
 				CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */,
 				01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/ManualUIViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualUIViewLoadScenario.swift
@@ -1,0 +1,18 @@
+//
+//  ManualUIViewLoadScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 14.02.23.
+//
+
+import BugsnagPerformance
+
+class ManualUIViewLoadScenario: Scenario {
+
+    override func run() {
+        var controller = UIViewController()
+        BugsnagPerformance.startViewLoadSpan(controller: controller, startTime: Date())
+        BugsnagPerformance.endViewLoadSpan(controller: controller, endTime: Date())
+        waitForCurrentBatch()
+    }
+}

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -65,6 +65,17 @@ Feature: Manual creation of spans
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span_category" equals "view_load"
 
+  Scenario: Manually report a UIViewController load span
+    Given I run "ManualUIViewLoadScenario" and discard the initial p-value request
+    And I wait for 1 span
+    * every span field "name" equals "ViewLoaded/UIKit/UIViewController"
+    * every span string attribute "bugsnag.view.name" equals "UIViewController"
+    * every span string attribute "bugsnag.view.type" equals "UIKit"
+    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span string attribute "bugsnag.span_category" equals "view_load"
+
   Scenario: Manually start a network span
     Given I run "ManualNetworkSpanScenario" and discard the initial p-value request
     And I wait for 1 span


### PR DESCRIPTION
## Goal

PLAT-9526: Add missing UIViewController span APIs to BugsnagPerformance.

## Design

For this functionality, spans are keyed off the address of the view controller (to look up the appropriate span when calling `endViewLoadSpan`).

`NSMapTable` offers eventually-consistent weak key functionality (it will remove dead keys, but only after certain internal operations for performance reasons).

The view controller mapping is guarded behind a mutex.

## Testing

Added new unit tests and e2e tests.
