### PR TITLE
[PLAT-9565] Rename ViewLoaded to ViewLoad

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -46,12 +46,12 @@ public:
 
     BugsnagPerformanceSpan *startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType) {
         return [[BugsnagPerformanceSpan alloc] initWithSpan:
-                tracer_.startViewLoadedSpan(viewType, name, CFAbsoluteTimeGetCurrent())];
+                tracer_.startViewLoadSpan(viewType, name, CFAbsoluteTimeGetCurrent())];
     }
 
     BugsnagPerformanceSpan *startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType, NSDate *startTime) {
         return [[BugsnagPerformanceSpan alloc] initWithSpan:
-                tracer_.startViewLoadedSpan(viewType, name, startTime.timeIntervalSinceReferenceDate)];
+                tracer_.startViewLoadSpan(viewType, name, startTime.timeIntervalSinceReferenceDate)];
     }
 
     void startViewLoadSpan(UIViewController *controller, NSDate *startTime);

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -254,7 +254,7 @@ void BugsnagPerformanceImpl::uploadPackage(std::unique_ptr<OtlpPackage> package,
 
 void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, NSDate *startTime) {
     auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
-            tracer_.startViewLoadedSpan(BugsnagPerformanceViewTypeUIKit,
+            tracer_.startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
                                         [NSString stringWithUTF8String:object_getClassName(controller)],
                                         startTime.timeIntervalSinceReferenceDate)];
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -61,7 +61,7 @@ ViewLoadInstrumentation::onLoadView(UIViewController *viewController) noexcept {
     }
     
     auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
-                 tracer_.startViewLoadedSpan(BugsnagPerformanceViewTypeUIKit,
+                 tracer_.startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
                                              NSStringFromClass([viewController class]),
                                              CFAbsoluteTimeGetCurrent())];
     

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -32,7 +32,7 @@ public:
     
     std::unique_ptr<class Span> startSpan(NSString *name, CFAbsoluteTime startTime) noexcept;
     
-    std::unique_ptr<class Span> startViewLoadedSpan(BugsnagPerformanceViewType viewType,
+    std::unique_ptr<class Span> startViewLoadSpan(BugsnagPerformanceViewType viewType,
                                                     NSString *className,
                                                     CFAbsoluteTime startTime) noexcept;
     

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -54,7 +54,7 @@ void Tracer::tryAddSpanToBatch(std::unique_ptr<SpanData> spanData) {
 }
 
 std::unique_ptr<class Span>
-Tracer::startViewLoadedSpan(BugsnagPerformanceViewType viewType,
+Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
                             NSString *className,
                             CFAbsoluteTime startTime) noexcept {
     NSString *type;
@@ -63,7 +63,7 @@ Tracer::startViewLoadedSpan(BugsnagPerformanceViewType viewType,
         case BugsnagPerformanceViewTypeUIKit:   type = @"UIKit"; break;
         default:                                type = @"?"; break;
     }
-    NSString *name = [NSString stringWithFormat:@"ViewLoaded/%@/%@", type, className];
+    NSString *name = [NSString stringWithFormat:@"ViewLoad/%@/%@", type, className];
     auto span = startSpan(name, startTime);
     span->addAttributes(@{
         @"bugsnag.span.category": @"view_load",

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -20,7 +20,7 @@ Feature: Automatic instrumentation spans
     Given I run "AutoInstrumentViewLoadScenario" and discard the initial p-value request
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * every span field "name" equals "ViewLoaded/UIKit/Fixture.AutoInstrumentViewLoadScenario_ViewController"
+    * every span field "name" equals "ViewLoad/UIKit/Fixture.AutoInstrumentViewLoadScenario_ViewController"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals "SPAN_KIND_INTERNAL"

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -54,10 +54,10 @@ Feature: Manual creation of spans
   Scenario: Manually report a view load span
     Given I run "ManualViewLoadScenario" and discard the initial p-value request
     And I wait for 2 spans
-    * a span field "name" equals "ViewLoaded/UIKit/ManualViewController"
+    * a span field "name" equals "ViewLoad/UIKit/ManualViewController"
     * a span string attribute "bugsnag.view.name" equals "ManualViewController"
     * a span string attribute "bugsnag.view.type" equals "UIKit"
-    * a span field "name" equals "ViewLoaded/SwiftUI/ManualView"
+    * a span field "name" equals "ViewLoad/SwiftUI/ManualView"
     * a span string attribute "bugsnag.view.name" equals "ManualView"
     * a span string attribute "bugsnag.view.type" equals "SwiftUI"
     * every span field "kind" equals "SPAN_KIND_INTERNAL"
@@ -68,13 +68,13 @@ Feature: Manual creation of spans
   Scenario: Manually report a UIViewController load span
     Given I run "ManualUIViewLoadScenario" and discard the initial p-value request
     And I wait for 1 span
-    * every span field "name" equals "ViewLoaded/UIKit/UIViewController"
+    * every span field "name" equals "ViewLoad/UIKit/UIViewController"
     * every span string attribute "bugsnag.view.name" equals "UIViewController"
     * every span string attribute "bugsnag.view.type" equals "UIKit"
     * every span field "kind" equals "SPAN_KIND_INTERNAL"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span string attribute "bugsnag.span_category" equals "view_load"
+    * every span string attribute "bugsnag.span.category" equals "view_load"
 
   Scenario: Manually start a network span
     Given I run "ManualNetworkSpanScenario" and discard the initial p-value request


### PR DESCRIPTION
Note: Please review this after https://github.com/bugsnag/bugsnag-cocoa-performance/pull/44 is merged.

## Goal

Change `ViewLoaded/` prefix to `ViewLoad/` to match the updated spec.
