### PR TITLE
[PLAT-9650] Add BugsnagPerformanceSpanOptions

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -62,7 +62,12 @@
 		CB34771F29068C350033759C /* BSGURLSessionPerformanceProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */; };
 		CB34772029068C350033759C /* BSGURLSessionPerformanceProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */; };
 		CB34772129068C350033759C /* NSURLSession+Instrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */; };
+		CB747D1F299E4984003CA1B4 /* SpanOptionsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */; };
+		CB747D21299E5458003CA1B4 /* TimeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB747D20299E5458003CA1B4 /* TimeTests.mm */; };
 		CB7FD929299BA5AD00499E13 /* ViewControllerSpanTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD928299BA5AD00499E13 /* ViewControllerSpanTests.mm */; };
+		CB7FD930299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7FD92F299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB7FD932299D2F7700499E13 /* BugsnagPerformanceSpanOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD931299D2F7700499E13 /* BugsnagPerformanceSpanOptions.m */; };
+		CB7FD934299D31D300499E13 /* BugsnagPerformanceSpanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7FD933299D309B00499E13 /* BugsnagPerformanceSpanContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBB48A3C295EE1E10044E9AC /* ObjCUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */; };
 		CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */; };
 		CBE8EA09294A20ED00702950 /* BSGInternalConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */; };
@@ -169,7 +174,13 @@
 		CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGURLSessionPerformanceProxy.m; sourceTree = "<group>"; };
 		CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGURLSessionPerformanceProxy.h; sourceTree = "<group>"; };
 		CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSession+Instrumentation.h"; sourceTree = "<group>"; };
+		CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SpanOptionsTests.mm; sourceTree = "<group>"; };
+		CB747D20299E5458003CA1B4 /* TimeTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TimeTests.mm; sourceTree = "<group>"; };
 		CB7FD928299BA5AD00499E13 /* ViewControllerSpanTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ViewControllerSpanTests.mm; sourceTree = "<group>"; };
+		CB7FD92F299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanOptions.h; sourceTree = "<group>"; };
+		CB7FD931299D2F7700499E13 /* BugsnagPerformanceSpanOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagPerformanceSpanOptions.m; sourceTree = "<group>"; };
+		CB7FD933299D309B00499E13 /* BugsnagPerformanceSpanContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanContext.h; sourceTree = "<group>"; };
+		CB7FD935299D330500499E13 /* SpanOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpanOptions.h; sourceTree = "<group>"; };
 		CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCUtils.h; sourceTree = "<group>"; };
 		CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCUtils.mm; sourceTree = "<group>"; };
 		CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGInternalConfig.h; sourceTree = "<group>"; };
@@ -266,6 +277,8 @@
 				0122C21929019770002D243C /* BugsnagPerformanceConfiguration.h */,
 				CB0AD76929657381002A3FB6 /* BugsnagPerformanceErrors.h */,
 				0122C21729019770002D243C /* BugsnagPerformanceSpan.h */,
+				CB7FD933299D309B00499E13 /* BugsnagPerformanceSpanContext.h */,
+				CB7FD92F299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h */,
 				0122C21829019770002D243C /* BugsnagPerformanceViewType.h */,
 			);
 			path = BugsnagPerformance;
@@ -278,6 +291,7 @@
 				0122C21C29019770002D243C /* BugsnagPerformanceConfiguration.mm */,
 				CB0AD7672965734F002A3FB6 /* BugsnagPerformanceErrors.m */,
 				0122C21E29019770002D243C /* BugsnagPerformanceSpan.mm */,
+				CB7FD931299D2F7700499E13 /* BugsnagPerformanceSpanOptions.m */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -293,6 +307,8 @@
 				0122C23229019770002D243C /* BugsnagPerformanceSpan+Private.h */,
 				CBEC51D42976BCAD009C0CE3 /* Filesystem.h */,
 				CBEC51D52976BCAD009C0CE3 /* Filesystem.m */,
+				CBF7C5DF297A8E9100D47719 /* Gzip.h */,
+				CBF7C5E0297A8E9100D47719 /* Gzip.m */,
 				0122C22229019770002D243C /* IdGenerator.h */,
 				0122C22929019770002D243C /* Instrumentation */,
 				CBEC51BE296DB311009C0CE3 /* JSON.h */,
@@ -323,6 +339,7 @@
 				0122C22829019770002D243C /* SpanData.h */,
 				0122C22129019770002D243C /* SpanData.mm */,
 				0122C22329019770002D243C /* SpanKind.h */,
+				CB7FD935299D330500499E13 /* SpanOptions.h */,
 				0122C23329019770002D243C /* Tracer.h */,
 				0122C22529019770002D243C /* Tracer.mm */,
 				CBF621052919418F004BEE0B /* Uploader.h */,
@@ -330,8 +347,6 @@
 				015836C3291264E0002F54C8 /* Version.h */,
 				CBE8EA18294B5AB800702950 /* Worker.h */,
 				CBE8EA19294B5AB800702950 /* Worker.mm */,
-				CBF7C5DF297A8E9100D47719 /* Gzip.h */,
-				CBF7C5E0297A8E9100D47719 /* Gzip.m */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -388,6 +403,8 @@
 				01A58C10290931A5006E4DF7 /* SamplerTests.mm */,
 				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
 				CB7FD928299BA5AD00499E13 /* ViewControllerSpanTests.mm */,
+				CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */,
+				CB747D20299E5458003CA1B4 /* TimeTests.mm */,
 			);
 			path = BugsnagPerformanceTests;
 			sourceTree = "<group>";
@@ -443,6 +460,7 @@
 				CB34772029068C350033759C /* BSGURLSessionPerformanceProxy.h in Headers */,
 				0122C24C29019770002D243C /* NetworkInstrumentation.h in Headers */,
 				0122C24729019770002D243C /* SpanData.h in Headers */,
+				CB7FD930299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h in Headers */,
 				01A414D12913C238003152A4 /* Reachability.h in Headers */,
 				01EAF980291AAF19007AC627 /* Utils.h in Headers */,
 				015836C4291264E0002F54C8 /* Version.h in Headers */,
@@ -451,6 +469,7 @@
 				0122C23A29019770002D243C /* BugsnagPerformanceConfiguration.h in Headers */,
 				CBF7C5E1297A8E9100D47719 /* Gzip.h in Headers */,
 				0122C25329019770002D243C /* Span.h in Headers */,
+				CB7FD934299D31D300499E13 /* BugsnagPerformanceSpanContext.h in Headers */,
 				CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */,
 				CBE8EA09294A20ED00702950 /* BSGInternalConfig.h in Headers */,
 				CBEC51C0296DB312009C0CE3 /* JSON.h in Headers */,
@@ -618,7 +637,9 @@
 				CBEC51CE296EEF52009C0CE3 /* PersistenceTests.mm in Sources */,
 				CBEC51D92976D54B009C0CE3 /* FilesystemTests.m in Sources */,
 				CB0AD75D29641B59002A3FB6 /* BatchTests.mm in Sources */,
+				CB747D21299E5458003CA1B4 /* TimeTests.mm in Sources */,
 				0122C27129019CEF002D243C /* OtlpTraceEncodingTests.mm in Sources */,
+				CB747D1F299E4984003CA1B4 /* SpanOptionsTests.mm in Sources */,
 				CB0AD76C296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -634,6 +655,7 @@
 				CB04969829150D860097E526 /* OtlpPackage.mm in Sources */,
 				0122C23D29019770002D243C /* BugsnagPerformance.mm in Sources */,
 				CBEC51D72976BCAD009C0CE3 /* Filesystem.m in Sources */,
+				CB7FD932299D2F7700499E13 /* BugsnagPerformanceSpanOptions.m in Sources */,
 				CBEC51BD296D9EEE009C0CE3 /* PersistentState.mm in Sources */,
 				CBEC51B9296D8386009C0CE3 /* Persistence.mm in Sources */,
 				CBE8EA17294B528100702950 /* BugsnagPerformanceImpl.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -34,27 +34,17 @@ public:
         tracer_.reportNetworkSpan(task, metrics);
     }
 
-    BugsnagPerformanceSpan *startSpan(NSString *name) {
-        return [[BugsnagPerformanceSpan alloc] initWithSpan:
-                tracer_.startSpan(name, CFAbsoluteTimeGetCurrent())];
-    }
+    BugsnagPerformanceSpan *startSpan(NSString *name);
 
-    BugsnagPerformanceSpan *startSpan(NSString *name, NSDate *startTime) {
-        return [[BugsnagPerformanceSpan alloc] initWithSpan:
-                tracer_.startSpan(name, startTime.timeIntervalSinceReferenceDate)];
-    }
+    BugsnagPerformanceSpan *startSpan(NSString *name, BugsnagPerformanceSpanOptions *options);
 
-    BugsnagPerformanceSpan *startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType) {
-        return [[BugsnagPerformanceSpan alloc] initWithSpan:
-                tracer_.startViewLoadSpan(viewType, name, CFAbsoluteTimeGetCurrent())];
-    }
+    BugsnagPerformanceSpan *startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType);
 
-    BugsnagPerformanceSpan *startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType, NSDate *startTime) {
-        return [[BugsnagPerformanceSpan alloc] initWithSpan:
-                tracer_.startViewLoadSpan(viewType, name, startTime.timeIntervalSinceReferenceDate)];
-    }
+    BugsnagPerformanceSpan *startViewLoadSpan(NSString *name,
+                                              BugsnagPerformanceViewType viewType,
+                                              BugsnagPerformanceSpanOptions *options);
 
-    void startViewLoadSpan(UIViewController *controller, NSDate *startTime);
+    void startViewLoadSpan(UIViewController *controller, BugsnagPerformanceSpanOptions *options);
 
     void endViewLoadSpan(UIViewController *controller, NSDate *endTime);
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -252,11 +252,31 @@ void BugsnagPerformanceImpl::uploadPackage(std::unique_ptr<OtlpPackage> package,
 
 #pragma mark Spans
 
-void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, NSDate *startTime) {
+BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name) {
+    return [[BugsnagPerformanceSpan alloc] initWithSpan:
+            tracer_.startSpan(name, defaultSpanOptionsForCustom())];
+}
+
+BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name, BugsnagPerformanceSpanOptions *options) {
+    return [[BugsnagPerformanceSpan alloc] initWithSpan:
+            tracer_.startSpan(name, SpanOptions(options))];
+}
+
+BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType) {
+    return [[BugsnagPerformanceSpan alloc] initWithSpan:
+            tracer_.startViewLoadSpan(viewType, name, defaultSpanOptionsForViewLoad())];
+}
+
+BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType, BugsnagPerformanceSpanOptions *options) {
+    return [[BugsnagPerformanceSpan alloc] initWithSpan:
+            tracer_.startViewLoadSpan(viewType, name, SpanOptions(options))];
+}
+
+void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, BugsnagPerformanceSpanOptions *options) {
     auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
             tracer_.startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
                                         [NSString stringWithUTF8String:object_getClassName(controller)],
-                                        startTime.timeIntervalSinceReferenceDate)];
+                                      SpanOptions(options))];
 
     std::lock_guard<std::mutex> guard(viewControllersToSpansMutex_);
     [viewControllersToSpans_ setObject:span forKey:controller];

--- a/Sources/BugsnagPerformance/Private/IdGenerator.h
+++ b/Sources/BugsnagPerformance/Private/IdGenerator.h
@@ -7,37 +7,27 @@
 
 #pragma once
 
-#import <array>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+
 #import <stdlib.h>
 
 namespace bugsnag {
-// https://opentelemetry.io/docs/reference/specification/trace/api/#spancontext
-
-using SpanId = std::array<uint64_t, 1>;
-
-static_assert(sizeof(SpanId) == 8,
-              "A valid span identifier is an 8-byte array with at least one non-zero byte.");
-
-using TraceId = std::array<uint64_t, 2>;
-
-static_assert(sizeof(TraceId) == 16,
-              "A valid trace identifier is a 16-byte array with at least one non-zero byte.");
 
 // https://opentelemetry.io/docs/reference/specification/trace/sdk/#id-generators
 class IdGenerator {
 public:
-    static SpanId generateSpanIdBytes() noexcept {
+    static SpanId generateSpanId() noexcept {
         return random<SpanId>();
     }
     
-    static TraceId generateTraceIdBytes() noexcept {
+    static TraceId generateTraceId() noexcept {
         return random<TraceId>();
     }
     
 private:
     template<typename T> static T random() noexcept {
         T result;
-        arc4random_buf(std::begin(result), sizeof result);
+        arc4random_buf(&result, sizeof result);
         return result;
     }
 };

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -99,7 +99,7 @@ AppStartupInstrumentation::reportSpan(CFAbsoluteTime endTime) noexcept {
         return;
     }
     auto name = isCold_ ? @"AppStart/Cold" : @"AppStart/Warm"; 
-    auto span = tracer_.startSpan(name, startTime);
+    auto span = tracer_.startSpan(name, defaultSpanOptionsForInternal());
     span->addAttributes(@{
         @"bugsnag.app_start.type": isCold_ ? @"cold" : @"warm",
         @"bugsnag.span.category": @"app_start",
@@ -119,7 +119,7 @@ AppStartupInstrumentation::getProcessStartTime() noexcept {
     
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
     auto timeval = info.kp_proc.p_un.__p_starttime;
-    return (CFTimeInterval(timeval.tv_sec) + CFTimeInterval(timeval.tv_usec) / USEC_PER_SEC) - kCFAbsoluteTimeIntervalSince1970;
+    return timevalToAbsoluteTime(timeval);
 }
 
 // TODO: Remove after integration with Bugsnag

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -62,8 +62,8 @@ ViewLoadInstrumentation::onLoadView(UIViewController *viewController) noexcept {
     
     auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
                  tracer_.startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
-                                             NSStringFromClass([viewController class]),
-                                             CFAbsoluteTimeGetCurrent())];
+                                           NSStringFromClass([viewController class]),
+                                           defaultSpanOptionsForViewLoad())];
     
     objc_setAssociatedObject(viewController, &kAssociatedSpan, span,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -24,17 +24,11 @@ static NSString * EncodeSpanKind(SpanKind kind) {
 }
 
 static NSString * EncodeSpanId(SpanId const &spanId) {
-    auto ptr = reinterpret_cast<unsigned const char *>(std::begin(spanId));
-    return [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x",
-            ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5], ptr[6], ptr[7]];
+    return [NSString stringWithFormat:@"%016llx", spanId];
 }
 
 static NSString * EncodeTraceId(TraceId const &traceId) {
-    auto ptr = reinterpret_cast<unsigned const char *>(std::begin(traceId));
-    return [NSString stringWithFormat:
-            @"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
-            ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5], ptr[6], ptr[7],
-            ptr[8], ptr[9], ptr[10], ptr[11], ptr[12], ptr[13], ptr[14], ptr[15]];
+    return [NSString stringWithFormat:@"%016llx%016llx", traceId.hi, traceId.lo];
 }
 
 static NSString * EncodeCFAbsoluteTime(CFAbsoluteTime time) {

--- a/Sources/BugsnagPerformance/Private/Sampler.mm
+++ b/Sources/BugsnagPerformance/Private/Sampler.mm
@@ -62,7 +62,7 @@ bool Sampler::sampled(SpanData &span) noexcept {
     } else {
         idUpperBound = uint64_t(p * double(UINT64_MAX));
     }
-    bool isSampled = span.traceId[0] < idUpperBound;
+    bool isSampled = span.traceId.hi < idUpperBound;
     if (isSampled) {
         span.updateSamplingProbability(p);
     }

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -41,7 +41,10 @@ public:
         data_->endTime = time;
         onEnd_(std::move(data_));
     }
-    
+
+    TraceId traceId() {return data_->traceId;}
+    SpanId spanId() {return data_->spanId;}
+
 private:
     std::unique_ptr<SpanData> data_;
     OnSpanEnd onEnd_;

--- a/Sources/BugsnagPerformance/Private/SpanData.h
+++ b/Sources/BugsnagPerformance/Private/SpanData.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpan.h>
 
 #import "IdGenerator.h"
 #import "SpanKind.h"

--- a/Sources/BugsnagPerformance/Private/SpanData.mm
+++ b/Sources/BugsnagPerformance/Private/SpanData.mm
@@ -10,8 +10,8 @@
 using namespace bugsnag;
 
 SpanData::SpanData(NSString *name, CFAbsoluteTime startTime) noexcept
-: traceId(IdGenerator::generateTraceIdBytes())
-, spanId(IdGenerator::generateSpanIdBytes())
+: traceId(IdGenerator::generateTraceId())
+, spanId(IdGenerator::generateSpanId())
 , name([name copy])
 , attributes([NSMutableDictionary dictionary])
 , samplingProbability(1.0)

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -1,0 +1,63 @@
+//
+//  SpanOptions.h
+//  BugsnagPerformance
+//
+//  Created by Karl Stenerud on 15.02.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
+#import "Utils.h"
+
+namespace bugsnag {
+
+static inline CFAbsoluteTime defaultTimeIfNil(NSDate *date) {
+    if (date == nil) {
+        return CFAbsoluteTimeGetCurrent();
+    }
+    return dateToAbsoluteTime(date);
+}
+
+class SpanOptions {
+public:
+    SpanOptions(id<BugsnagPerformanceSpanContext> parentContext,
+                CFAbsoluteTime startTime,
+                bool makeContextCurrent,
+                BSGFirstClass isFirstClass)
+    : parentContext(parentContext)
+    , startTime(startTime)
+    , makeContextCurrent(makeContextCurrent)
+    , isFirstClass(isFirstClass)
+    {}
+    
+    SpanOptions(BugsnagPerformanceSpanOptions *options)
+    : parentContext(options.parentContext)
+    , startTime(defaultTimeIfNil(options.startTime))
+    , makeContextCurrent(options.makeContextCurrent)
+    , isFirstClass(options.isFirstClass)
+    {}
+    
+    id<BugsnagPerformanceSpanContext> parentContext;
+    CFAbsoluteTime startTime;
+    bool makeContextCurrent;
+    BSGFirstClass isFirstClass;
+};
+
+static inline SpanOptions defaultSpanOptionsForCustom() {
+    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), false, BSGFirstClassYes);
+}
+
+static inline SpanOptions defaultSpanOptionsForInternal() {
+    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), false, BSGFirstClassUnset);
+}
+
+static inline SpanOptions defaultSpanOptionsForViewLoad() {
+    // TODO: This will check the stack for a view load in a later PR
+    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), false, BSGFirstClassYes);
+}
+
+static inline SpanOptions defaultSpanOptionsForNetwork(CFAbsoluteTime startTime) {
+    return SpanOptions(nil, startTime, false, BSGFirstClassUnset);
+}
+}
+

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -15,6 +15,7 @@
 #import "Span.h"
 #import "Sampler.h"
 #import "Batch.h"
+#import "SpanOptions.h"
 
 #import <memory>
 
@@ -30,11 +31,11 @@ public:
     
     void start(BugsnagPerformanceConfiguration *configuration) noexcept;
     
-    std::unique_ptr<class Span> startSpan(NSString *name, CFAbsoluteTime startTime) noexcept;
+    std::unique_ptr<class Span> startSpan(NSString *name, SpanOptions options) noexcept;
     
     std::unique_ptr<class Span> startViewLoadSpan(BugsnagPerformanceViewType viewType,
-                                                    NSString *className,
-                                                    CFAbsoluteTime startTime) noexcept;
+                                                  NSString *className,
+                                                  SpanOptions options) noexcept;
     
     void reportNetworkSpan(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept;
     

--- a/Sources/BugsnagPerformance/Private/Utils.h
+++ b/Sources/BugsnagPerformance/Private/Utils.h
@@ -55,10 +55,38 @@ static inline T *BSGDynamicCast(__unsafe_unretained id obj) {
     return nil;
 }
 
+/**
+ * Convert an NSDate into a CFAbsoluteTime.
+ * CFAbsoluteTime is a double containing the number of seconds since (00:00:00 1 January 2001).
+ */
+static inline CFAbsoluteTime dateToAbsoluteTime(NSDate *date) {
+    return date.timeIntervalSinceReferenceDate;
+}
+
+/**
+ * Convert a struct timeval to a CFAbsoluteTime.
+ * struct timeval is the number of seconds and microseconds since (00:00:00 1 January 1970).
+ * CFAbsoluteTime is a double containing the number of seconds since (00:00:00 1 January 2001).
+ */
+static inline CFAbsoluteTime timevalToAbsoluteTime(struct timeval &tv) {
+    CFAbsoluteTime time = CFAbsoluteTime(tv.tv_sec) + (CFAbsoluteTime(tv.tv_usec) / USEC_PER_SEC);
+    return time - kCFAbsoluteTimeIntervalSince1970;
+}
+
+/**
+ * Convert a CFAbsoluteTime to a dispatch_time_t.
+ * CFAbsoluteTime is a double containing the number of seconds since (00:00:00 1 January 2001).
+ * dispatch_time_t is the number of nanoseconds since (00:00:00 1 January 1970).
+ */
 static inline dispatch_time_t absoluteTimeToNanoseconds(CFAbsoluteTime time) {
     return (dispatch_time_t) ((time + kCFAbsoluteTimeIntervalSince1970) * NSEC_PER_SEC);
 }
 
+/**
+ * Convert an NSTimeInterval to a dispatch_time_t.
+ * NSTimeInterval is a double containing the time interval in seconds.
+ * dispatch_time_t is the time interval in nanoseconds.
+ */
 static inline dispatch_time_t intervalToNanoseconds(NSTimeInterval interval) {
     return (dispatch_time_t) (interval * NSEC_PER_SEC);
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -39,21 +39,21 @@ static BugsnagPerformanceImpl& getImpl() {
     return getImpl().startSpan(name);
 }
 
-+ (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name startTime:(NSDate *)startTime {
-    return getImpl().startSpan(name, startTime);
++ (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name options:(BugsnagPerformanceSpanOptions *)options {
+    return getImpl().startSpan(name, options);
 }
 
 + (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name viewType:(BugsnagPerformanceViewType)viewType {
     return getImpl().startViewLoadSpan(name, viewType);
 }
 
-+ (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name viewType:(BugsnagPerformanceViewType)viewType startTime:(NSDate *)startTime {
-    return getImpl().startViewLoadSpan(name, viewType, startTime);
++ (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name viewType:(BugsnagPerformanceViewType)viewType options:(BugsnagPerformanceSpanOptions *)options {
+    return getImpl().startViewLoadSpan(name, viewType, options);
 }
 
 + (void)startViewLoadSpanWithController:(UIViewController *)controller
-                              startTime:(NSDate *)startTime {
-    getImpl().startViewLoadSpan(controller, startTime);
+                                options:(BugsnagPerformanceSpanOptions *)options {
+    getImpl().startViewLoadSpan(controller, options);
 }
 
 + (void)endViewLoadSpanWithController:(UIViewController *)controller

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -6,6 +6,7 @@
 //
 
 #import "../Private/BugsnagPerformanceSpan+Private.h"
+#import "../Private/Utils.h"
 
 using namespace bugsnag;
 
@@ -32,9 +33,17 @@ using namespace bugsnag;
 
 - (void)endWithEndTime:(NSDate *)endTime {
     if (_span) {
-        _span->end(endTime.timeIntervalSinceReferenceDate);
+        _span->end(dateToAbsoluteTime(endTime));
         _span.reset();
     }
+}
+
+- (TraceId)traceId {
+    return _span->traceId();
+}
+
+- (SpanId)spanId {
+    return _span->spanId();
 }
 
 @end

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -1,0 +1,51 @@
+//
+//  BugsnagPerformanceSpanOptions.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 15.02.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
+
+@implementation BugsnagPerformanceSpanOptions
+
++ (instancetype)optionsWithStartTime:(NSDate *)startTime
+                       parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
+                  makeContextCurrent:(BOOL)makeContextCurrent
+                        isFirstClass:(BSGFirstClass)isFirstClass {
+    return [[self alloc] initWithStartTime:startTime
+                             parentContext:parentContext
+                        makeContextCurrent:makeContextCurrent
+                              isFirstClass:isFirstClass];
+}
+
+- (instancetype)init {
+    return [self initWithStartTime:nil
+                     parentContext:nil
+                makeContextCurrent:false
+                      isFirstClass:BSGFirstClassUnset];
+}
+
+- (instancetype)initWithStartTime:(NSDate *)startTime
+                    parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
+               makeContextCurrent:(BOOL)makeContextCurrent
+                     isFirstClass:(BSGFirstClass)isFirstClass {
+    if ((self = [super init])) {
+        _startTime = startTime;
+        _parentContext = parentContext;
+        _makeContextCurrent = makeContextCurrent;
+        _isFirstClass = isFirstClass;
+    }
+    return self;
+}
+
+- (instancetype)clone {
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+    return [BugsnagPerformanceSpanOptions optionsWithStartTime:_startTime
+                                                 parentContext:_parentContext
+                                            makeContextCurrent:_makeContextCurrent
+                                                  isFirstClass:_isFirstClass];
+}
+
+@end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -8,6 +8,8 @@
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceErrors.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -23,7 +25,7 @@ OBJC_EXPORT
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name NS_SWIFT_NAME(startSpan(name:));
 
-+ (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name startTime:(NSDate *)startTime NS_SWIFT_NAME(startSpan(name:startTime:));
++ (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name options:(BugsnagPerformanceSpanOptions *)options NS_SWIFT_NAME(startSpan(name:options:));
 
 @end
 
@@ -35,12 +37,12 @@ OBJC_EXPORT
 
 + (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name
                                              viewType:(BugsnagPerformanceViewType)viewType
-                                            startTime:(NSDate *)startTime
-  NS_SWIFT_NAME(startViewLoadSpan(name:viewType:startTime:));
+                                              options:(BugsnagPerformanceSpanOptions *)options
+  NS_SWIFT_NAME(startViewLoadSpan(name:viewType:options:));
 
 + (void)startViewLoadSpanWithController:(UIViewController *)controller
-                              startTime:(NSDate *)startTime
-  NS_SWIFT_NAME(startViewLoadSpan(controller:startTime:));
+                                options:(BugsnagPerformanceSpanOptions *)options
+  NS_SWIFT_NAME(startViewLoadSpan(controller:options:));
 
 + (void)endViewLoadSpanWithController:(UIViewController *)controller
                               endTime:(NSDate *)endTime

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
@@ -5,12 +5,12 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
-#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 OBJC_EXPORT
-@interface BugsnagPerformanceSpan : NSObject
+@interface BugsnagPerformanceSpan : NSObject<BugsnagPerformanceSpanContext>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
@@ -1,0 +1,35 @@
+//
+//  BugsnagPerformanceSpanContext.h
+//  BugsnagPerformance
+//
+//  Created by Karl Stenerud on 15.02.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef union {
+    __uint128_t value;
+    struct {
+        uint64_t lo;
+        uint64_t hi;
+    };
+} TraceId;
+static_assert(sizeof(TraceId) == 16, "Compiler issue: TraceId was not 16 bytes long");
+
+typedef uint64_t SpanId;
+static_assert(sizeof(SpanId) == 8, "Compiler issue: SpanId was not 8 bytes long");
+
+
+// https://opentelemetry.io/docs/reference/specification/trace/api/#spancontext
+OBJC_EXPORT
+@protocol BugsnagPerformanceSpanContext <NSObject>
+
+@property(nonatomic,readonly) TraceId traceId;
+@property(nonatomic,readonly) SpanId spanId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -1,0 +1,45 @@
+//
+//  BugsnagPerformanceSpanOptions.h
+//  BugsnagPerformance
+//
+//  Created by Karl Stenerud on 15.02.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+
+typedef NS_ENUM(uint8_t, BSGFirstClass) {
+    BSGFirstClassNo = 0,
+    BSGFirstClassYes = 1,
+    BSGFirstClassUnset = 2,
+};
+
+// Span options allow the user to affect how spans are created.
+OBJC_EXPORT
+@interface BugsnagPerformanceSpanOptions: NSObject
+
+// The time that this span is deemed to have started.
+@property(nonatomic,readwrite,strong) NSDate *startTime;
+
+// The context that this span is to be a child of, or nil if this will be a top-level span.
+@property(nonatomic,readwrite,strong) id<BugsnagPerformanceSpanContext> parentContext;
+
+// If true, the span will be added to the current context stack.
+@property(nonatomic,readwrite) BOOL makeContextCurrent;
+
+// If true, this span will be considered "first class" on the dashboard.
+@property(nonatomic,readwrite) BSGFirstClass isFirstClass;
+
++ (instancetype)optionsWithStartTime:(NSDate *)starttime
+                       parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
+                  makeContextCurrent:(BOOL)makeContextCurrent
+                        isFirstClass:(BSGFirstClass)isFirstClass;
+
+- (instancetype)initWithStartTime:(NSDate *)starttime
+                    parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
+               makeContextCurrent:(BOOL)makeContextCurrent
+                     isFirstClass:(BSGFirstClass)isFirstClass;
+
+- (instancetype)clone;
+
+@end

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -62,7 +62,7 @@ using namespace bugsnag;
 }
 
 - (void)testEncodeSpan {
-    auto startTime = [NSDate dateWithTimeIntervalSince1970:1664352000].timeIntervalSinceReferenceDate;
+    CFAbsoluteTime startTime = [NSDate dateWithTimeIntervalSince1970:1664352000].timeIntervalSinceReferenceDate;
     
     SpanData span(@"My span", startTime);
     span.endTime = startTime + 15;

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -1,0 +1,66 @@
+//
+//  SpanOptionsTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 16.02.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
+#import "SpanOptions.h"
+
+using namespace bugsnag;
+
+@interface SpanOptionsTests : XCTestCase
+
+@end
+
+@interface MockContext: NSObject<BugsnagPerformanceSpanContext>
+
+@property(nonatomic,readonly) TraceId traceId;
+@property(nonatomic,readonly) SpanId spanId;
+
+@end
+
+@implementation MockContext
+
+@end
+
+
+@implementation SpanOptionsTests
+
+- (void)testUnset {
+    BugsnagPerformanceSpanOptions *objcOptions = [BugsnagPerformanceSpanOptions new];
+    XCTAssertNil(objcOptions.parentContext);
+    XCTAssertNil(objcOptions.startTime);
+    XCTAssertFalse(objcOptions.makeContextCurrent);
+    XCTAssertEqual(objcOptions.isFirstClass, BSGFirstClassUnset);
+}
+
+- (void)testConversionDefaults {
+    BugsnagPerformanceSpanOptions *objcOptions = [BugsnagPerformanceSpanOptions new];
+    SpanOptions cOptions(objcOptions);
+    XCTAssertNil(cOptions.parentContext);
+    XCTAssertTrue(abs(cOptions.startTime - CFAbsoluteTimeGetCurrent()) < 1);
+    XCTAssertFalse(cOptions.makeContextCurrent);
+    XCTAssertEqual(cOptions.isFirstClass, BSGFirstClassUnset);
+}
+
+- (void)testConversion {
+    id<BugsnagPerformanceSpanContext> context = [MockContext new];
+    BugsnagPerformanceSpanOptions *objcOptions = [BugsnagPerformanceSpanOptions new];
+    objcOptions.startTime = [NSDate dateWithTimeIntervalSinceReferenceDate:1.0];
+    objcOptions.parentContext = context;
+    objcOptions.makeContextCurrent = true;
+    objcOptions.isFirstClass = BSGFirstClassNo;
+
+    SpanOptions cOptions(objcOptions);
+    XCTAssertEqual(1.0, cOptions.startTime);
+    XCTAssertEqual(context, cOptions.parentContext);
+    XCTAssertEqual(true, cOptions.makeContextCurrent);
+    XCTAssertEqual(BSGFirstClassNo, cOptions.isFirstClass);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/TimeTests.mm
+++ b/Tests/BugsnagPerformanceTests/TimeTests.mm
@@ -1,0 +1,39 @@
+//
+//  TimeTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 16.02.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "Utils.h"
+
+using namespace bugsnag;
+
+@interface TimeTests : XCTestCase
+
+@end
+
+@implementation TimeTests
+
+- (void)testTimeToNanoseconds {
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:0];
+    dispatch_time_t time = absoluteTimeToNanoseconds(dateToAbsoluteTime(date));
+    
+    XCTAssertEqual(0, time);
+    
+    date = [NSDate dateWithTimeIntervalSince1970:1000];
+    time = absoluteTimeToNanoseconds(dateToAbsoluteTime(date));
+    
+    XCTAssertEqual(1000000000000, time);
+}
+
+- (void)testCurrentTime {
+    CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
+    CFAbsoluteTime dateToTime = dateToAbsoluteTime([NSDate date]);
+    
+    XCTAssertTrue(abs(now - dateToTime) < 0.1);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/ViewControllerSpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/ViewControllerSpanTests.mm
@@ -21,7 +21,7 @@ using namespace bugsnag;
     BugsnagPerformanceImpl perf;
     @autoreleasepool {
         UIViewController *controller = [UIViewController new];
-        perf.startViewLoadSpan(controller, [NSDate date]);
+        perf.startViewLoadSpan(controller, [BugsnagPerformanceSpanOptions new]);
         XCTAssertEqual(1, perf.testing_getViewControllersToSpansCount());
         perf.endViewLoadSpan(controller, [NSDate date]);
         XCTAssertEqual(0, perf.testing_getViewControllersToSpansCount());
@@ -33,7 +33,7 @@ using namespace bugsnag;
 
     @autoreleasepool {
         UIViewController *controller = [UIViewController new];
-        perf.startViewLoadSpan(controller, [NSDate date]);
+        perf.startViewLoadSpan(controller, [BugsnagPerformanceSpanOptions new]);
         XCTAssertEqual(1, perf.testing_getViewControllersToSpansCount());
     }
 
@@ -47,7 +47,7 @@ using namespace bugsnag;
     @autoreleasepool {
         for (int i = 0; i < 100; i++) {
             UIViewController *controller = [UIViewController new];
-            perf.startViewLoadSpan(controller, [NSDate date]);
+            perf.startViewLoadSpan(controller, [BugsnagPerformanceSpanOptions new]);
         }
 
         XCTAssertLessThan(perf.testing_getViewControllersToSpansCount(), 100);

--- a/features/fixtures/ios/Scenarios/ManualUIViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualUIViewLoadScenario.swift
@@ -10,8 +10,10 @@ import BugsnagPerformance
 class ManualUIViewLoadScenario: Scenario {
 
     override func run() {
-        var controller = UIViewController()
-        BugsnagPerformance.startViewLoadSpan(controller: controller, startTime: Date())
+        let controller = UIViewController()
+        let options = BugsnagPerformanceSpanOptions()
+        options.startTime = Date()
+        BugsnagPerformance.startViewLoadSpan(controller: controller, options: options)
         BugsnagPerformance.endViewLoadSpan(controller: controller, endTime: Date())
         waitForCurrentBatch()
     }

--- a/features/fixtures/ios/Scenarios/ManualViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualViewLoadScenario.swift
@@ -12,6 +12,8 @@ class ManualViewLoadScenario: Scenario {
     override func run() {
         BugsnagPerformance.startViewLoadSpan(name: "ManualViewController", viewType: .uiKit).end()
         waitForCurrentBatch()
-        BugsnagPerformance.startViewLoadSpan(name: "ManualView", viewType: .swiftUI, startTime: Date()).end()
+        let options = BugsnagPerformanceSpanOptions()
+        options.startTime = Date()
+        BugsnagPerformance.startViewLoadSpan(name: "ManualView", viewType: .swiftUI, options:options).end()
     }
 }


### PR DESCRIPTION
## Goal

Replaced `startTime` in the public API with `options`, and added the concept of a span context.

## Design

Internally, the Objective-C options is converted to a more performant C++ implementation that is passed by value.

`SpanId` is now a `uint64_t` and `TraceId` is now a 128 bit union with hi and low portions so that it's compatible with Swift (due to these types now being exposed via the span context).

All time conversions are now done via utility functions since the standard APIs leave too much room for error.

## Testing

Added tests for time conversions and ObjC span options to C++ span options conversion.
