### PR TITLE
Add isValid API to span context interface rather than fishing through introspection

### DIFF
--- a/Sources/BugsnagPerformance/Private/SpanContextStack.mm
+++ b/Sources/BugsnagPerformance/Private/SpanContextStack.mm
@@ -91,19 +91,6 @@ static const char * const ActivityRefKey = "BSGActivityRef";
     return self;
 }
 
-static bool isContextValid(id<BugsnagPerformanceSpanContext> context) {
-    if (context == nil) {
-        return false;
-    }
-
-    if ([context isKindOfClass:[BugsnagPerformanceSpan class]]) {
-        return ![(BugsnagPerformanceSpan *)context isEnded];
-    }
-
-    // We don't know what kind it is, so we have to assume it is valid.
-    return true;
-}
-
 static id<BugsnagPerformanceSpanContext> lastObject(NSPointerArray *stack) {
     if (stack.count > 0) {
         return (__bridge id<BugsnagPerformanceSpanContext>)[stack pointerAtIndex:stack.count-1];
@@ -115,7 +102,7 @@ static id<BugsnagPerformanceSpanContext> lastObject(NSPointerArray *stack) {
     @synchronized (stack) {
         while (stack.count > 0) {
             auto context = (__bridge id<BugsnagPerformanceSpanContext>)[stack pointerAtIndex:stack.count-1];
-            if (!isContextValid(context)) {
+            if (!context.isValid) {
                 // Remove the invalid context in multiple steps:
 
                 // Remove the context from our current stack.

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -48,4 +48,8 @@ using namespace bugsnag;
     return _span->spanId();
 }
 
+- (BOOL)isValid {
+    return !_isEnded;
+}
+
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
@@ -29,6 +29,7 @@ OBJC_EXPORT
 
 @property(nonatomic,readonly) TraceId traceId;
 @property(nonatomic,readonly) SpanId spanId;
+@property(nonatomic,readonly) BOOL isValid;
 
 @end
 


### PR DESCRIPTION
## Goal

The current codebase uses introspection to extract a span context implementation to check for validity, which is a code smell.

## Design

Instead, make a span context API "isValid" and implement it in the concrete class.

## Testing

Existing tests cover this refactoring.
