### PR TITLE
Always set Bugsnag-Span-Sampling, even for initial P request

### DIFF
--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -307,5 +307,6 @@ std::unique_ptr<OtlpPackage> OtlpTraceEncoding::buildPValueRequestPackage() noex
     return std::make_unique<OtlpPackage>(0, emptyPayload, @{
         @"Content-Type": @"application/json",
         @"Bugsnag-Integrity": integrityDigestForData(emptyPayload),
+        @"Bugsnag-Span-Sampling": @"1:0",
     });
 }

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -4,6 +4,7 @@ Feature: Automatic instrumentation spans
     Given I run "AutoInstrumentAppStartsScenario" and discard the initial p-value request
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "AppStart/Cold"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
@@ -20,6 +21,7 @@ Feature: Automatic instrumentation spans
     Given I run "AutoInstrumentViewLoadScenario" and discard the initial p-value request
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "ViewLoad/UIKit/Fixture.AutoInstrumentViewLoadScenario_ViewController"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
@@ -37,6 +39,7 @@ Feature: Automatic instrumentation spans
     Given I run "AutoInstrumentNetworkScenario" and discard the initial p-value request
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "HTTP/GET"
     * every span string attribute "http.flavor" exists
     * every span string attribute "http.url" matches the regex "http://.*:9340/reflect/"

--- a/features/initial-p-value.feature
+++ b/features/initial-p-value.feature
@@ -4,6 +4,7 @@ Feature: Initial P values
     Given I set the sampling probability for the next traces to "0"
     And I run "InitialPScenario"
     And I wait to receive 1 traces
+    * the trace "Bugsnag-Span-Sampling" header equals "1:0"
     * the trace payload field "resourceSpans" is an array with 0 elements
 
   Scenario: Initial P value of 1
@@ -17,3 +18,6 @@ Feature: Initial P values
     * every span field "kind" equals "SPAN_KIND_INTERNAL"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:0"
+    And I discard the oldest trace
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -4,8 +4,9 @@ Feature: Manual creation of spans
 
   Scenario: Retry a manual span
     Given I set the HTTP status code for the next requests to "200,500,200,200"
-    And I run "RetryScenario"
+    And I run "RetryScenario" and discard the initial p-value request
     And I wait for 3 spans
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * a span field "name" equals "WillRetry"
     * a span field "name" equals "Success"
 
@@ -16,6 +17,7 @@ Feature: Manual creation of spans
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "ManualSpanScenario"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
@@ -41,6 +43,7 @@ Feature: Manual creation of spans
   Scenario: Starting and ending a span before starting the SDK
     Given I run "ManualSpanBeforeStartScenario" and discard the initial p-value request
     And I wait for 1 span
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "BeforeStart"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
@@ -54,6 +57,7 @@ Feature: Manual creation of spans
   Scenario: Manually report a view load span
     Given I run "ManualViewLoadScenario" and discard the initial p-value request
     And I wait for 2 spans
+    * the trace "Bugsnag-Span-Sampling" header is not null
     * a span field "name" equals "ViewLoad/UIKit/ManualViewController"
     * a span string attribute "bugsnag.view.name" equals "ManualViewController"
     * a span string attribute "bugsnag.view.type" equals "UIKit"
@@ -68,6 +72,7 @@ Feature: Manual creation of spans
   Scenario: Manually report a UIViewController load span
     Given I run "ManualUIViewLoadScenario" and discard the initial p-value request
     And I wait for 1 span
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "ViewLoad/UIKit/UIViewController"
     * every span string attribute "bugsnag.view.name" equals "UIViewController"
     * every span string attribute "bugsnag.view.type" equals "UIKit"
@@ -80,6 +85,7 @@ Feature: Manual creation of spans
     Given I run "ManualNetworkSpanScenario" and discard the initial p-value request
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
@@ -100,6 +106,7 @@ Feature: Manual creation of spans
     Given I run "BatchingScenario" and discard the initial p-value request
     And I wait for 2 spans
     Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header is not null
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
@@ -115,6 +122,7 @@ Feature: Manual creation of spans
     Given I run "BatchingScenario" and discard the initial p-value request
     And I wait for 2 spans
     Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header is not null
     * a span field "name" equals "Span1"
     * a span field "name" equals "Span2"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"

--- a/features/sampling.feature
+++ b/features/sampling.feature
@@ -9,4 +9,5 @@ Feature: Sampling
     Given I set the sampling probability to "1.0"
     And I run "SamplingProbabilityZeroScenario" and discard the initial p-value request
     And I wait for 1 span
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * a span field "name" equals "Post-start"


### PR DESCRIPTION
## Goal

The `Bugsnag-Span-Sampling` HTTP header must always be set when calling the `/v1/traces` API. It was not being set for the initial P value request.

## Testing

Updated e2e tests to check for this.