### PR TITLE
[PLAT-9263] Actually set start time for app start

### DIFF
--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -98,8 +98,10 @@ AppStartupInstrumentation::reportSpan(CFAbsoluteTime endTime) noexcept {
         BSGLogWarning(@"Ignoring excessively long app startup span");
         return;
     }
-    auto name = isCold_ ? @"AppStart/Cold" : @"AppStart/Warm"; 
-    auto span = tracer_.startSpan(name, defaultSpanOptionsForInternal());
+    auto name = isCold_ ? @"AppStart/Cold" : @"AppStart/Warm";
+    auto options = defaultSpanOptionsForInternal();
+    options.startTime = startTime;
+    auto span = tracer_.startSpan(name, options);
     span->addAttributes(@{
         @"bugsnag.app_start.type": isCold_ ? @"cold" : @"warm",
         @"bugsnag.span.category": @"app_start",


### PR DESCRIPTION
## Goal

The app start time instrumentation wasn't actually using the start time that was originally calculated, but was just taking the default span options (which set it to the current time).

## Testing

Tested manually.
