### PR TITLE
[PLAT-9461] Don't revert to the configured P value on expiry.

### DIFF
--- a/Sources/BugsnagPerformance/Private/BSGInternalConfig.c
+++ b/Sources/BugsnagPerformance/Private/BSGInternalConfig.c
@@ -8,6 +8,7 @@
 
 #include "BSGInternalConfig.h"
 
+
 uint64_t bsgp_autoTriggerExportOnBatchSize = 100;
 
 dispatch_time_t bsgp_autoTriggerExportOnTimeDuration = 30 * NSEC_PER_SEC;
@@ -15,3 +16,6 @@ dispatch_time_t bsgp_autoTriggerExportOnTimeDuration = 30 * NSEC_PER_SEC;
 NSTimeInterval bsgp_performWorkInterval = 30;
 
 NSTimeInterval bsgp_maxRetryAge = 24 * 60 * 60;
+
+CFTimeInterval bsgp_probabilityValueExpiresAfterSeconds = 24 * 3600;
+CFTimeInterval bsgp_probabilityRequestsPauseForSeconds = 30;

--- a/Sources/BugsnagPerformance/Private/BSGInternalConfig.h
+++ b/Sources/BugsnagPerformance/Private/BSGInternalConfig.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 #include <dispatch/time.h>
+#include <CoreFoundation/CFDate.h>
 
 #ifdef __OBJC__
 #import <Foundation/Foundation.h>
@@ -27,5 +28,8 @@ extern dispatch_time_t bsgp_autoTriggerExportOnTimeDuration;
 extern NSTimeInterval bsgp_performWorkInterval;
 
 extern NSTimeInterval bsgp_maxRetryAge;
+
+extern CFTimeInterval bsgp_probabilityValueExpiresAfterSeconds;
+extern CFTimeInterval bsgp_probabilityRequestsPauseForSeconds;
 
 #endif /* BSGInternalConfig_h */

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -52,6 +52,8 @@ public:
         tracer_.reportNetworkSpan(task, metrics);
     }
 
+    void onSpanStarted() noexcept;
+
 private:
     bool started_;
     std::mutex instanceMutex_;
@@ -67,6 +69,8 @@ private:
     bool shouldPersistState_;
     std::mutex viewControllersToSpansMutex_;
     NSMapTable<UIViewController *, BugsnagPerformanceSpan *> *viewControllersToSpans_;
+    CFAbsoluteTime probabilityExpiry_;
+    CFAbsoluteTime pausePValueRequestsUntil_;
 
     // Tasks
     NSArray<Task> *buildInitialTasks();
@@ -85,6 +89,7 @@ private:
 
     // Utility
     void wakeWorker() noexcept;
+    void uploadPValueRequest() noexcept;
     void uploadPackage(std::unique_ptr<OtlpPackage> package, bool isRetry) noexcept;
 
 public: // For testing

--- a/Sources/BugsnagPerformance/Private/Sampler.h
+++ b/Sources/BugsnagPerformance/Private/Sampler.h
@@ -25,9 +25,7 @@ class Sampler {
 public:
     Sampler(double fallbackProbability) noexcept;
     
-    void setFallbackProbability(double value) noexcept {
-        fallbackProbability_ = value;
-    }
+    void setFallbackProbability(double value) noexcept;
 
     /**
      * Sets the probability value to use in all sampling for the next 24 hours.
@@ -50,8 +48,6 @@ public:
     sampled(std::unique_ptr<std::vector<std::unique_ptr<SpanData>>> spans) noexcept;
 
 private:
-    double fallbackProbability_;
     double probability_;
-    CFAbsoluteTime probabilityExpiry_;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -27,7 +27,7 @@ namespace bugsnag {
  */
 class Tracer {
 public:
-    Tracer(std::shared_ptr<Sampler> sampler, std::shared_ptr<Batch> batch) noexcept;
+    Tracer(std::shared_ptr<Sampler> sampler, std::shared_ptr<Batch> batch, void (^onSpanStarted)()) noexcept;
     
     void start(BugsnagPerformanceConfiguration *configuration) noexcept;
     
@@ -46,6 +46,7 @@ private:
     std::unique_ptr<class NetworkInstrumentation> networkInstrumentation_;
     
     std::shared_ptr<Batch> batch_;
+    void (^onSpanStarted_)();
     
     void tryAddSpanToBatch(std::unique_ptr<SpanData> spanData);
 };

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -13,9 +13,10 @@
 
 using namespace bugsnag;
 
-Tracer::Tracer(std::shared_ptr<Sampler> sampler, std::shared_ptr<Batch> batch) noexcept
+Tracer::Tracer(std::shared_ptr<Sampler> sampler, std::shared_ptr<Batch> batch, void (^onSpanStarted)()) noexcept
 : sampler_(sampler)
 , batch_(batch)
+, onSpanStarted_(onSpanStarted)
 {}
 
 void
@@ -44,6 +45,9 @@ Tracer::startSpan(NSString *name, SpanOptions options) noexcept {
         blockThis->tryAddSpanToBatch(std::move(spanData));
     });
     span->addAttributes(SpanAttributes::get());
+    if (onSpanStarted_) {
+        onSpanStarted_();
+    }
     return span;
 }
 

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */; };
 		CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */; };
 		CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */; };
+		CBE43A9929A8EFA3000B4205 /* ProbabilityExpiryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
 /* End PBXBuildFile section */
@@ -56,6 +57,7 @@
 		CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualUIViewLoadScenario.swift; sourceTree = "<group>"; };
 		CBAAE25429125F5F006D4AA0 /* Fixture-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fixture-Bridging-Header.h"; sourceTree = "<group>"; };
 		CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingScenario.swift; sourceTree = "<group>"; };
+		CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProbabilityExpiryScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
 		CBE8EA0B294A220600702950 /* BSGInternalConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSGInternalConfig.h; path = ../../../../Sources/BugsnagPerformance/Private/BSGInternalConfig.h; sourceTree = "<group>"; };
 		CBF62108291A4F47004BEE0B /* RetryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryScenario.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
 				CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */,
 				01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */,
+				CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */,
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
@@ -225,6 +228,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CBE43A9929A8EFA3000B4205 /* ProbabilityExpiryScenario.swift in Sources */,
 				0185C47228F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/ProbabilityExpiryScenario.swift
+++ b/features/fixtures/ios/Scenarios/ProbabilityExpiryScenario.swift
@@ -1,0 +1,28 @@
+//
+//  ProbabilityExpiryScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 24.02.23.
+//
+
+import BugsnagPerformance
+
+class ProbabilityExpiryScenario: Scenario {
+    
+    override func startBugsnag() {
+        bsgp_probabilityRequestsPauseForSeconds = 0.1
+        bsgp_probabilityValueExpiresAfterSeconds = 0.1
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        // Check that another P value request gets sent when a span is started after
+        // the current P value has expired.
+
+        // Give the initial P value time to expire.
+        Thread.sleep(forTimeInterval: 0.5)
+        
+        // Now starting a new span should trigger a new P value request.
+        BugsnagPerformance.startSpan(name: "myspan")
+    }
+}

--- a/features/initial-p-value.feature
+++ b/features/initial-p-value.feature
@@ -21,3 +21,9 @@ Feature: Initial P values
     * the trace "Bugsnag-Span-Sampling" header equals "1:0"
     And I discard the oldest trace
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+
+  Scenario: ProbabilityExpiryScenario
+    Given I run "ProbabilityExpiryScenario"
+    And I wait to receive 2 traces
+    * the trace "Bugsnag-Span-Sampling" header equals "1:0"
+    * the trace payload field "resourceSpans" is an array with 0 elements


### PR DESCRIPTION
## Goal

When the current P value expires, start fetching P values from the server on span start instead of reverting to the original configured value.

## Design

Also added a delay latch so that it can't send P value requests more than once every 30 seconds (so that we don't flood the server on span-heavy apps whenever the timer expires).

## Testing

New e2e scenario to test p value expiry.
