### PR TITLE
[PLAT-9677] Use integer values for enums instead of strings

### DIFF
--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -12,17 +12,6 @@
 
 using namespace bugsnag;
 
-static NSString * EncodeSpanKind(SpanKind kind) {
-    switch (kind) {
-        case SPAN_KIND_UNSPECIFIED: return @"SPAN_KIND_UNSPECIFIED";
-        case SPAN_KIND_INTERNAL:    return @"SPAN_KIND_INTERNAL";
-        case SPAN_KIND_SERVER:      return @"SPAN_KIND_SERVER";
-        case SPAN_KIND_CLIENT:      return @"SPAN_KIND_CLIENT";
-        case SPAN_KIND_PRODUCER:    return @"SPAN_KIND_PRODUCER";
-        case SPAN_KIND_CONSUMER:    return @"SPAN_KIND_CONSUMER";
-    }
-}
-
 static NSString * EncodeSpanId(SpanId const &spanId) {
     return [NSString stringWithFormat:@"%016llx", spanId];
 }
@@ -83,7 +72,7 @@ OtlpTraceEncoding::encode(const SpanData &span) noexcept {
         // Distinguishes between spans generated in a particular context. For example,
         // two spans with the same name may be distinguished using `CLIENT` (caller)
         // and `SERVER` (callee) to identify queueing latency associated with the span.
-        @"kind": EncodeSpanKind(span.kind),
+        @"kind": @(span.kind),
         
         // start_time_unix_nano is the start time of the span. On the client side, this is the time
         // kept by the local machine where the span execution starts. On the server side, this

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -79,7 +79,7 @@ using namespace bugsnag;
     
     XCTAssertEqualObjects(json[@"name"], @"My span");
     
-    XCTAssertEqualObjects(json[@"kind"], @"SPAN_KIND_INTERNAL");
+    XCTAssertEqualObjects(json[@"kind"], @(SPAN_KIND_INTERNAL));
     
     XCTAssertEqualObjects(json[@"startTimeUnixNano"], @"1664352000000000000");
     XCTAssertEqualObjects(json[@"endTimeUnixNano"], @"1664352015000000000");

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -8,7 +8,7 @@ Feature: Automatic instrumentation spans
     * every span field "name" equals "AppStart/Cold"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.app_start.type" equals "cold"
@@ -25,7 +25,7 @@ Feature: Automatic instrumentation spans
     * every span field "name" equals "ViewLoad/UIKit/Fixture.AutoInstrumentViewLoadScenario_ViewController"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "view_load"
@@ -49,7 +49,7 @@ Feature: Automatic instrumentation spans
     * every span string attribute "net.host.connection.type" equals "wifi"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"

--- a/features/initial-p-value.feature
+++ b/features/initial-p-value.feature
@@ -15,7 +15,7 @@ Feature: Initial P values
     * a span field "name" equals "Second"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:0"

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -21,7 +21,7 @@ Feature: Manual creation of spans
     * every span field "name" equals "ManualSpanScenario"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.app.in_foreground" is true
@@ -47,7 +47,7 @@ Feature: Manual creation of spans
     * every span field "name" equals "BeforeStart"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
@@ -64,7 +64,7 @@ Feature: Manual creation of spans
     * a span field "name" equals "ViewLoad/SwiftUI/ManualView"
     * a span string attribute "bugsnag.view.name" equals "ManualView"
     * a span string attribute "bugsnag.view.type" equals "SwiftUI"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "view_load"
@@ -76,7 +76,7 @@ Feature: Manual creation of spans
     * every span field "name" equals "ViewLoad/UIKit/UIViewController"
     * every span string attribute "bugsnag.view.name" equals "UIViewController"
     * every span string attribute "bugsnag.view.type" equals "UIKit"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "view_load"
@@ -98,7 +98,7 @@ Feature: Manual creation of spans
     * every span string attribute "net.host.connection.type" equals "wifi"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
@@ -114,7 +114,7 @@ Feature: Manual creation of spans
     * a span field "name" equals "Span2"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
@@ -127,7 +127,7 @@ Feature: Manual creation of spans
     * a span field "name" equals "Span2"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -16,3 +16,9 @@ When("I run {string} and discard the initial p-value request") do |scenario|
   }
 end
 
+Then('every span field {string} equals {int}') do |key, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_keys = spans.map { |span| span[key] == expected }
+  Maze.check.not_includes selected_keys, false
+end
+


### PR DESCRIPTION
## Goal

Use integer values for enum fields instead of string values.

## Testing

Updated tests to check for integer values.
