### PR TITLE
[Plat 9654] first class spans

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		CB7FD934299D31D300499E13 /* BugsnagPerformanceSpanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7FD933299D309B00499E13 /* BugsnagPerformanceSpanContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBB48A3C295EE1E10044E9AC /* ObjCUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */; };
 		CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */; };
+		CBE43A9F29AE2F8D000B4205 /* BugsnagPerformanceSpanOptions+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE43A9E29AE1512000B4205 /* BugsnagPerformanceSpanOptions+Private.h */; };
 		CBE8EA09294A20ED00702950 /* BSGInternalConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */; };
 		CBE8EA0A294A20ED00702950 /* BSGInternalConfig.c in Sources */ = {isa = PBXBuildFile; fileRef = CBE8EA08294A20ED00702950 /* BSGInternalConfig.c */; };
 		CBE8EA16294B528100702950 /* BugsnagPerformanceImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */; };
@@ -189,6 +190,7 @@
 		CB7FD935299D330500499E13 /* SpanOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpanOptions.h; sourceTree = "<group>"; };
 		CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCUtils.h; sourceTree = "<group>"; };
 		CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCUtils.mm; sourceTree = "<group>"; };
+		CBE43A9E29AE1512000B4205 /* BugsnagPerformanceSpanOptions+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceSpanOptions+Private.h"; sourceTree = "<group>"; };
 		CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGInternalConfig.h; sourceTree = "<group>"; };
 		CBE8EA08294A20ED00702950 /* BSGInternalConfig.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BSGInternalConfig.c; sourceTree = "<group>"; };
 		CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceImpl.h; sourceTree = "<group>"; };
@@ -311,6 +313,7 @@
 				CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */,
 				CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */,
 				0122C23229019770002D243C /* BugsnagPerformanceSpan+Private.h */,
+				CBE43A9E29AE1512000B4205 /* BugsnagPerformanceSpanOptions+Private.h */,
 				CBEC51D42976BCAD009C0CE3 /* Filesystem.h */,
 				CBEC51D52976BCAD009C0CE3 /* Filesystem.m */,
 				CBF7C5DF297A8E9100D47719 /* Gzip.h */,
@@ -499,6 +502,7 @@
 				CBE8EA1E294B5E1500702950 /* Batch.h in Headers */,
 				CBEC51BC296D9EEE009C0CE3 /* PersistentState.h in Headers */,
 				0122C23829019770002D243C /* BugsnagPerformanceSpan.h in Headers */,
+				CBE43A9F29AE2F8D000B4205 /* BugsnagPerformanceSpanOptions+Private.h in Headers */,
 				CB0AD76A296573FC002A3FB6 /* BugsnagPerformanceErrors.h in Headers */,
 				0122C23B29019770002D243C /* BugsnagPerformance.h in Headers */,
 				0122C24B29019770002D243C /* ViewLoadInstrumentation.h in Headers */,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -293,7 +293,7 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name) {
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name, BugsnagPerformanceSpanOptions *optionsIn) {
-    auto options = SpanOptions(optionsIn);
+    auto options = SpanOptionsForCustom(optionsIn);
     auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:tracer_.startSpan(name, options)];
     possiblyMakeSpanCurrent(span, options);
     return span;
@@ -308,7 +308,7 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *name
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType, BugsnagPerformanceSpanOptions *optionsIn) {
-    auto options = SpanOptions(optionsIn);
+    auto options = SpanOptionsForViewLoad(optionsIn);
     auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
                  tracer_.startViewLoadSpan(viewType, name, options)];
     possiblyMakeSpanCurrent(span, options);
@@ -316,7 +316,7 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *name
 }
 
 void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, BugsnagPerformanceSpanOptions *optionsIn) {
-    auto options = SpanOptions(optionsIn);
+    auto options = SpanOptionsForViewLoad(optionsIn);
     auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
             tracer_.startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
                                       [NSString stringWithUTF8String:object_getClassName(controller)],

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanOptions+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanOptions+Private.h
@@ -1,0 +1,15 @@
+//
+//  BugsnagPerformanceSpanOptions+Private.h
+//  BugsnagPerformance
+//
+//  Created by Karl Stenerud on 28.02.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
+
+@interface BugsnagPerformanceSpanOptions ()
+
+@property(nonatomic,readwrite) BOOL wasFirstClassSet;
+
+@end

--- a/Sources/BugsnagPerformance/Private/SpanData.h
+++ b/Sources/BugsnagPerformance/Private/SpanData.h
@@ -18,7 +18,12 @@ namespace bugsnag {
  */
 class SpanData {
 public:
-    SpanData(NSString *name, TraceId traceId, SpanId spanId, SpanId parentId, CFAbsoluteTime startTime) noexcept;
+    SpanData(NSString *name,
+             TraceId traceId,
+             SpanId spanId,
+             SpanId parentId,
+             CFAbsoluteTime startTime,
+             bool isFirstClass) noexcept;
     
     SpanData(const SpanData&) = delete;
     

--- a/Sources/BugsnagPerformance/Private/SpanData.mm
+++ b/Sources/BugsnagPerformance/Private/SpanData.mm
@@ -9,7 +9,12 @@
 
 using namespace bugsnag;
 
-SpanData::SpanData(NSString *name, TraceId traceId, SpanId spanId, SpanId parentId, CFAbsoluteTime startTime) noexcept
+SpanData::SpanData(NSString *name,
+                   TraceId traceId,
+                   SpanId spanId,
+                   SpanId parentId,
+                   CFAbsoluteTime startTime,
+                   bool isFirstClass) noexcept
 : traceId(traceId)
 , spanId(spanId)
 , parentId(parentId)
@@ -18,6 +23,9 @@ SpanData::SpanData(NSString *name, TraceId traceId, SpanId spanId, SpanId parent
 , samplingProbability(1.0)
 , startTime(startTime)
 {
+    if (isFirstClass) {
+        attributes[@"bugsnag.span.first_class"] = @(true);
+    }
 }
 
 void

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 
-#import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
+#import "../Private/BugsnagPerformanceSpanOptions+Private.h"
 #import "Utils.h"
 
 namespace bugsnag {
@@ -23,49 +23,48 @@ public:
     SpanOptions(id<BugsnagPerformanceSpanContext> parentContext,
                 CFAbsoluteTime startTime,
                 bool makeContextCurrent,
-                BSGFirstClass isFirstClass)
+                bool isFirstClass)
     : parentContext(parentContext)
     , startTime(startTime)
     , makeContextCurrent(makeContextCurrent)
     , isFirstClass(isFirstClass)
     {}
     
-    SpanOptions(BugsnagPerformanceSpanOptions *options)
-    : SpanOptions(options.parentContext,
-                  defaultTimeIfNil(options.startTime),
-                  options.makeContextCurrent,
-                  options.isFirstClass)
-    {}
-    
-    SpanOptions()
-    // These defaults must match the defaults in BugsnagPerformanceSpanOptions.m
-    : SpanOptions(nil,
-                  CFAbsoluteTimeGetCurrent(),
-                  true,
-                  BSGFirstClassUnset)
-    {}
-    
     id<BugsnagPerformanceSpanContext> parentContext;
     CFAbsoluteTime startTime;
     bool makeContextCurrent;
-    BSGFirstClass isFirstClass;
+    bool isFirstClass;
 };
 
 static inline SpanOptions defaultSpanOptionsForCustom() {
-    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), true, BSGFirstClassYes);
+    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), true, true);
+}
+
+static inline SpanOptions SpanOptionsForCustom(BugsnagPerformanceSpanOptions *options) {
+    return SpanOptions(options.parentContext,
+                       defaultTimeIfNil(options.startTime),
+                       options.makeContextCurrent,
+                       options.wasFirstClassSet ? options.isFirstClass : true);
 }
 
 static inline SpanOptions defaultSpanOptionsForInternal() {
-    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), true, BSGFirstClassUnset);
+    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), true, false);
 }
 
 static inline SpanOptions defaultSpanOptionsForViewLoad() {
     // TODO: This will check the stack for a view load in a later PR
-    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), true, BSGFirstClassYes);
+    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), true, true);
+}
+
+static inline SpanOptions SpanOptionsForViewLoad(BugsnagPerformanceSpanOptions *options) {
+    return SpanOptions(options.parentContext,
+                       defaultTimeIfNil(options.startTime),
+                       options.makeContextCurrent,
+                       options.wasFirstClassSet ? options.isFirstClass : true);
 }
 
 static inline SpanOptions defaultSpanOptionsForNetwork(CFAbsoluteTime startTime) {
-    return SpanOptions(nil, startTime, true, BSGFirstClassUnset);
+    return SpanOptions(nil, startTime, true, false);
 }
 }
 

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -51,7 +51,8 @@ Tracer::startSpan(NSString *name, SpanOptions options) noexcept {
                                                                   traceId,
                                                                   spanId,
                                                                   currentContext.spanId,
-                                                                  options.startTime),
+                                                                  options.startTime,
+                                                                  options.isFirstClass),
                                        ^void(std::unique_ptr<SpanData> spanData) {
         blockThis->tryAddSpanToBatch(std::move(spanData));
     });

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -6,14 +6,35 @@
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 
-#import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
+#import "../Private/BugsnagPerformanceSpanOptions+Private.h"
 
 @implementation BugsnagPerformanceSpanOptions
+
+- (instancetype)initWithStartTime:(NSDate *)startTime
+                    parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
+               makeContextCurrent:(BOOL)makeContextCurrent
+                     isFirstClass:(BOOL)isFirstClass
+                 wasFirstClassSet:(BOOL)wasFirstClassSet {
+    if ((self = [super init])) {
+        _startTime = startTime;
+        _parentContext = parentContext;
+        _makeContextCurrent = makeContextCurrent;
+        _isFirstClass = isFirstClass;
+        _wasFirstClassSet = wasFirstClassSet;
+    }
+    return self;
+}
+
+- (void)setIsFirstClass:(BOOL)isFirstClass {
+    _isFirstClass = isFirstClass;
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+    _wasFirstClassSet = true;
+}
 
 + (instancetype)optionsWithStartTime:(NSDate *)startTime
                        parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
                   makeContextCurrent:(BOOL)makeContextCurrent
-                        isFirstClass:(BSGFirstClass)isFirstClass {
+                        isFirstClass:(BOOL)isFirstClass {
     return [[self alloc] initWithStartTime:startTime
                              parentContext:parentContext
                         makeContextCurrent:makeContextCurrent
@@ -25,28 +46,28 @@
     return [self initWithStartTime:nil
                      parentContext:nil
                 makeContextCurrent:true
-                      isFirstClass:BSGFirstClassUnset];
+                      isFirstClass:false
+                  wasFirstClassSet:false];
 }
 
 - (instancetype)initWithStartTime:(NSDate *)startTime
                     parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
                makeContextCurrent:(BOOL)makeContextCurrent
-                     isFirstClass:(BSGFirstClass)isFirstClass {
-    if ((self = [super init])) {
-        _startTime = startTime;
-        _parentContext = parentContext;
-        _makeContextCurrent = makeContextCurrent;
-        _isFirstClass = isFirstClass;
-    }
-    return self;
+                     isFirstClass:(BOOL)isFirstClass {
+    return [self initWithStartTime:startTime
+                     parentContext:parentContext
+                makeContextCurrent:makeContextCurrent
+                      isFirstClass:isFirstClass
+                  wasFirstClassSet:false];
 }
 
 - (instancetype)clone {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    return [BugsnagPerformanceSpanOptions optionsWithStartTime:_startTime
-                                                 parentContext:_parentContext
-                                            makeContextCurrent:_makeContextCurrent
-                                                  isFirstClass:_isFirstClass];
+    return [[BugsnagPerformanceSpanOptions alloc] initWithStartTime:_startTime
+                                                      parentContext:_parentContext
+                                                 makeContextCurrent:_makeContextCurrent
+                                                       isFirstClass:_isFirstClass
+                                                   wasFirstClassSet:_wasFirstClassSet];
 }
 
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -8,12 +8,6 @@
 
 #import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 
-typedef NS_ENUM(uint8_t, BSGFirstClass) {
-    BSGFirstClassNo = 0,
-    BSGFirstClassYes = 1,
-    BSGFirstClassUnset = 2,
-};
-
 // Span options allow the user to affect how spans are created.
 OBJC_EXPORT
 @interface BugsnagPerformanceSpanOptions: NSObject
@@ -28,17 +22,17 @@ OBJC_EXPORT
 @property(nonatomic,readwrite) BOOL makeContextCurrent;
 
 // If true, this span will be considered "first class" on the dashboard.
-@property(nonatomic,readwrite) BSGFirstClass isFirstClass;
+@property(nonatomic,readwrite) BOOL isFirstClass;
 
 + (instancetype)optionsWithStartTime:(NSDate *)starttime
                        parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
                   makeContextCurrent:(BOOL)makeContextCurrent
-                        isFirstClass:(BSGFirstClass)isFirstClass;
+                        isFirstClass:(BOOL)isFirstClass;
 
 - (instancetype)initWithStartTime:(NSDate *)starttime
                     parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
                makeContextCurrent:(BOOL)makeContextCurrent
-                     isFirstClass:(BSGFirstClass)isFirstClass;
+                     isFirstClass:(BOOL)isFirstClass;
 
 - (instancetype)clone;
 

--- a/Tests/BugsnagPerformanceTests/BatchTests.mm
+++ b/Tests/BugsnagPerformanceTests/BatchTests.mm
@@ -23,7 +23,7 @@ using namespace bugsnag;
 
 static std::unique_ptr<SpanData> newSpanData() {
     TraceId tid = {.value = 1};
-    return std::make_unique<SpanData>(@"test", tid, 1, 0, 0);
+    return std::make_unique<SpanData>(@"test", tid, 1, 0, 0, false);
 }
 
 - (void)setUp {

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -46,10 +46,30 @@ using namespace bugsnag;
     XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @"Hello"}), (@[@{@"key": @"key", @"value": @{@"stringValue": @"Hello"}}]));
 }
 
+static id findAttributeNamed(NSDictionary *span, NSString *name) {
+    for (NSDictionary *attribute in span[@"attributes"]) {
+        if ([attribute[@"key"] isEqual:name]) {
+            id value = attribute[@"value"][@"stringValue"];
+            if (value != nil) {
+                return value;
+            }
+            value = attribute[@"value"][@"intValue"];
+            if (value != nil) {
+                return [NSNumber numberWithLong:[value longValue]];
+            }
+            value = attribute[@"value"][@"boolValue"];
+            if (value != nil) {
+                return value;
+            }
+        }
+    }
+    return nil;
+}
+
 - (void)testEncodeRequest {
     std::vector<std::unique_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
-    spans.push_back(std::make_unique<SpanData>(@"", tid, 1, 0, CFAbsoluteTimeGetCurrent()));
+    spans.push_back(std::make_unique<SpanData>(@"", tid, 1, 0, CFAbsoluteTimeGetCurrent(), true));
     auto json = OtlpTraceEncoding::encode(spans, @{});
     
     XCTAssertIsKindOfClass(json[@"resourceSpans"], [NSArray class]);
@@ -60,6 +80,30 @@ using namespace bugsnag;
     XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"][0], [NSDictionary class]);
     XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"][0][@"spans"], [NSArray class]);
     XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"][0][@"spans"][0][@"spanId"], [NSString class]);
+
+    NSDictionary *span = json[@"resourceSpans"][0][@"scopeSpans"][0][@"spans"][0];
+    XCTAssertNotNil(span);
+    XCTAssertEqualObjects(findAttributeNamed(span, @"bugsnag.span.first_class"), @YES);
+}
+
+- (void)testEncodeRequest2 {
+    std::vector<std::unique_ptr<SpanData>> spans;
+    TraceId tid = {.value=1};
+    spans.push_back(std::make_unique<SpanData>(@"", tid, 1, 0, CFAbsoluteTimeGetCurrent(), false));
+    auto json = OtlpTraceEncoding::encode(spans, @{});
+    
+    XCTAssertIsKindOfClass(json[@"resourceSpans"], [NSArray class]);
+    XCTAssertIsKindOfClass(json[@"resourceSpans"][0], [NSDictionary class]);
+    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"resource"], [NSDictionary class]);
+    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"resource"][@"attributes"], [NSArray class]);
+    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"], [NSArray class]);
+    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"][0], [NSDictionary class]);
+    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"][0][@"spans"], [NSArray class]);
+    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"][0][@"spans"][0][@"spanId"], [NSString class]);
+
+    NSDictionary *span = json[@"resourceSpans"][0][@"scopeSpans"][0][@"spans"][0];
+    XCTAssertNotNil(span);
+    XCTAssertNil(findAttributeNamed(span, @"bugsnag.span.first_class"));
 }
 
 - (void)testEncodeSpan {
@@ -69,7 +113,7 @@ using namespace bugsnag;
         .hi=0xfedcba9876543210,
         .lo=0x0123456789abcdef
     };
-    SpanData span(@"My span", tid, 0xface, 0, startTime);
+    SpanData span(@"My span", tid, 0xface, 0, startTime, true);
     span.endTime = startTime + 15;
     
     auto json = OtlpTraceEncoding::encode(span);
@@ -86,10 +130,11 @@ using namespace bugsnag;
 
     XCTAssertEqualObjects(json[@"name"], @"My span");
     
-    XCTAssertEqualObjects(json[@"kind"], @"SPAN_KIND_INTERNAL");
+    XCTAssertEqualObjects(json[@"kind"], @1);
     
     XCTAssertEqualObjects(json[@"startTimeUnixNano"], @"1664352000000000000");
     XCTAssertEqualObjects(json[@"endTimeUnixNano"], @"1664352015000000000");
+    XCTAssertEqualObjects(span.attributes[@"bugsnag.span.first_class"], @(true));
 }
 
 - (void)testEncodeSpanWithParent {
@@ -99,7 +144,7 @@ using namespace bugsnag;
         .hi=0xfedcba9876543210,
         .lo=0x0123456789abcdef
     };
-    SpanData span(@"My span", tid, 0xface, 0xcafe, startTime);
+    SpanData span(@"My span", tid, 0xface, 0xcafe, startTime, false);
     span.endTime = startTime + 15;
     
     auto json = OtlpTraceEncoding::encode(span);
@@ -122,6 +167,7 @@ using namespace bugsnag;
     
     XCTAssertEqualObjects(json[@"startTimeUnixNano"], @"1664352000000000000");
     XCTAssertEqualObjects(json[@"endTimeUnixNano"], @"1664352015000000000");
+    XCTAssertNil(span.attributes[@"bugsnag.span.first_class"]);
 }
 
 - (void)testBuildPValueRequestPackage {
@@ -142,7 +188,7 @@ using namespace bugsnag;
 - (void)testBuildUploadPackage {
     std::vector<std::unique_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
-    spans.push_back(std::make_unique<SpanData>(@"test", tid, 1, 0, 0));
+    spans.push_back(std::make_unique<SpanData>(@"test", tid, 1, 0, 0, false));
     auto resourceAttributes = @{};
     auto package = OtlpTraceEncoding::buildUploadPackage(spans, resourceAttributes);
 
@@ -159,7 +205,7 @@ using namespace bugsnag;
 - (void)testPValueHistogram1 {
     std::vector<std::unique_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
-    spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0));
+    spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0, false));
     spans[0]->updateSamplingProbability(0.3);
 
     auto resourceAttributes = @{};
@@ -172,8 +218,8 @@ using namespace bugsnag;
 - (void)testPValueHistogram2 {
     std::vector<std::unique_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
-    spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test2", tid, 2, 0, 0));
+    spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test2", tid, 2, 0, 0, false));
     spans[0]->updateSamplingProbability(0.3);
     spans[1]->updateSamplingProbability(0.1);
 
@@ -187,8 +233,8 @@ using namespace bugsnag;
 - (void)testPValueHistogram2Same {
     std::vector<std::unique_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
-    spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test2", tid, 2, 0, 0));
+    spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test2", tid, 2, 0, 0, false));
     spans[0]->updateSamplingProbability(0.5);
     spans[1]->updateSamplingProbability(0.5);
 
@@ -202,11 +248,11 @@ using namespace bugsnag;
 - (void)testPValueHistogram5 {
     std::vector<std::unique_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
-    spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test2", tid, 2, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test3", tid, 3, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test4", tid, 4, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test5", tid, 5, 0, 0));
+    spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test2", tid, 2, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test3", tid, 3, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test4", tid, 4, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test5", tid, 5, 0, 0, false));
     spans[0]->updateSamplingProbability(0.3);
     spans[1]->updateSamplingProbability(0.1);
     spans[2]->updateSamplingProbability(0.3);
@@ -223,17 +269,17 @@ using namespace bugsnag;
 - (void)testPValueHistogram11 {
     std::vector<std::unique_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
-    spans.push_back(std::make_unique<SpanData>(@"test0", tid, 1, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test1", tid, 2, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test2", tid, 3, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test3", tid, 4, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test4", tid, 5, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test5", tid, 6, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test6", tid, 7, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test7", tid, 8, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test8", tid, 9, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test9", tid, 10, 0, 0));
-    spans.push_back(std::make_unique<SpanData>(@"test10", tid, 11, 0, 0));
+    spans.push_back(std::make_unique<SpanData>(@"test0", tid, 1, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test1", tid, 2, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test2", tid, 3, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test3", tid, 4, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test4", tid, 5, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test5", tid, 6, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test6", tid, 7, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test7", tid, 8, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test8", tid, 9, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test9", tid, 10, 0, 0, false));
+    spans.push_back(std::make_unique<SpanData>(@"test10", tid, 11, 0, 0, false));
     spans[0]->updateSamplingProbability(0.0);
     spans[1]->updateSamplingProbability(0.1);
     spans[2]->updateSamplingProbability(0.2);

--- a/Tests/BugsnagPerformanceTests/SamplerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SamplerTests.mm
@@ -49,7 +49,7 @@ using namespace bugsnag;
     auto numSamplesTries = 1'000;
     auto count = 0;
     for (auto i = 0; i < numSamplesTries; i++) {
-        SpanData spanData(@"a", IdGenerator::generateTraceId(), IdGenerator::generateSpanId(), 0, 0);
+        SpanData spanData(@"a", IdGenerator::generateTraceId(), IdGenerator::generateSpanId(), 0, 0, false);
         if (sampler.sampled(spanData)) {
             count++;
         }

--- a/Tests/BugsnagPerformanceTests/SpanContextStackTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanContextStackTests.mm
@@ -23,7 +23,7 @@ using namespace bugsnag;
 
 static BugsnagPerformanceSpan *newSpan() {
     TraceId tid = {.value = 1};
-    auto data = std::make_unique<SpanData>(@"test", tid, 1, 0, 0);
+    auto data = std::make_unique<SpanData>(@"test", tid, 1, 0, 0, false);
     auto span = std::make_unique<Span>(std::move(data), ^(std::unique_ptr<SpanData>) {});
     return [[BugsnagPerformanceSpan alloc] initWithSpan:std::move(span)];
 }

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -8,7 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
-#import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
+#import "BugsnagPerformanceSpanOptions+Private.h"
 #import "SpanOptions.h"
 
 using namespace bugsnag;
@@ -21,6 +21,7 @@ using namespace bugsnag;
 
 @property(nonatomic,readonly) TraceId traceId;
 @property(nonatomic,readonly) SpanId spanId;
+@property(nonatomic,readonly) bool isValid;
 
 @end
 
@@ -36,16 +37,18 @@ using namespace bugsnag;
     XCTAssertNil(objcOptions.parentContext);
     XCTAssertNil(objcOptions.startTime);
     XCTAssertTrue(objcOptions.makeContextCurrent);
-    XCTAssertEqual(objcOptions.isFirstClass, BSGFirstClassUnset);
+    XCTAssertFalse(objcOptions.isFirstClass);
+    XCTAssertFalse(objcOptions.wasFirstClassSet);
 }
 
 - (void)testConversionDefaults {
     BugsnagPerformanceSpanOptions *objcOptions = [BugsnagPerformanceSpanOptions new];
-    SpanOptions cOptions(objcOptions);
+    SpanOptions cOptions = SpanOptionsForCustom(objcOptions);
     XCTAssertNil(cOptions.parentContext);
     XCTAssertTrue(abs(cOptions.startTime - CFAbsoluteTimeGetCurrent()) < 1);
     XCTAssertTrue(cOptions.makeContextCurrent);
-    XCTAssertEqual(cOptions.isFirstClass, BSGFirstClassUnset);
+    XCTAssertFalse(objcOptions.isFirstClass);
+    XCTAssertFalse(objcOptions.wasFirstClassSet);
 }
 
 - (void)testConversion {
@@ -54,13 +57,41 @@ using namespace bugsnag;
     objcOptions.startTime = [NSDate dateWithTimeIntervalSinceReferenceDate:1.0];
     objcOptions.parentContext = context;
     objcOptions.makeContextCurrent = true;
-    objcOptions.isFirstClass = BSGFirstClassNo;
+    objcOptions.isFirstClass = false;
 
-    SpanOptions cOptions(objcOptions);
+    SpanOptions cOptions = SpanOptionsForCustom(objcOptions);
     XCTAssertEqual(1.0, cOptions.startTime);
     XCTAssertEqual(context, cOptions.parentContext);
     XCTAssertEqual(true, cOptions.makeContextCurrent);
-    XCTAssertEqual(BSGFirstClassNo, cOptions.isFirstClass);
+    XCTAssertFalse(objcOptions.isFirstClass);
+    XCTAssertTrue(objcOptions.wasFirstClassSet);
+
+
+    objcOptions = [BugsnagPerformanceSpanOptions new];
+    objcOptions.startTime = [NSDate dateWithTimeIntervalSinceReferenceDate:1.0];
+    objcOptions.parentContext = context;
+    objcOptions.makeContextCurrent = true;
+    objcOptions.isFirstClass = true;
+
+    cOptions = SpanOptionsForCustom(objcOptions);
+    XCTAssertEqual(1.0, cOptions.startTime);
+    XCTAssertEqual(context, cOptions.parentContext);
+    XCTAssertEqual(true, cOptions.makeContextCurrent);
+    XCTAssertTrue(objcOptions.isFirstClass);
+    XCTAssertTrue(objcOptions.wasFirstClassSet);
+
+
+    objcOptions = [BugsnagPerformanceSpanOptions new];
+    objcOptions.startTime = [NSDate dateWithTimeIntervalSinceReferenceDate:1.0];
+    objcOptions.parentContext = context;
+    objcOptions.makeContextCurrent = true;
+
+    cOptions = SpanOptionsForCustom(objcOptions);
+    XCTAssertEqual(1.0, cOptions.startTime);
+    XCTAssertEqual(context, cOptions.parentContext);
+    XCTAssertEqual(true, cOptions.makeContextCurrent);
+    XCTAssertFalse(objcOptions.isFirstClass);
+    XCTAssertFalse(objcOptions.wasFirstClassSet);
 }
 
 @end

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */; };
 		CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */; };
 		CBE43A9929A8EFA3000B4205 /* ProbabilityExpiryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */; };
+		CBE43A9B29ADF5B5000B4205 /* FirstClassYesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE43A9A29ADF5B5000B4205 /* FirstClassYesScenario.swift */; };
+		CBE43A9D29ADF5C1000B4205 /* FirstClassNoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE43A9C29ADF5C1000B4205 /* FirstClassNoScenario.swift */; };
 		CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
@@ -59,6 +61,8 @@
 		CBAAE25429125F5F006D4AA0 /* Fixture-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fixture-Bridging-Header.h"; sourceTree = "<group>"; };
 		CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingScenario.swift; sourceTree = "<group>"; };
 		CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProbabilityExpiryScenario.swift; sourceTree = "<group>"; };
+		CBE43A9A29ADF5B5000B4205 /* FirstClassYesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstClassYesScenario.swift; sourceTree = "<group>"; };
+		CBE43A9C29ADF5C1000B4205 /* FirstClassNoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstClassNoScenario.swift; sourceTree = "<group>"; };
 		CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSpanScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
 		CBE8EA0B294A220600702950 /* BSGInternalConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSGInternalConfig.h; path = ../../../../Sources/BugsnagPerformance/Private/BSGInternalConfig.h; sourceTree = "<group>"; };
@@ -148,6 +152,8 @@
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
+				CBE43A9A29ADF5B5000B4205 /* FirstClassYesScenario.swift */,
+				CBE43A9C29ADF5C1000B4205 /* FirstClassNoScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -235,6 +241,7 @@
 				0185C47228F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */,
+				CBE43A9D29ADF5C1000B4205 /* FirstClassNoScenario.swift in Sources */,
 				CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */,
 				01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */,
 				01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */,
@@ -248,6 +255,7 @@
 				01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */,
 				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,
+				CBE43A9B29ADF5B5000B4205 /* FirstClassYesScenario.swift in Sources */,
 				01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */,
 				01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */,
 				CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/FirstClassNoScenario.swift
+++ b/features/fixtures/ios/Scenarios/FirstClassNoScenario.swift
@@ -1,0 +1,18 @@
+//
+//  FirstClassNoScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 28.02.23.
+//
+
+import BugsnagPerformance
+
+class FirstClassNoScenario: Scenario {
+    
+    override func run() {
+        waitForCurrentBatch()
+        var opts = BugsnagPerformanceSpanOptions()
+        opts.isFirstClass = false;
+        BugsnagPerformance.startSpan(name: "FirstClassNoScenario", options: opts).end()
+    }
+}

--- a/features/fixtures/ios/Scenarios/FirstClassYesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FirstClassYesScenario.swift
@@ -1,0 +1,16 @@
+//
+//  FirstClassYesScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 28.02.23.
+//
+
+import BugsnagPerformance
+
+class FirstClassYesScenario: Scenario {
+    
+    override func run() {
+        waitForCurrentBatch()
+        BugsnagPerformance.startSpan(name: "FirstClassYesScenario").end()
+    }
+}

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -9,6 +9,7 @@ Feature: Manual creation of spans
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * a span field "name" equals "WillRetry"
     * a span field "name" equals "Success"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually start and end a span
     Given I run "ManualSpanScenario" and discard the initial p-value request
@@ -39,6 +40,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "1.0"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Starting and ending a span before starting the SDK
     Given I run "ManualSpanBeforeStartScenario" and discard the initial p-value request
@@ -53,6 +55,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually report a view load span
     Given I run "ManualViewLoadScenario" and discard the initial p-value request
@@ -68,6 +71,7 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "view_load"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually report a UIViewController load span
     Given I run "ManualUIViewLoadScenario" and discard the initial p-value request
@@ -80,6 +84,7 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "view_load"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually start a network span
     Given I run "ManualNetworkSpanScenario" and discard the initial p-value request
@@ -101,6 +106,7 @@ Feature: Manual creation of spans
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" does not exist
 
   Scenario: Manually start and end a span field "with" batching
     Given I run "BatchingScenario" and discard the initial p-value request
@@ -117,6 +123,7 @@ Feature: Manual creation of spans
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually start and end a span field "with" batching
     Given I run "BatchingScenario" and discard the initial p-value request
@@ -133,6 +140,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually start and end parent and child spans
     Given I run "ParentSpanScenario" and discard the initial p-value request
@@ -145,8 +153,39 @@ Feature: Manual creation of spans
     * a span field "name" equals "SpanChild"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals "SPAN_KIND_INTERNAL"
+    * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     # Note: The child span ends up first in the list of spans.
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span bool attribute "bugsnag.span.first_class" is true
+
+  Scenario: Manually start and end first class span
+    Given I run "FirstClassYesScenario" and discard the initial p-value request
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
+    * every span field "name" equals "FirstClassYesScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
+
+  Scenario: Manually start and end non-first-class span
+    Given I run "FirstClassNoScenario" and discard the initial p-value request
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0"
+    * every span field "name" equals "FirstClassNoScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" does not exist

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -22,3 +22,9 @@ Then('every span field {string} equals {int}') do |key, expected|
   Maze.check.not_includes selected_keys, false
 end
 
+
+Then('every span bool attribute {string} does not exist') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze.check.nil span['attributes'].find { |a| a['key'] == attribute } }
+end
+


### PR DESCRIPTION
## Goal

This PR adds support for the `bugsnag.span.first_class` span attribute.

## Design

Replaced the `BSGFirstClass` enum with two booleans `isFirstClass` and `wasFirstClassSet` because Swift wasn't happy with the enum. `wasFirstClassSet` is internally accessible only.

Special processing of unset `isFirstClass` values is being done in the SpanOptions header for now. The defaults for views will likely be moved to a different file when support for traversing view hierarchies is added later.

## Testing

Added e2e and unit tests.
