### PR TITLE
[PLAT-9798] Simplified BugsnagPerformance.start API

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -29,7 +29,7 @@ class BugsnagPerformanceImpl {
 public:
     BugsnagPerformanceImpl() noexcept;
     
-    bool start(BugsnagPerformanceConfiguration *configuration, NSError **error) noexcept;
+    void start(BugsnagPerformanceConfiguration *configuration) noexcept;
     
     void reportNetworkSpan(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept {
         tracer_.reportNetworkSpan(task, metrics);

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -19,20 +19,12 @@ static BugsnagPerformanceImpl& getImpl() {
     return impl;
 }
 
-+ (BOOL)start:(NSError * __autoreleasing _Nullable *)error {
-    auto config = [BugsnagPerformanceConfiguration loadConfig:error];
-    if (config == nil) {
-        return NO;
-    }
-    return [self startWithConfiguration:config error:error];
++ (void)start {
+    [self startWithConfiguration:[BugsnagPerformanceConfiguration loadConfig]];
 }
 
-+ (BOOL)startWithConfiguration:(BugsnagPerformanceConfiguration *)configuration error:(NSError * __autoreleasing _Nullable *)error {
-    if (![configuration validate:error]) {
-        return NO;
-    }
-
-    return getImpl().start(configuration, error);
++ (void)startWithConfiguration:(BugsnagPerformanceConfiguration *)configuration {
+    getImpl().start(configuration);
 }
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name {

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -19,9 +19,9 @@ OBJC_EXPORT
 
 - (instancetype)init NS_UNAVAILABLE;
 
-+ (BOOL)start:(NSError * __autoreleasing _Nullable *)error NS_SWIFT_NAME(start());
++ (void)start;
 
-+ (BOOL)startWithConfiguration:(BugsnagPerformanceConfiguration *)configuration error:(NSError * __autoreleasing _Nullable *)error NS_SWIFT_NAME(start(configuration:));
++ (void)startWithConfiguration:(BugsnagPerformanceConfiguration *)configuration;
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name NS_SWIFT_NAME(startSpan(name:));
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -21,7 +21,7 @@ OBJC_EXPORT
 
 + (void)start;
 
-+ (void)startWithConfiguration:(BugsnagPerformanceConfiguration *)configuration;
++ (void)startWithConfiguration:(BugsnagPerformanceConfiguration *)configuration NS_SWIFT_NAME(start(configuration:));
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name NS_SWIFT_NAME(startSpan(name:));
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -16,17 +16,17 @@ typedef BOOL (^ BugsnagPerformanceViewControllerInstrumentationCallback)(UIViewC
 OBJC_EXPORT
 @interface BugsnagPerformanceConfiguration : NSObject
 
-- (instancetype _Nullable)initWithApiKey:(NSString *)apiKey error:(NSError **)error NS_SWIFT_NAME(init(apiKey:)) NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithApiKey:(NSString *)apiKey NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-+ (instancetype _Nullable)loadConfig:(NSError **)error NS_SWIFT_NAME(loadConfig());
++ (instancetype)loadConfig;
 
 - (BOOL) validate:(NSError * __autoreleasing _Nullable *)error NS_SWIFT_NAME(validate());
 
 @property (nonatomic) NSString *apiKey;
 
-@property (nonatomic) NSURL *endpoint;
+@property (nonatomic) NSURL *_Nullable endpoint;
 
 @property (nonatomic) BOOL autoInstrumentAppStarts;
 

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
@@ -15,36 +15,40 @@
 
 @implementation BugsnagPerformanceConfigurationTests
 
-- (void)testValidate {
-    // Bad API key format
+- (void)testShouldPassValidationWithCorrectApiKeyAndDefaultEndpoint {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
     NSError *error = nil;
-    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"" error:&error];
-    XCTAssertNotNil(error);
-    XCTAssertNil(config);
-
-    config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"YOUR-API-KEY-HERE" error:&error];
-    XCTAssertNotNil(error);
-    XCTAssertNil(config);
-
-    // Valid looking API key
-    config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef" error:&error];
+    XCTAssertTrue([config validate:&error]);
     XCTAssertNil(error);
-    XCTAssertNotNil(config);
+}
 
-    // Invalid endpoint
-    config.endpoint = (NSURL *_Nonnull)[NSURL URLWithString:@""];
-    [config validate:&error];
+- (void)testShouldNotPassValidationWithAnExceptionWithEmptyApiKeyAndDefaultEndpoint {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@""];
+    NSError *error = nil;
+    XCTAssertThrows([config validate:&error]);
+}
+
+- (void)testShouldNotPassValidationWithInvalidApiKeyAndDefaultEndpoint {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"YOUR-API-KEY-HERE"];
+    NSError *error = nil;
+    XCTAssertFalse([config validate:&error]);
     XCTAssertNotNil(error);
+}
 
-    error = nil;
-    config.endpoint = (NSURL *_Nonnull)[NSURL URLWithString:@"x"];
-    [config validate:&error];
-    XCTAssertNotNil(error);
-
-    // Valid looking URL
+- (void)testShouldPassValidationWithValidApiKeyAndValidCustomEndpoint {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
     config.endpoint = (NSURL *_Nonnull)[NSURL URLWithString:@"http://bugsnag.com"];
-    [config validate:&error];
+    NSError *error = nil;
+    XCTAssertTrue([config validate:&error]);
     XCTAssertNil(error);
+}
+
+- (void)testShouldNotPassValidationWithValidApiKeyAndInvalidCustomEndpoint {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
+    config.endpoint = (NSURL *_Nonnull)[NSURL URLWithString:@"x"];
+    NSError *error = nil;
+    XCTAssertFalse([config validate:&error]);
+    XCTAssertNotNil(error);
 }
 
 @end

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceTests.mm
@@ -16,12 +16,9 @@
 @implementation BugsnagPerformanceTests
 
 - (void)setUp {
-    NSError *error = nil;
-    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef" error:&error];
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
     config.endpoint = [NSURL URLWithString:@"http://localhost"];
-    XCTAssertNil(error);
-    XCTAssertTrue([BugsnagPerformance startWithConfiguration:config error:&error]);
-    XCTAssertNil(error);
+    [BugsnagPerformance startWithConfiguration:config];
 }
 
 - (void)testStartSpanWithName {

--- a/Tests/BugsnagPerformanceTests/ResourceAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/ResourceAttributesTests.mm
@@ -22,7 +22,7 @@ using namespace bugsnag;
 
 - (void)setUp {
     NSError *error = nil;
-    self.config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef" error:&error];
+    self.config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
     XCTAssertNil(error);
     XCTAssertNotNil(self.config);
 }

--- a/Tests/BugsnagPerformanceTestsSwift/ConfigurationTests.swift
+++ b/Tests/BugsnagPerformanceTestsSwift/ConfigurationTests.swift
@@ -3,15 +3,17 @@ import BugsnagPerformance
 
 class ConfigurationTests: XCTestCase {
 
-    func testValidateEmptyAPIKey() throws {
-        XCTAssertThrowsError(try BugsnagPerformanceConfiguration(apiKey: "")) { (error) in
+    func testValidateShouldPassIfAPIKeyIsValid() throws {
+        let config = BugsnagPerformanceConfiguration(apiKey: "0123456789abcdef0123456789abcdef")
+        XCTAssertEqual(config.apiKey, "0123456789abcdef0123456789abcdef")
+        try! config.validate()
+    }
+    
+    func testValidateShouldThrowAnExceptionIfAPIKeyIsNotValid() throws {
+        let config = BugsnagPerformanceConfiguration(apiKey: "FakeKey")
+        XCTAssertThrowsError(try config.validate()) { (error) in
             XCTAssertEqual(error.localizedDescription, "Invalid configuration")
             XCTAssertEqual((error as NSError).code, BugsnagPerformanceConfigurationBadApiKey)
         }
-    }
-
-    func testValidateValidAPIKey() throws {
-        let config = try! BugsnagPerformanceConfiguration(apiKey: "0123456789abcdef0123456789abcdef")
-        XCTAssertEqual(config.apiKey, "0123456789abcdef0123456789abcdef")
     }
 }

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -12,7 +12,7 @@ class Scenario: NSObject {
     
     static let mazeRunnerURL = "http://bs-local.com:9339"
     
-    var config = try! BugsnagPerformanceConfiguration.loadConfig()
+    var config = BugsnagPerformanceConfiguration.loadConfig()
     
     func configure() {
         bsgp_autoTriggerExportOnBatchSize = 1;
@@ -31,7 +31,7 @@ class Scenario: NSObject {
     }
     
     func startBugsnag() {
-        try! BugsnagPerformance.start(configuration: config)
+        BugsnagPerformance.start(configuration: config)
     }
     
     func run() {


### PR DESCRIPTION
## Goal

Simplify BugsnagPerformance.start API

## Changeset

Since there’s only one user-controllable thing that can go wrong when BugsnagPerformance starts, we don’t really need the complication of declared Swift errors and return status values.

## Testing

Unit Tests