### PR TITLE
[PLAT-9823] Re-enable background/foreground status check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.22.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.21.0'
 
 #gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 071e771eec1590a3c31b67fb1a33d0408f95e693
-  tag: v7.22.0
+  revision: 2d2ae80b79c7d7e5d7be4fec819c24dfb3067f60
+  tag: v7.21.0
   specs:
-    bugsnag-maze-runner (7.22.0)
+    bugsnag-maze-runner (7.21.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -93,7 +93,7 @@ GEM
     os (1.0.1)
     power_assert (2.0.3)
     racc (1.6.2)
-    rack (2.2.6.3)
+    rack (2.2.6.4)
     rake (12.3.3)
     regexp_parser (2.7.0)
     rexml (3.2.5)

--- a/Sources/BugsnagPerformance/Private/AppStateTracker.h
+++ b/Sources/BugsnagPerformance/Private/AppStateTracker.h
@@ -12,6 +12,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AppStateTracker : NSObject
 
+- (instancetype)init __attribute__((unavailable("use sharedInstance"))) NS_UNAVAILABLE;
+
++ (instancetype)sharedInstance;
+
+@property(nonatomic,readonly) BOOL isInForeground;
+
 @property(nonatomic,readwrite,strong) void (^onTransitionToForeground)(void);
 
 @end

--- a/Sources/BugsnagPerformance/Private/AppStateTracker.m
+++ b/Sources/BugsnagPerformance/Private/AppStateTracker.m
@@ -20,14 +20,50 @@
 
 @implementation AppStateTracker
 
++ (void)initialize {
+    [self sharedInstance];
+}
+
++ (instancetype)sharedInstance {
+    static id sharedInstance;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self alloc] init];
+    });
+    return sharedInstance;
+}
+
+static BOOL isInForeground(void) {
+#if __has_include(<WatchKit/WatchKit.h>)
+    return WKApplication.sharedApplication.applicationState != WKApplicationStateBackground;
+#elif __has_include(<UIKit/UIKit.h>)
+    return UIApplication.sharedApplication.applicationState != UIApplicationStateBackground;
+#else
+    return YES;
+#endif
+}
+
 - (instancetype) init {
     if ((self = [super init])) {
+        if ([NSThread isMainThread]) {
+            _isInForeground = isInForeground();
+        } else {
+            __block AppStateTracker *blockSelf = self;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                blockSelf->_isInForeground = isInForeground();
+            });
+        }
+
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
 
 #if __has_include(<AppKit/AppKit.h>)
         [notificationCenter addObserver:self
                                selector:@selector(handleAppForegroundEvent)
                                    name:NSApplicationDidBecomeActiveNotification
+                                 object:nil];
+        [notificationCenter addObserver:self
+                               selector:@selector(handleAppBackgroundEvent)
+                                   name:NSApplicationDidResignActiveNotification
                                  object:nil];
 #endif
 
@@ -36,6 +72,10 @@
                                selector:@selector(handleAppForegroundEvent)
                                    name:UIApplicationDidBecomeActiveNotification
                                  object:nil];
+        [notificationCenter addObserver:self
+                               selector:@selector(handleAppBackgroundEvent)
+                                   name:UIApplicationDidEnterBackgroundNotification
+                                 object:nil];
 #endif
 
 #if __has_include(<WatchKit/WatchKit.h>)
@@ -43,16 +83,27 @@
                                selector:@selector(handleAppForegroundEvent)
                                    name:WKApplicationDidBecomeActiveNotification
                                  object:nil];
+        [notificationCenter addObserver:self
+                               selector:@selector(handleAppBackgroundEvent)
+                                   name:WKApplicationDidEnterBackgroundNotification
+                                 object:nil];
 #endif
     }
     return self;
 }
 
 - (void) handleAppForegroundEvent {
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+    _isInForeground = YES;
     void (^callback)(void) = self.onTransitionToForeground;
     if (callback != nil) {
         callback();
     }
+}
+
+- (void) handleAppBackgroundEvent {
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+    _isInForeground = NO;
 }
 
 @end

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -37,7 +37,7 @@ BugsnagPerformanceImpl::BugsnagPerformanceImpl() noexcept
 , sampler_(std::make_shared<Sampler>(initialProbability))
 , tracer_(sampler_, batch_, generateOnSpanStarted(this))
 , persistence_(std::make_shared<Persistence>(getPersistenceDir()))
-, appStateTracker_([AppStateTracker new])
+, appStateTracker_([AppStateTracker sharedInstance])
 , viewControllersToSpans_([NSMapTable mapTableWithKeyOptions:NSMapTableWeakMemory | NSMapTableObjectPointerPersonality
                                                 valueOptions:NSMapTableStrongMemory])
 {}

--- a/Sources/BugsnagPerformance/Private/SpanAttributes.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributes.mm
@@ -9,26 +9,9 @@
 #import "SpanAttributes.h"
 
 #import "Reachability.h"
-
-#import <UIKit/UIKit.h>
+#import "AppStateTracker.h"
 
 using namespace bugsnag;
-
-//static bool appInForeground() noexcept {
-//    auto inner = [](){
-//        return UIApplication.sharedApplication.applicationState != UIApplicationStateBackground;
-//    };
-//
-//    if ([NSThread isMainThread]) {
-//        return inner();
-//    }
-//
-//    bool __block result;
-//    dispatch_sync(dispatch_get_main_queue(), ^{
-//        result = inner();
-//    });
-//    return result;
-//}
 
 static NSString *hostConnectionType() noexcept {
     switch (Reachability::get().getConnectivity()) {
@@ -42,7 +25,7 @@ static NSString *hostConnectionType() noexcept {
 NSDictionary *
 SpanAttributes::get() noexcept {
     return @{
-//        @"bugsnag.app.in_foreground": appInForeground() ? @YES : @NO,
+        @"bugsnag.app.in_foreground": @(AppStateTracker.sharedInstance.isInForeground),
         
         // https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#network-transport-attributes
         @"net.host.connection.type": hostConnectionType(),

--- a/features/fixtures/ios/Scenarios/BackgroundForegroundScenario.swift
+++ b/features/fixtures/ios/Scenarios/BackgroundForegroundScenario.swift
@@ -8,20 +8,21 @@
 import BugsnagPerformance
 
 class BackgroundForegroundScenario: Scenario {
-    
+    var backgroundTask: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier.invalid
+
     override func configure() {
         super.configure()
         bsgp_autoTriggerExportOnBatchSize = 100
         bsgp_performWorkInterval = 1000
     }
     
-//    override func startBugsnag() {
-//        BugsnagPerformance.startSpan(name: "Pre-start").end()
-//        super.startBugsnag()
-//    }
+    func onBackgrounded() {
+        BugsnagPerformance.startSpan(name: "BackgroundForegroundScenario").end()
+    }
 
     override func run() {
-        waitForCurrentBatch()
-        BugsnagPerformance.startSpan(name: "BackgroundForegroundScenario").end()
+        NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) { _ in
+            BugsnagPerformance.startSpan(name: "BackgroundForegroundScenario").end()
+        }
     }
 }

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -24,8 +24,7 @@ Feature: Manual creation of spans
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
-    # TODO: Disabled until bugsnag.app.in_foreground is made safe
-    # * every span bool attribute "bugsnag.app.in_foreground" is true
+    * every span bool attribute "bugsnag.app.in_foreground" is true
     * every span string attribute "net.host.connection.type" equals "wifi"
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" equals "1"
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -22,3 +22,7 @@ Then('every span field {string} equals {int}') do |key, expected|
   Maze.check.not_includes selected_keys, false
 end
 
+Then('every span bool attribute {string} is false') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze::check.false span['attributes'].find { |a| a['key'] == attribute }['value']['boolValue'] }
+end

--- a/features/triggers.feature
+++ b/features/triggers.feature
@@ -12,3 +12,4 @@ Feature: Automatic send triggers
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.app.in_foreground" is false


### PR DESCRIPTION
## Goal

The old background status check dispatched to the main queue and waited, but if the code that calls `BugsnagPerformanc.start` waits on the main thread, we deadlock.

The new design uses `NSNotificationCenter` as well as a check at the earliest point in the Objective-C runtime initialization so that this can be avoided.

## Design

`AppStateTracker` now keeps a boolean value containing the latest updated app background state in addition to its existing callback responsibility.

The initial state is grabbed during `initialize` so that it must run on the main thread. After that, all updates are done via `NSNotificationCenter`.

## Testing

Re-enabled and enhanced app background state tests.
