### PR TITLE
Import main dispatch header rather than dispatch/time.h

### DIFF
--- a/Sources/BugsnagPerformance/Private/BSGInternalConfig.h
+++ b/Sources/BugsnagPerformance/Private/BSGInternalConfig.h
@@ -10,7 +10,7 @@
 #define BSGInternalConfig_h
 
 #include <stdint.h>
-#include <dispatch/time.h>
+#include <dispatch/dispatch.h>
 #include <CoreFoundation/CFDate.h>
 
 #ifdef __OBJC__


### PR DESCRIPTION
## Goal

Some clients are getting compile time errors because our code is importing `dispatch/time.h`.

## Changeset

Import `dispatch/dispatch.h` instead, as per the error message.
