### PR TITLE
[PLAT-9830] Enable UBSan and malloc scribble on the example app and the maze runner app

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/BugsnagPerformance.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/BugsnagPerformance.xcscheme
@@ -58,12 +58,26 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
+      enableASanStackUseAfterReturn = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		011C69E128F5CA1E00C5BA3C /* IgnoredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011C69E028F5CA1E00C5BA3C /* IgnoredViewController.swift */; };
 		0185C46728F6C04B006F9BDC /* ExampleLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 0185C46628F6C04B006F9BDC /* ExampleLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB572EF429C1B96100FD7A2A /* AnotherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011C69DE28F57F1500C5BA3C /* AnotherViewController.swift */; };
+		CBC90C4029C45DCB00280884 /* ForceUBSan.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC90C3F29C45DCB00280884 /* ForceUBSan.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +36,9 @@
 		011C69E028F5CA1E00C5BA3C /* IgnoredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoredViewController.swift; sourceTree = "<group>"; };
 		0185C46428F6C04B006F9BDC /* ExampleLibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ExampleLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0185C46628F6C04B006F9BDC /* ExampleLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExampleLibrary.h; sourceTree = "<group>"; };
+		CBC90C3D29C45DCB00280884 /* Example-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Example-Bridging-Header.h"; sourceTree = "<group>"; };
+		CBC90C3E29C45DCB00280884 /* ForceUBSan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForceUBSan.h; sourceTree = "<group>"; };
+		CBC90C3F29C45DCB00280884 /* ForceUBSan.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ForceUBSan.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,6 +92,9 @@
 				010656B028DB2E8E00F2A9A6 /* Assets.xcassets */,
 				010656B228DB2E8E00F2A9A6 /* LaunchScreen.storyboard */,
 				010656B528DB2E8E00F2A9A6 /* Info.plist */,
+				CBC90C3E29C45DCB00280884 /* ForceUBSan.h */,
+				CBC90C3F29C45DCB00280884 /* ForceUBSan.m */,
+				CBC90C3D29C45DCB00280884 /* Example-Bridging-Header.h */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -180,6 +187,7 @@
 				TargetAttributes = {
 					010656A328DB2E8C00F2A9A6 = {
 						CreatedOnToolsVersion = 14.0;
+						LastSwiftMigration = 1420;
 					};
 					0185C46328F6C04B006F9BDC = {
 						CreatedOnToolsVersion = 14.0.1;
@@ -231,6 +239,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				011C69DD28F5747200C5BA3C /* SomeView.swift in Sources */,
+				CBC90C4029C45DCB00280884 /* ForceUBSan.m in Sources */,
 				010656AC28DB2E8C00F2A9A6 /* ViewController.swift in Sources */,
 				CB572EF429C1B96100FD7A2A /* AnotherViewController.swift in Sources */,
 				010656A828DB2E8C00F2A9A6 /* AppDelegate.swift in Sources */,
@@ -387,6 +396,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 372ZUL2ZB7;
@@ -405,6 +415,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Example/Example-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -415,6 +427,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 372ZUL2ZB7;
@@ -433,6 +446,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Example/Example-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -34,6 +34,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
+      enableASanStackUseAfterReturn = "YES"
+      enableUBSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -50,6 +53,13 @@
             ReferencedContainer = "container:Example.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Example/Example-Bridging-Header.h
+++ b/Example/Example/Example-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/Example/Example/ForceUBSan.h
+++ b/Example/Example/ForceUBSan.h
@@ -1,0 +1,20 @@
+//
+//  ForceUBSan.h
+//  Example
+//
+//  Created by Karl Stenerud on 17.03.23.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// This file exists solely to force the Xcode scheme to allow UBSan to run.
+// The UB sanitizer is forcibly disabled if Xcode thinks it's a Swift-only project.
+// Linking in a non-swift framework isn't enough to convince it.
+
+@interface ForceUBSan : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/Example/ForceUBSan.m
+++ b/Example/Example/ForceUBSan.m
@@ -1,0 +1,16 @@
+//
+//  ForceUBSan.m
+//  Example
+//
+//  Created by Karl Stenerud on 17.03.23.
+//
+
+#import "ForceUBSan.h"
+
+@implementation ForceUBSan
+
++ (void)forceUBSan {
+    
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/Batch.h
+++ b/Sources/BugsnagPerformance/Private/Batch.h
@@ -74,8 +74,8 @@ public:
     }
 
 private:
-    void (^onBatchFull)();
-    bool drainIsAllowed_;
+    void (^onBatchFull)(){nullptr};
+    bool drainIsAllowed_{false};
     std::mutex mutex_;
     std::unique_ptr<std::vector<std::unique_ptr<SpanData>>> spans_;
 };

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -56,24 +56,24 @@ public:
     void onSpanStarted() noexcept;
 
 private:
-    bool started_;
+    bool started_{false};
     std::mutex instanceMutex_;
     std::shared_ptr<Batch> batch_;
     std::shared_ptr<class Sampler> sampler_;
     Tracer tracer_;
-    Worker *worker_;
+    Worker *worker_{nil};
     std::shared_ptr<Persistence> persistence_;
     std::shared_ptr<PersistentState> persistentState_;
     std::shared_ptr<OtlpUploader> uploader_;
     std::unique_ptr<RetryQueue> retryQueue_;
-    NSDictionary *resourceAttributes_;
-    std::atomic<bool> shouldPersistState_;
+    NSDictionary *resourceAttributes_{nil};
+    std::atomic<bool> shouldPersistState_{false};
     std::mutex viewControllersToSpansMutex_;
     NSMapTable<UIViewController *, BugsnagPerformanceSpan *> *viewControllersToSpans_;
-    CFAbsoluteTime probabilityExpiry_;
-    CFAbsoluteTime pausePValueRequestsUntil_;
-    NSTimer *workerTimer_;
-    AppStateTracker *appStateTracker_;
+    CFAbsoluteTime probabilityExpiry_{0};
+    CFAbsoluteTime pausePValueRequestsUntil_{0};
+    NSTimer *workerTimer_{nil};
+    AppStateTracker *appStateTracker_{nil};
 
     // Tasks
     NSArray<Task> *buildInitialTasks();

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
@@ -30,6 +30,6 @@ private:
     void reportSpan(CFAbsoluteTime endTime) noexcept;
     
     class Tracer &tracer_;
-    bool isCold_;
+    bool isCold_{false};
 };
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -31,7 +31,7 @@ private:
     void onViewDidAppear(UIViewController *viewController) noexcept;
     
     class Tracer &tracer_;
-    BOOL (^ callback_)(UIViewController *viewController) = nullptr;
-    NSSet *observedClasses_ = nil;
+    BOOL (^ callback_)(UIViewController *viewController){nullptr};
+    NSSet *observedClasses_{nil};
 };
 }

--- a/Sources/BugsnagPerformance/Private/OtlpPackage.h
+++ b/Sources/BugsnagPerformance/Private/OtlpPackage.h
@@ -33,15 +33,15 @@ public:
 
     NSData *serialize() noexcept;
 
-    const dispatch_time_t timestamp;
+    const dispatch_time_t timestamp{0};
 
 
 private:
     friend bool operator==(const OtlpPackage &lhs, const OtlpPackage &rhs);
     OtlpPackage() = delete;
 
-    const NSData *payload_;
-    const NSDictionary *headers_;
+    const NSData *payload_{nil};
+    const NSDictionary *headers_{nil};
 
 public: // For testing only
     const NSData *getPayloadForUnitTest() {return payload_;}

--- a/Sources/BugsnagPerformance/Private/OtlpUploader.h
+++ b/Sources/BugsnagPerformance/Private/OtlpUploader.h
@@ -33,9 +33,9 @@ public:
     void upload(OtlpPackage &package, UploadResultCallback callback) noexcept override;
 
 private:
-    const NSURL *endpoint_;
-    NSString *apiKey_;
-    NewProbabilityCallback newProbabilityCallback_;
+    const NSURL *endpoint_{nil};
+    NSString *apiKey_{nil};
+    NewProbabilityCallback newProbabilityCallback_{nullptr};
 
     UploadResult getUploadResult(NSURLResponse *response) const;
     double getNewProbability(NSURLResponse *response) const;

--- a/Sources/BugsnagPerformance/Private/Persistence.h
+++ b/Sources/BugsnagPerformance/Private/Persistence.h
@@ -20,7 +20,7 @@ public:
     NSError *clear(void) noexcept;
     NSString *topLevelDirectory(void) noexcept;
 private:
-    NSString *topLevelDir_;
+    NSString *topLevelDir_{nil};
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/PersistentState.h
+++ b/Sources/BugsnagPerformance/Private/PersistentState.h
@@ -32,10 +32,10 @@ public:
      */
     NSError *load() noexcept;
 private:
-    NSString *jsonFilePath_;
-    NSString *persistentStateDir_;
-    double probability_;
-    void (^onPersistenceNeeded_)();
+    NSString *jsonFilePath_{nil};
+    NSString *persistentStateDir_{nil};
+    double probability_{0};
+    void (^onPersistenceNeeded_)(){nil};
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/ResourceAttributes.h
+++ b/Sources/BugsnagPerformance/Private/ResourceAttributes.h
@@ -20,6 +20,6 @@ public:
     NSDictionary *get() noexcept;
     
 private:
-    NSString *releaseStage_;
+    NSString *releaseStage_{nil};
 };
 }

--- a/Sources/BugsnagPerformance/Private/RetryQueue.h
+++ b/Sources/BugsnagPerformance/Private/RetryQueue.h
@@ -55,8 +55,8 @@ public:
     }
 
 private:
-    NSString *baseDir_;
-    void (^onFilesystemError)();
+    NSString *baseDir_{nil};
+    void (^onFilesystemError)(){nullptr};
 
     void remove(NSString *filename) noexcept;
     NSString *fullPath(NSString *filename) noexcept;

--- a/Sources/BugsnagPerformance/Private/Sampler.h
+++ b/Sources/BugsnagPerformance/Private/Sampler.h
@@ -48,6 +48,6 @@ public:
     sampled(std::unique_ptr<std::vector<std::unique_ptr<SpanData>>> spans) noexcept;
 
 private:
-    double probability_;
+    double probability_{0};
 };
 }

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -47,7 +47,7 @@ public:
 
 private:
     std::unique_ptr<SpanData> data_;
-    OnSpanEnd onEnd_;
+    OnSpanEnd onEnd_{nil};
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/SpanData.h
+++ b/Sources/BugsnagPerformance/Private/SpanData.h
@@ -26,13 +26,13 @@ public:
     
     void updateSamplingProbability(double value) noexcept;
     
-    TraceId traceId;
-    SpanId spanId;
-    NSString *name;
-    SpanKind kind = SPAN_KIND_INTERNAL;
-    NSMutableDictionary *attributes;
-    double samplingProbability;
-    CFAbsoluteTime startTime;
-    CFAbsoluteTime endTime = 0;
+    TraceId traceId{0};
+    SpanId spanId{0};
+    NSString *name{nil};
+    SpanKind kind{SPAN_KIND_INTERNAL};
+    NSMutableDictionary *attributes{nil};
+    double samplingProbability{0};
+    CFAbsoluteTime startTime{0};
+    CFAbsoluteTime endTime{0};
 };
 }

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -37,10 +37,10 @@ public:
     , isFirstClass(options.isFirstClass)
     {}
     
-    id<BugsnagPerformanceSpanContext> parentContext;
-    CFAbsoluteTime startTime;
-    bool makeContextCurrent;
-    BSGFirstClass isFirstClass;
+    id<BugsnagPerformanceSpanContext> parentContext{nil};
+    CFAbsoluteTime startTime{0};
+    bool makeContextCurrent{false};
+    BSGFirstClass isFirstClass{BSGFirstClassUnset};
 };
 
 static inline SpanOptions defaultSpanOptionsForCustom() {

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -46,7 +46,7 @@ private:
     std::unique_ptr<class NetworkInstrumentation> networkInstrumentation_;
     
     std::shared_ptr<Batch> batch_;
-    void (^onSpanStarted_)();
+    void (^onSpanStarted_)(){nil};
     
     void tryAddSpanToBatch(std::unique_ptr<SpanData> spanData);
 };

--- a/Sources/BugsnagPerformance/Private/Version.h
+++ b/Sources/BugsnagPerformance/Private/Version.h
@@ -9,4 +9,4 @@
 #pragma once
 
 #define TELEMETRY_SDK_NAME "bugsnag.performance.cocoa"
-#define TELEMETRY_SDK_VERSION "0.1.0"
+#define TELEMETRY_SDK_VERSION "0.1.3"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */; };
 		CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */; };
 		CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */; };
+		CBC90C4329C466BD00280884 /* ForceUBSan.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC90C4229C466BD00280884 /* ForceUBSan.m */; };
 		CBE43A9929A8EFA3000B4205 /* ProbabilityExpiryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
@@ -59,6 +60,8 @@
 		CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualUIViewLoadScenario.swift; sourceTree = "<group>"; };
 		CBAAE25429125F5F006D4AA0 /* Fixture-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fixture-Bridging-Header.h"; sourceTree = "<group>"; };
 		CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingScenario.swift; sourceTree = "<group>"; };
+		CBC90C4129C466BD00280884 /* ForceUBSan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForceUBSan.h; sourceTree = "<group>"; };
+		CBC90C4229C466BD00280884 /* ForceUBSan.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ForceUBSan.m; sourceTree = "<group>"; };
 		CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProbabilityExpiryScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
 		CBE8EA0B294A220600702950 /* BSGInternalConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSGInternalConfig.h; path = ../../../../Sources/BugsnagPerformance/Private/BSGInternalConfig.h; sourceTree = "<group>"; };
@@ -148,6 +151,8 @@
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
 				CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */,
+				CBC90C4129C466BD00280884 /* ForceUBSan.h */,
+				CBC90C4229C466BD00280884 /* ForceUBSan.m */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -250,6 +255,7 @@
 				CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,
 				01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */,
+				CBC90C4329C466BD00280884 /* ForceUBSan.m in Sources */,
 				01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/features/fixtures/ios/Fixture.xcodeproj/xcshareddata/xcschemes/Fixture.xcscheme
+++ b/features/fixtures/ios/Fixture.xcodeproj/xcshareddata/xcschemes/Fixture.xcscheme
@@ -34,6 +34,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
+      enableASanStackUseAfterReturn = "YES"
+      enableUBSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -50,6 +53,18 @@
             ReferencedContainer = "container:Fixture.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/features/fixtures/ios/Scenarios/ForceUBSan.h
+++ b/features/fixtures/ios/Scenarios/ForceUBSan.h
@@ -1,0 +1,20 @@
+//
+//  ForceUBSan.h
+//  Fixture
+//
+//  Created by Karl Stenerud on 17.03.23.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// This file exists solely to force the Xcode scheme to allow UBSan to run.
+// The UB sanitizer is forcibly disabled if Xcode thinks it's a Swift-only project.
+// Linking in a non-swift framework isn't enough to convince it.
+
+@interface ForceUBSan : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios/Scenarios/ForceUBSan.m
+++ b/features/fixtures/ios/Scenarios/ForceUBSan.m
@@ -1,0 +1,12 @@
+//
+//  ForceUBSan.m
+//  Fixture
+//
+//  Created by Karl Stenerud on 17.03.23.
+//
+
+#import "ForceUBSan.h"
+
+@implementation ForceUBSan
+
+@end


### PR DESCRIPTION
## Goal

Some of the C++ objects weren't initializing their members, resulting in undefined behaviour.

This PR adds default initializers to all C++ members that are not `std::something` (those types have default initializers already).

The example app and maze runner fixture have also been modified to turn on every sanitizer possible.
