### PR TITLE
Fix compile issue with mac catalyst targets

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		CB7FD935299D330500499E13 /* SpanOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpanOptions.h; sourceTree = "<group>"; };
 		CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCUtils.h; sourceTree = "<group>"; };
 		CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCUtils.mm; sourceTree = "<group>"; };
+		CBC90C4429C84DEB00280884 /* Targets.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Targets.h; sourceTree = "<group>"; };
 		CBE8EA07294A20ED00702950 /* BSGInternalConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGInternalConfig.h; sourceTree = "<group>"; };
 		CBE8EA08294A20ED00702950 /* BSGInternalConfig.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BSGInternalConfig.c; sourceTree = "<group>"; };
 		CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceImpl.h; sourceTree = "<group>"; };
@@ -346,6 +347,7 @@
 				0122C22129019770002D243C /* SpanData.mm */,
 				0122C22329019770002D243C /* SpanKind.h */,
 				CB7FD935299D330500499E13 /* SpanOptions.h */,
+				CBC90C4429C84DEB00280884 /* Targets.h */,
 				0122C23329019770002D243C /* Tracer.h */,
 				0122C22529019770002D243C /* Tracer.mm */,
 				CBF621052919418F004BEE0B /* Uploader.h */,
@@ -407,10 +409,10 @@
 				01A414C42912B93F003152A4 /* ResourceAttributesTests.mm */,
 				CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */,
 				01A58C10290931A5006E4DF7 /* SamplerTests.mm */,
-				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
-				CB7FD928299BA5AD00499E13 /* ViewControllerSpanTests.mm */,
 				CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */,
 				CB747D20299E5458003CA1B4 /* TimeTests.mm */,
+				CB7FD928299BA5AD00499E13 /* ViewControllerSpanTests.mm */,
+				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
 			);
 			path = BugsnagPerformanceTests;
 			sourceTree = "<group>";

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.21.0'
+gem 'bugsnag-maze-runner', '~>7.0'
 
 #gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,16 @@
-GIT
-  remote: https://github.com/bugsnag/maze-runner
-  revision: 2d2ae80b79c7d7e5d7be4fec819c24dfb3067f60
-  tag: v7.21.0
+GEM
+  remote: https://rubygems.org/
   specs:
-    bugsnag-maze-runner (7.21.0)
+    appium_lib (12.0.1)
+      appium_lib_core (~> 5.0)
+      nokogiri (~> 1.8, >= 1.8.1)
+      tomlrb (>= 1.1, < 3.0)
+    appium_lib_core (5.4.0)
+      faye-websocket (~> 0.11.0)
+      selenium-webdriver (~> 4.2, < 4.6)
+    bugsnag (6.25.2)
+      concurrent-ruby (~> 1.0)
+    bugsnag-maze-runner (7.22.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -19,19 +26,6 @@ GIT
       selenium-webdriver (~> 4.0)
       test-unit (~> 3.5.2)
       webrick (~> 1.7.0)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    appium_lib (12.0.1)
-      appium_lib_core (~> 5.0)
-      nokogiri (~> 1.8, >= 1.8.1)
-      tomlrb (>= 1.1, < 3.0)
-    appium_lib_core (5.4.0)
-      faye-websocket (~> 0.11.0)
-      selenium-webdriver (~> 4.2, < 4.6)
-    bugsnag (6.25.2)
-      concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (4.1.0)
     concurrent-ruby (1.2.2)
@@ -84,10 +78,8 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
-    mini_portile2 (2.8.1)
     multi_test (0.1.2)
-    nokogiri (1.14.2)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -116,10 +108,10 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-20
 
 DEPENDENCIES
-  bugsnag-maze-runner!
+  bugsnag-maze-runner (~> 7.0)
 
 BUNDLED WITH
-   2.3.21
+   2.2.32

--- a/Sources/BugsnagPerformance/Private/AppStateTracker.m
+++ b/Sources/BugsnagPerformance/Private/AppStateTracker.m
@@ -7,14 +7,15 @@
 //
 
 #import "AppStateTracker.h"
+#import "Targets.h"
 
-#if __has_include(<UIKit/UIKit.h>)
+#if BSG_TARGET_UIKIT
 #import <UIKit/UIKit.h>
 #endif
-#if __has_include(<AppKit/AppKit.h>)
+#if BSG_TARGET_APPKIT
 #import <AppKit/AppKit.h>
 #endif
-#if __has_include(<WatchKit/WatchKit.h>)
+#if BSG_TARGET_WATCHKIT
 #import <WatchKit/WatchKit.h>
 #endif
 
@@ -34,9 +35,9 @@
 }
 
 static BOOL isInForeground(void) {
-#if __has_include(<WatchKit/WatchKit.h>)
+#if BSG_TARGET_WATCHKIT
     return WKApplication.sharedApplication.applicationState != WKApplicationStateBackground;
-#elif __has_include(<UIKit/UIKit.h>)
+#elif BSG_TARGET_UIKIT
     return UIApplication.sharedApplication.applicationState != UIApplicationStateBackground;
 #else
     return YES;
@@ -56,7 +57,7 @@ static BOOL isInForeground(void) {
 
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
 
-#if __has_include(<AppKit/AppKit.h>)
+#if BSG_TARGET_APPKIT
         [notificationCenter addObserver:self
                                selector:@selector(handleAppForegroundEvent)
                                    name:NSApplicationDidBecomeActiveNotification
@@ -67,7 +68,7 @@ static BOOL isInForeground(void) {
                                  object:nil];
 #endif
 
-#if __has_include(<UIKit/UIKit.h>)
+#if BSG_TARGET_UIKIT
         [notificationCenter addObserver:self
                                selector:@selector(handleAppForegroundEvent)
                                    name:UIApplicationDidBecomeActiveNotification
@@ -78,7 +79,7 @@ static BOOL isInForeground(void) {
                                  object:nil];
 #endif
 
-#if __has_include(<WatchKit/WatchKit.h>)
+#if BSG_TARGET_WATCHKIT
         [notificationCenter addObserver:self
                                selector:@selector(handleAppForegroundEvent)
                                    name:WKApplicationDidBecomeActiveNotification

--- a/Sources/BugsnagPerformance/Private/Targets.h
+++ b/Sources/BugsnagPerformance/Private/Targets.h
@@ -1,0 +1,18 @@
+//
+//  Targets.h
+//  BugsnagPerformance
+//
+//  Created by Karl Stenerud on 20.03.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+// Targets based on what technologis they use.
+// We can't depend on includes being present or not because catalyst target will have a crippled appkit include.
+
+#define BSG_TARGET_UIKIT (TARGET_OS_IOS || TARGET_OS_MACCATALYST || TARGET_OS_TV)
+
+#define BSG_TARGET_WATCHKIT (TARGET_OS_WATCH)
+
+#define BSG_TARGET_APPKIT (TARGET_OS_OSX)


### PR DESCRIPTION
## Goal

Using `#if __has_include(<AppKit/AppKit.h>)` breaks on mac catalyst targets because they do have an appkit include that lacks most of appkit.

## Changeset

* Use the `TARGET_OS_xyz` defines as a base instead.
* Build new conditionals that target technologies rather than platforms.
* Put the checks in a centralized `Targets.h` to avoid future copypasta bugs.
