### PR TITLE
[Plat 9654] Add full support for the first_class span attribute

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -312,14 +312,14 @@ static inline void possiblyMakeSpanCurrent(BugsnagPerformanceSpan *span, SpanOpt
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name) {
     auto options = defaultSpanOptionsForCustom();
-    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:tracer_.startSpan(name, options)];
+    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:tracer_.startSpan(name, options, BSGFirstClassYes)];
     possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name, BugsnagPerformanceSpanOptions *optionsIn) {
     auto options = SpanOptions(optionsIn);
-    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:tracer_.startSpan(name, options)];
+    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:tracer_.startSpan(name, options, BSGFirstClassYes)];
     possiblyMakeSpanCurrent(span, options);
     return span;
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -101,7 +101,7 @@ AppStartupInstrumentation::reportSpan(CFAbsoluteTime endTime) noexcept {
     auto name = isCold_ ? @"AppStart/Cold" : @"AppStart/Warm";
     auto options = defaultSpanOptionsForInternal();
     options.startTime = startTime;
-    auto span = tracer_.startSpan(name, options);
+    auto span = tracer_.startSpan(name, options, BSGFirstClassUnset);
     span->addAttributes(@{
         @"bugsnag.app_start.type": isCold_ ? @"cold" : @"warm",
         @"bugsnag.span.category": @"app_start",

--- a/Sources/BugsnagPerformance/Private/SpanData.h
+++ b/Sources/BugsnagPerformance/Private/SpanData.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 
 #import "IdGenerator.h"
 #import "SpanKind.h"
@@ -18,7 +19,12 @@ namespace bugsnag {
  */
 class SpanData {
 public:
-    SpanData(NSString *name, TraceId traceId, SpanId spanId, SpanId parentId, CFAbsoluteTime startTime) noexcept;
+    SpanData(NSString *name,
+             TraceId traceId,
+             SpanId spanId,
+             SpanId parentId,
+             CFAbsoluteTime startTime,
+             BSGFirstClass firstClass) noexcept;
     
     SpanData(const SpanData&) = delete;
     
@@ -35,5 +41,6 @@ public:
     double samplingProbability{0};
     CFAbsoluteTime startTime{0};
     CFAbsoluteTime endTime{0};
+    BSGFirstClass firstClass{BSGFirstClassUnset};
 };
 }

--- a/Sources/BugsnagPerformance/Private/SpanData.mm
+++ b/Sources/BugsnagPerformance/Private/SpanData.mm
@@ -9,7 +9,12 @@
 
 using namespace bugsnag;
 
-SpanData::SpanData(NSString *name, TraceId traceId, SpanId spanId, SpanId parentId, CFAbsoluteTime startTime) noexcept
+SpanData::SpanData(NSString *name,
+                   TraceId traceId,
+                   SpanId spanId,
+                   SpanId parentId,
+                   CFAbsoluteTime startTime,
+                   BSGFirstClass firstClass) noexcept
 : traceId(traceId)
 , spanId(spanId)
 , parentId(parentId)
@@ -17,7 +22,11 @@ SpanData::SpanData(NSString *name, TraceId traceId, SpanId spanId, SpanId parent
 , attributes([NSMutableDictionary dictionary])
 , samplingProbability(1.0)
 , startTime(startTime)
+, firstClass(firstClass)
 {
+    if (firstClass != BSGFirstClassUnset) {
+        attributes[@"bugsnag.span.first_class"] = @(firstClass == BSGFirstClassYes);
+    }
 }
 
 void

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -23,18 +23,18 @@ public:
     SpanOptions(id<BugsnagPerformanceSpanContext> parentContext,
                 CFAbsoluteTime startTime,
                 bool makeContextCurrent,
-                BSGFirstClass isFirstClass)
+                BSGFirstClass firstClass)
     : parentContext(parentContext)
     , startTime(startTime)
     , makeContextCurrent(makeContextCurrent)
-    , isFirstClass(isFirstClass)
+    , firstClass(firstClass)
     {}
     
     SpanOptions(BugsnagPerformanceSpanOptions *options)
     : SpanOptions(options.parentContext,
                   defaultTimeIfNil(options.startTime),
                   options.makeContextCurrent,
-                  options.isFirstClass)
+                  options.firstClass)
     {}
     
     SpanOptions()
@@ -48,7 +48,7 @@ public:
     id<BugsnagPerformanceSpanContext> parentContext{nil};
     CFAbsoluteTime startTime{0};
     bool makeContextCurrent{false};
-    BSGFirstClass isFirstClass{BSGFirstClassUnset};
+    BSGFirstClass firstClass{BSGFirstClassUnset};
 };
 
 static inline SpanOptions defaultSpanOptionsForCustom() {

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -31,7 +31,7 @@ public:
     
     void start(BugsnagPerformanceConfiguration *configuration) noexcept;
     
-    std::unique_ptr<class Span> startSpan(NSString *name, SpanOptions options) noexcept;
+    std::unique_ptr<class Span> startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
     
     std::unique_ptr<class Span> startViewLoadSpan(BugsnagPerformanceViewType viewType,
                                                   NSString *className,

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -13,11 +13,11 @@
 + (instancetype)optionsWithStartTime:(NSDate *)startTime
                        parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
                   makeContextCurrent:(BOOL)makeContextCurrent
-                        isFirstClass:(BSGFirstClass)isFirstClass {
+                          firstClass:(BSGFirstClass)firstClass {
     return [[self alloc] initWithStartTime:startTime
                              parentContext:parentContext
                         makeContextCurrent:makeContextCurrent
-                              isFirstClass:isFirstClass];
+                                firstClass:firstClass];
 }
 
 - (instancetype)init {
@@ -25,18 +25,18 @@
     return [self initWithStartTime:nil
                      parentContext:nil
                 makeContextCurrent:true
-                      isFirstClass:BSGFirstClassUnset];
+                        firstClass:BSGFirstClassUnset];
 }
 
 - (instancetype)initWithStartTime:(NSDate *)startTime
                     parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
                makeContextCurrent:(BOOL)makeContextCurrent
-                     isFirstClass:(BSGFirstClass)isFirstClass {
+                       firstClass:(BSGFirstClass)firstClass {
     if ((self = [super init])) {
         _startTime = startTime;
         _parentContext = parentContext;
         _makeContextCurrent = makeContextCurrent;
-        _isFirstClass = isFirstClass;
+        _firstClass = firstClass;
     }
     return self;
 }
@@ -46,7 +46,7 @@
     return [BugsnagPerformanceSpanOptions optionsWithStartTime:_startTime
                                                  parentContext:_parentContext
                                             makeContextCurrent:_makeContextCurrent
-                                                  isFirstClass:_isFirstClass];
+                                                    firstClass:_firstClass];
 }
 
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -28,17 +28,17 @@ OBJC_EXPORT
 @property(nonatomic,readwrite) BOOL makeContextCurrent;
 
 // If true, this span will be considered "first class" on the dashboard.
-@property(nonatomic,readwrite) BSGFirstClass isFirstClass;
+@property(nonatomic,readwrite) BSGFirstClass firstClass;
 
 + (instancetype)optionsWithStartTime:(NSDate *)starttime
                        parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
                   makeContextCurrent:(BOOL)makeContextCurrent
-                        isFirstClass:(BSGFirstClass)isFirstClass;
+                          firstClass:(BSGFirstClass)firstClass;
 
 - (instancetype)initWithStartTime:(NSDate *)starttime
                     parentContext:(id<BugsnagPerformanceSpanContext>)parentContext
                makeContextCurrent:(BOOL)makeContextCurrent
-                     isFirstClass:(BSGFirstClass)isFirstClass;
+                       firstClass:(BSGFirstClass)firstClass;
 
 - (instancetype)clone;
 

--- a/Tests/BugsnagPerformanceTests/BatchTests.mm
+++ b/Tests/BugsnagPerformanceTests/BatchTests.mm
@@ -23,7 +23,7 @@ using namespace bugsnag;
 
 static std::unique_ptr<SpanData> newSpanData() {
     TraceId tid = {.value = 1};
-    return std::make_unique<SpanData>(@"test", tid, 1, 0, 0);
+    return std::make_unique<SpanData>(@"test", tid, 1, 0, 0, BSGFirstClassUnset);
 }
 
 - (void)setUp {

--- a/Tests/BugsnagPerformanceTests/SamplerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SamplerTests.mm
@@ -49,7 +49,7 @@ using namespace bugsnag;
     auto numSamplesTries = 1'000;
     auto count = 0;
     for (auto i = 0; i < numSamplesTries; i++) {
-        SpanData spanData(@"a", IdGenerator::generateTraceId(), IdGenerator::generateSpanId(), 0, 0);
+        SpanData spanData(@"a", IdGenerator::generateTraceId(), IdGenerator::generateSpanId(), 0, 0, BSGFirstClassUnset);
         if (sampler.sampled(spanData)) {
             count++;
         }

--- a/Tests/BugsnagPerformanceTests/SpanContextStackTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanContextStackTests.mm
@@ -23,7 +23,7 @@ using namespace bugsnag;
 
 static BugsnagPerformanceSpan *newSpan() {
     TraceId tid = {.value = 1};
-    auto data = std::make_unique<SpanData>(@"test", tid, 1, 0, 0);
+    auto data = std::make_unique<SpanData>(@"test", tid, 1, 0, 0, BSGFirstClassUnset);
     auto span = std::make_unique<Span>(std::move(data), ^(std::unique_ptr<SpanData>) {});
     return [[BugsnagPerformanceSpan alloc] initWithSpan:std::move(span)];
 }

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -38,7 +38,7 @@ using namespace bugsnag;
     XCTAssertNil(objcOptions.parentContext);
     XCTAssertNil(objcOptions.startTime);
     XCTAssertTrue(objcOptions.makeContextCurrent);
-    XCTAssertEqual(objcOptions.isFirstClass, BSGFirstClassUnset);
+    XCTAssertEqual(objcOptions.firstClass, BSGFirstClassUnset);
 }
 
 - (void)testConversionDefaults {
@@ -47,7 +47,7 @@ using namespace bugsnag;
     XCTAssertNil(cOptions.parentContext);
     XCTAssertTrue(abs(cOptions.startTime - CFAbsoluteTimeGetCurrent()) < 1);
     XCTAssertTrue(cOptions.makeContextCurrent);
-    XCTAssertEqual(cOptions.isFirstClass, BSGFirstClassUnset);
+    XCTAssertEqual(cOptions.firstClass, BSGFirstClassUnset);
 }
 
 - (void)testConversion {
@@ -56,13 +56,13 @@ using namespace bugsnag;
     objcOptions.startTime = [NSDate dateWithTimeIntervalSinceReferenceDate:1.0];
     objcOptions.parentContext = context;
     objcOptions.makeContextCurrent = true;
-    objcOptions.isFirstClass = BSGFirstClassNo;
+    objcOptions.firstClass = BSGFirstClassNo;
 
     SpanOptions cOptions(objcOptions);
     XCTAssertEqual(1.0, cOptions.startTime);
     XCTAssertEqual(context, cOptions.parentContext);
     XCTAssertEqual(true, cOptions.makeContextCurrent);
-    XCTAssertEqual(BSGFirstClassNo, cOptions.isFirstClass);
+    XCTAssertEqual(BSGFirstClassNo, cOptions.firstClass);
 }
 
 @end

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */; };
 		CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */; };
 		CBC90C4329C466BD00280884 /* ForceUBSan.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC90C4229C466BD00280884 /* ForceUBSan.m */; };
+		CBC90CDE29CDCFF700280884 /* FirstClassNoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */; };
+		CBC90CE029CDD02800280884 /* FirstClassYesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */; };
 		CBE43A9929A8EFA3000B4205 /* ProbabilityExpiryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */; };
 		CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
@@ -65,6 +67,8 @@
 		CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingScenario.swift; sourceTree = "<group>"; };
 		CBC90C4129C466BD00280884 /* ForceUBSan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForceUBSan.h; sourceTree = "<group>"; };
 		CBC90C4229C466BD00280884 /* ForceUBSan.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ForceUBSan.m; sourceTree = "<group>"; };
+		CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstClassNoScenario.swift; sourceTree = "<group>"; };
+		CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstClassYesScenario.swift; sourceTree = "<group>"; };
 		CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProbabilityExpiryScenario.swift; sourceTree = "<group>"; };
 		CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSpanScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
@@ -159,6 +163,8 @@
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
+				CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */,
+				CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -262,6 +268,8 @@
 				CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,
 				01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */,
+				CBC90CE029CDD02800280884 /* FirstClassYesScenario.swift in Sources */,
+				CBC90CDE29CDCFF700280884 /* FirstClassNoScenario.swift in Sources */,
 				CBC90C4329C466BD00280884 /* ForceUBSan.m in Sources */,
 				01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */,
 				CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/FirstClassNoScenario.swift
+++ b/features/fixtures/ios/Scenarios/FirstClassNoScenario.swift
@@ -1,0 +1,18 @@
+//
+//  FirstClassNoScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 24.03.23.
+//
+
+import BugsnagPerformance
+
+class FirstClassNoScenario: Scenario {
+
+    override func run() {
+        waitForCurrentBatch()
+        let opts = BugsnagPerformanceSpanOptions()
+        opts.firstClass = BSGFirstClass.no;
+        BugsnagPerformance.startSpan(name: "FirstClassNoScenario", options: opts).end()
+    }
+}

--- a/features/fixtures/ios/Scenarios/FirstClassYesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FirstClassYesScenario.swift
@@ -1,0 +1,18 @@
+//
+//  FirstClassYesScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 24.03.23.
+//
+
+import BugsnagPerformance
+
+class FirstClassYesScenario: Scenario {
+
+    override func run() {
+        waitForCurrentBatch()
+        let opts = BugsnagPerformanceSpanOptions()
+        opts.firstClass = BSGFirstClass.yes;
+        BugsnagPerformance.startSpan(name: "FirstClassYesScenario", options: opts).end()
+    }
+}

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -9,6 +9,7 @@ Feature: Manual creation of spans
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * a span field "name" equals "WillRetry"
     * a span field "name" equals "Success"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually start and end a span
     Given I run "ManualSpanScenario" and discard the initial p-value request
@@ -26,6 +27,7 @@ Feature: Manual creation of spans
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.app.in_foreground" is true
     * every span string attribute "net.host.connection.type" equals "wifi"
+    * every span bool attribute "bugsnag.span.first_class" is true
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" equals "1"
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"
     * the trace payload field "resourceSpans.0.resource" string attribute "device.id" equals the stored value "bugsnag_device_id"
@@ -50,6 +52,7 @@ Feature: Manual creation of spans
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
@@ -64,6 +67,7 @@ Feature: Manual creation of spans
     * a span field "name" equals "ViewLoad/SwiftUI/ManualView"
     * a span string attribute "bugsnag.view.name" equals "ManualView"
     * a span string attribute "bugsnag.view.type" equals "SwiftUI"
+    * every span bool attribute "bugsnag.span.first_class" is true
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
@@ -80,6 +84,7 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "view_load"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually start a network span
     Given I run "ManualNetworkSpanScenario" and discard the initial p-value request
@@ -101,6 +106,7 @@ Feature: Manual creation of spans
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" does not exist
 
   Scenario: Manually start and end a span field "with" batching
     Given I run "BatchingScenario" and discard the initial p-value request
@@ -117,6 +123,7 @@ Feature: Manual creation of spans
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually start and end a span field "with" batching
     Given I run "BatchingScenario" and discard the initial p-value request
@@ -133,6 +140,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually start and end parent and child spans
     Given I run "ParentSpanScenario" and discard the initial p-value request
@@ -148,5 +156,36 @@ Feature: Manual creation of spans
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
     # Note: The child span ends up first in the list of spans.
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentId" matches the regex "^[A-Fa-f0-9]{16}$"
+
+  Scenario: Manually start and end first-class = yes span
+    Given I run "FirstClassYesScenario" and discard the initial p-value request
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+    * every span field "name" equals "FirstClassYesScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
+
+  Scenario: Manually start and end first-class = no span
+    Given I run "FirstClassNoScenario" and discard the initial p-value request
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+    * every span field "name" equals "FirstClassNoScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is false

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -26,3 +26,8 @@ Then('every span bool attribute {string} is false') do |attribute|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   spans.map { |span| Maze::check.false span['attributes'].find { |a| a['key'] == attribute }['value']['boolValue'] }
 end
+
+Then('every span bool attribute {string} does not exist') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze.check.nil span['attributes'].find { |a| a['key'] == attribute } }
+end


### PR DESCRIPTION
## Goal

Re-implementation of https://github.com/bugsnag/bugsnag-cocoa-performance/pull/56 to handle drift on `next`.
