### PR TITLE
[PLAT-9907] Sampling comparison should be <=, not <

### DIFF
--- a/Sources/BugsnagPerformance/Private/Sampler.mm
+++ b/Sources/BugsnagPerformance/Private/Sampler.mm
@@ -63,7 +63,7 @@ bool Sampler::sampled(SpanData &span) noexcept {
     } else {
         idUpperBound = uint64_t(p * double(UINT64_MAX));
     }
-    bool isSampled = span.traceId.hi < idUpperBound;
+    bool isSampled = span.traceId.hi <= idUpperBound;
     if (isSampled) {
         span.updateSamplingProbability(p);
     }


### PR DESCRIPTION
## Goal

Update the comparison to match the spec (it should be comparing less than or equal).
