### PR TITLE
[PLAT-9655] Set view span first_class based on whether other view spans are active

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -313,41 +313,38 @@ static inline void possiblyMakeSpanCurrent(BugsnagPerformanceSpan *span, SpanOpt
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name) {
-    auto options = defaultSpanOptionsForCustom();
-    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:tracer_.startSpan(name, options, BSGFirstClassYes)];
+    SpanOptions options;
+    auto span = tracer_.startCustomSpan(name, options);
     possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name, BugsnagPerformanceSpanOptions *optionsIn) {
     auto options = SpanOptions(optionsIn);
-    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:tracer_.startSpan(name, options, BSGFirstClassYes)];
+    auto span = tracer_.startCustomSpan(name, options);
     possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType) {
-    auto options = defaultSpanOptionsForViewLoad();
-    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
-                 tracer_.startViewLoadSpan(viewType, name, options)];
+    SpanOptions options;
+    auto span = tracer_.startViewLoadSpan(viewType, name, options);
     possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType, BugsnagPerformanceSpanOptions *optionsIn) {
     auto options = SpanOptions(optionsIn);
-    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
-                 tracer_.startViewLoadSpan(viewType, name, options)];
+    auto span = tracer_.startViewLoadSpan(viewType, name, options);
     possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
 void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, BugsnagPerformanceSpanOptions *optionsIn) {
     auto options = SpanOptions(optionsIn);
-    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
-            tracer_.startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
-                                      [NSString stringWithUTF8String:object_getClassName(controller)],
-                                      options)];
+    auto span = tracer_.startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
+                                          [NSString stringWithUTF8String:object_getClassName(controller)],
+                                          options);
     possiblyMakeSpanCurrent(span, options);
 
     std::lock_guard<std::mutex> guard(viewControllersToSpansMutex_);

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -25,8 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)endWithAbsoluteTime:(CFAbsoluteTime)endTime;
 
-@property(nonatomic,readwrite) BOOL isEnded;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -19,6 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSpan:(std::unique_ptr<bugsnag::Span>)span NS_DESIGNATED_INITIALIZER;
 
+- (void)addAttributes:(NSDictionary *)attributes;
+
+- (BOOL)hasAttribute:(NSString *)attributeName withValue:(id)value;
+
+- (void)endWithAbsoluteTime:(CFAbsoluteTime)endTime;
+
 @property(nonatomic,readwrite) BOOL isEnded;
 
 @end

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -10,6 +10,7 @@
 #import "../Span.h"
 #import "../Tracer.h"
 #import "../Utils.h"
+#import "../BugsnagPerformanceSpan+Private.h"
 
 #import <array>
 #import <os/trace_base.h>
@@ -107,9 +108,9 @@ AppStartupInstrumentation::reportSpan(CFAbsoluteTime endTime) noexcept {
         return;
     }
     auto name = isCold_ ? @"AppStart/Cold" : @"AppStart/Warm";
-    auto options = defaultSpanOptionsForInternal();
+    SpanOptions options;
     options.startTime = startTime;
-    auto span = tracer_.startSpan(name, options, BSGFirstClassUnset);
+    auto span = tracer_.startAppStartSpan(name, options);
     NSMutableDictionary *attributes = @{
         @"bugsnag.app_start.type": isCold_ ? @"cold" : @"warm",
         @"bugsnag.span.category": @"app_start",
@@ -117,8 +118,8 @@ AppStartupInstrumentation::reportSpan(CFAbsoluteTime endTime) noexcept {
     if (firstViewName_ != nullptr) {
         attributes[@"bugsnag.app_start.first_view_name"] = firstViewName_;
     }
-    span->addAttributes(attributes);
-    span->end(endTime);
+    [span addAttributes:attributes];
+    [span endWithAbsoluteTime:endTime];
 }
 
 CFAbsoluteTime

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -60,10 +60,10 @@ ViewLoadInstrumentation::onLoadView(UIViewController *viewController) noexcept {
         return;
     }
     
-    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:
-                 tracer_.startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
-                                           NSStringFromClass([viewController class]),
-                                           defaultSpanOptionsForViewLoad())];
+    SpanOptions options;
+    auto span = tracer_.startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
+                                          NSStringFromClass([viewController class]),
+                                          options);
     
     objc_setAssociatedObject(viewController, &kAssociatedSpan, span,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.h
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.h
@@ -21,14 +21,14 @@ public:
     /**
      * Build a package suitable for upload to the backend server.
      */
-    static std::unique_ptr<OtlpPackage> buildUploadPackage(const std::vector<std::unique_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept;
+    static std::unique_ptr<OtlpPackage> buildUploadPackage(const std::vector<std::shared_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept;
 
     static std::unique_ptr<OtlpPackage> buildPValueRequestPackage() noexcept;
 
 public: // Public for testing only
     static NSDictionary * encode(const SpanData &span) noexcept;
     
-    static NSDictionary * encode(const std::vector<std::unique_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept;
+    static NSDictionary * encode(const std::vector<std::shared_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept;
     
     static NSArray<NSDictionary *> * encode(NSDictionary *attributes) noexcept;
 };

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -108,7 +108,7 @@ OtlpTraceEncoding::encode(const SpanData &span) noexcept {
 }
 
 NSDictionary *
-OtlpTraceEncoding::encode(const std::vector<std::unique_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept {
+OtlpTraceEncoding::encode(const std::vector<std::shared_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept {
     auto encodedSpans = [NSMutableArray arrayWithCapacity:spans.size()];
     for (const auto &span: spans) {
         [encodedSpans addObject:encode(*span.get())];
@@ -205,7 +205,7 @@ OtlpTraceEncoding::encode(NSDictionary *attributes) noexcept {
     return result;
 }
 
-static dispatch_time_t getLatestTimestamp(const std::vector<std::unique_ptr<SpanData>> &spans) {
+static dispatch_time_t getLatestTimestamp(const std::vector<std::shared_ptr<SpanData>> &spans) {
     CFAbsoluteTime endTime = 0;
     for (auto &span: spans) {
         if (span->endTime > endTime) {
@@ -225,13 +225,13 @@ static NSString *integrityDigestForData(NSData *payload) {
                    md[15], md[16], md[17], md[18], md[19]];
 }
 
-static NSString *pValueHistogramForSpans(const std::vector<std::unique_ptr<SpanData>> &spans) {
+static NSString *pValueHistogramForSpans(const std::vector<std::shared_ptr<SpanData>> &spans) {
     // Calculate P value histogram the hard way because ObjC doesn't have such conveniences.
 
     NSMutableArray<NSNumber *> *ordered = [[NSMutableArray alloc] initWithCapacity:spans.size()];
     NSMutableDictionary<NSNumber *, NSNumber *> *counts = [NSMutableDictionary new];
 
-    for (const std::unique_ptr<SpanData> &span: spans) {
+    for (const std::shared_ptr<SpanData> &span: spans) {
         auto probability = @(span->samplingProbability);
         auto count = counts[probability];
         if (count == nil) {
@@ -265,7 +265,7 @@ static NSString *pValueHistogramForSpans(const std::vector<std::unique_ptr<SpanD
     return str;
 }
 
-std::unique_ptr<OtlpPackage> OtlpTraceEncoding::buildUploadPackage(const std::vector<std::unique_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept {
+std::unique_ptr<OtlpPackage> OtlpTraceEncoding::buildUploadPackage(const std::vector<std::shared_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept {
     // Anything smaller won't compress
     static const int MIN_SIZE_FOR_GZIP = 128;
 

--- a/Sources/BugsnagPerformance/Private/Sampler.h
+++ b/Sources/BugsnagPerformance/Private/Sampler.h
@@ -44,8 +44,8 @@ public:
      * Samples the given set of span data, returning those that are to be kept.
      * Also updates the sampling probability value of each kept span.
      */
-    std::unique_ptr<std::vector<std::unique_ptr<SpanData>>>
-    sampled(std::unique_ptr<std::vector<std::unique_ptr<SpanData>>> spans) noexcept;
+    std::unique_ptr<std::vector<std::shared_ptr<SpanData>>>
+    sampled(std::unique_ptr<std::vector<std::shared_ptr<SpanData>>> spans) noexcept;
 
 private:
     double probability_{0};

--- a/Sources/BugsnagPerformance/Private/Sampler.mm
+++ b/Sources/BugsnagPerformance/Private/Sampler.mm
@@ -72,12 +72,12 @@ bool Sampler::sampled(SpanData &span) noexcept {
 
 }
 
-std::unique_ptr<std::vector<std::unique_ptr<SpanData>>>
-Sampler::sampled(std::unique_ptr<std::vector<std::unique_ptr<SpanData>>> spans) noexcept {
-    auto sampledSpans = std::make_unique<std::vector<std::unique_ptr<SpanData>>>();
+std::unique_ptr<std::vector<std::shared_ptr<SpanData>>>
+Sampler::sampled(std::unique_ptr<std::vector<std::shared_ptr<SpanData>>> spans) noexcept {
+    auto sampledSpans = std::make_unique<std::vector<std::shared_ptr<SpanData>>>();
     for (size_t i = 0; i < spans->size(); i++) {
         if (sampled(*(*spans)[i])) {
-            sampledSpans->push_back(std::move((*spans)[i]));
+            sampledSpans->push_back((*spans)[i]);
         }
     }
     return sampledSpans;

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -33,13 +33,20 @@ public:
     void addAttributes(NSDictionary *attributes) noexcept {
         data_ ? data_->addAttributes(attributes) : (void)0;
     }
-    
+
+    bool hasAttribute(NSString *attributeName, id value) noexcept {
+        return data_ ? data_->hasAttribute(attributeName, value): false;
+    }
+
     void end(CFAbsoluteTime time) noexcept {
-        if (!data_) {
+        // TODO: Thread safety
+        auto data = std::move(data_);
+        data_ = nullptr;
+        if (!data) {
             return;
         }
-        data_->endTime = time;
-        onEnd_(std::move(data_));
+        data->endTime = time;
+        onEnd_(std::move(data));
     }
 
     TraceId traceId() {return data_->traceId;}

--- a/Sources/BugsnagPerformance/Private/SpanContextStack.h
+++ b/Sources/BugsnagPerformance/Private/SpanContextStack.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)push:(id<BugsnagPerformanceSpanContext>)context;
 - (id<BugsnagPerformanceSpanContext> _Nullable)context;
 
+- (BOOL)hasSpanWithAttribute:(NSString *)attribute value:(NSString *)value;
+
 // Accessible for testing only.
 @property(nonatomic,readwrite,strong) NSMutableDictionary<NSNumber *, NSPointerArray *> *stacks;
 

--- a/Sources/BugsnagPerformance/Private/SpanContextStack.mm
+++ b/Sources/BugsnagPerformance/Private/SpanContextStack.mm
@@ -104,10 +104,10 @@ static id<BugsnagPerformanceSpanContext> lastObject(NSPointerArray *stack) {
             auto context = (__bridge id<BugsnagPerformanceSpanContext>)[stack pointerAtIndex:stack.count-1];
             if (!context.isValid) {
                 // Remove the invalid context in multiple steps:
-                
+
                 // Remove the context from our current stack.
                 [stack removePointerAtIndex:stack.count-1];
-                
+
                 // Clear the activity ref so that it gets deallocated at the end of the autoreleasepool.
                 // Deallocation will cause the ref to leave the current activity.
                 NSNumber *key = nil;
@@ -118,7 +118,7 @@ static id<BugsnagPerformanceSpanContext> lastObject(NSPointerArray *stack) {
                         key = ref.key;
                     }
                 }
-                
+
                 // Remove this activity's reference to the stack
                 if (key != nil) {
                     @synchronized (self.stacks) {
@@ -134,15 +134,15 @@ static id<BugsnagPerformanceSpanContext> lastObject(NSPointerArray *stack) {
 
 - (void)push:(id<BugsnagPerformanceSpanContext>)context {
     NSPointerArray *stack = [self currentStackOrNew];
-    
+
     @synchronized (stack) {
         // Start a new activity scope under the current scope (or as top level if none exists).
         ActivityRef *ref = [ActivityRef new];
-        
+
         // Store it in the context so that we can find it again.
         // This also ensures that ref will live at most until context dies since the stack uses weak references.
         objc_setAssociatedObject(context, ActivityRefKey, ref, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        
+
         // Save a reference to this activity's stack so that we can find it again.
         @synchronized (self.stacks) {
             self.stacks[ref.key] = stack;

--- a/Sources/BugsnagPerformance/Private/SpanData.h
+++ b/Sources/BugsnagPerformance/Private/SpanData.h
@@ -29,7 +29,9 @@ public:
     SpanData(const SpanData&) = delete;
     
     void addAttributes(NSDictionary *attributes) noexcept;
-    
+
+    bool hasAttribute(NSString *attributeName, id value) noexcept;
+
     void updateSamplingProbability(double value) noexcept;
     
     TraceId traceId{0};

--- a/Sources/BugsnagPerformance/Private/SpanData.mm
+++ b/Sources/BugsnagPerformance/Private/SpanData.mm
@@ -34,6 +34,16 @@ SpanData::addAttributes(NSDictionary *dictionary) noexcept {
     [this->attributes addEntriesFromDictionary:dictionary];
 }
 
+bool
+SpanData::hasAttribute(NSString *attributeName, id value) noexcept {
+    for (id key in attributes) {
+        if ([key isEqualToString:attributeName]) {
+            return [attributes[key] isEqual:value];
+        }
+    }
+    return false;
+}
+
 void
 SpanData::updateSamplingProbability(double value) noexcept {
     if (samplingProbability > value) {

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -11,13 +11,6 @@
 
 namespace bugsnag {
 
-static inline CFAbsoluteTime defaultTimeIfNil(NSDate *date) {
-    if (date == nil) {
-        return CFAbsoluteTimeGetCurrent();
-    }
-    return dateToAbsoluteTime(date);
-}
-
 class SpanOptions {
 public:
     SpanOptions(id<BugsnagPerformanceSpanContext> parentContext,
@@ -32,7 +25,7 @@ public:
     
     SpanOptions(BugsnagPerformanceSpanOptions *options)
     : SpanOptions(options.parentContext,
-                  defaultTimeIfNil(options.startTime),
+                  options.startTime == nil ? CFAbsoluteTimeGetCurrent() : dateToAbsoluteTime(options.startTime),
                   options.makeContextCurrent,
                   options.firstClass)
     {}
@@ -51,21 +44,4 @@ public:
     BSGFirstClass firstClass{BSGFirstClassUnset};
 };
 
-static inline SpanOptions defaultSpanOptionsForCustom() {
-    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), true, BSGFirstClassYes);
 }
-
-static inline SpanOptions defaultSpanOptionsForInternal() {
-    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), true, BSGFirstClassUnset);
-}
-
-static inline SpanOptions defaultSpanOptionsForViewLoad() {
-    // TODO: This will check the stack for a view load in a later PR
-    return SpanOptions(nil, CFAbsoluteTimeGetCurrent(), true, BSGFirstClassYes);
-}
-
-static inline SpanOptions defaultSpanOptionsForNetwork(CFAbsoluteTime startTime) {
-    return SpanOptions(nil, startTime, true, BSGFirstClassUnset);
-}
-}
-

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -28,15 +28,17 @@ namespace bugsnag {
 class Tracer {
 public:
     Tracer(std::shared_ptr<Sampler> sampler, std::shared_ptr<Batch> batch, void (^onSpanStarted)()) noexcept;
-    
+
     void start(BugsnagPerformanceConfiguration *configuration) noexcept;
-    
-    std::unique_ptr<class Span> startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
-    
-    std::unique_ptr<class Span> startViewLoadSpan(BugsnagPerformanceViewType viewType,
-                                                  NSString *className,
-                                                  SpanOptions options) noexcept;
-    
+
+    BugsnagPerformanceSpan *startAppStartSpan(NSString *name, SpanOptions options) noexcept;
+
+    BugsnagPerformanceSpan *startCustomSpan(NSString *name, SpanOptions options) noexcept;
+
+    BugsnagPerformanceSpan *startViewLoadSpan(BugsnagPerformanceViewType viewType,
+                                              NSString *className,
+                                              SpanOptions options) noexcept;
+
     void reportNetworkSpan(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept;
     
 private:
@@ -48,6 +50,7 @@ private:
     std::shared_ptr<Batch> batch_;
     void (^onSpanStarted_)(){nil};
     
+    BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
     void tryAddSpanToBatch(std::unique_ptr<SpanData> spanData);
 };
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -51,6 +51,6 @@ private:
     void (^onSpanStarted_)(){nil};
     
     BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
-    void tryAddSpanToBatch(std::unique_ptr<SpanData> spanData);
+    void tryAddSpanToBatch(std::shared_ptr<SpanData> spanData);
 };
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -57,14 +57,14 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
         firstClass = defaultFirstClass;
     }
     auto spanId = IdGenerator::generateSpanId();
-    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:std::make_unique<Span>(std::make_unique<SpanData>(name,
+    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:std::make_unique<Span>(std::make_shared<SpanData>(name,
                                                               traceId,
                                                               spanId,
                                                               parentSpanId,
                                                               options.startTime,
                                                               firstClass),
-                                       ^void(std::unique_ptr<SpanData> spanData) {
-        blockThis->tryAddSpanToBatch(std::move(spanData));
+                                       ^void(std::shared_ptr<SpanData> spanData) {
+        blockThis->tryAddSpanToBatch(spanData);
     })];
     if (options.makeContextCurrent) {
         [SpanContextStack.current push:span];
@@ -76,9 +76,9 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
     return span;
 }
 
-void Tracer::tryAddSpanToBatch(std::unique_ptr<SpanData> spanData) {
+void Tracer::tryAddSpanToBatch(std::shared_ptr<SpanData> spanData) {
     if (sampler_->sampled(*spanData)) {
-        batch_->add(std::move(spanData));
+        batch_->add(spanData);
     }
 }
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -40,6 +40,14 @@ using namespace bugsnag;
     }
 }
 
+- (void)endWithAbsoluteTime:(CFAbsoluteTime)endTime {
+    if (_span) {
+        _span->end(endTime);
+        _span.reset();
+        _isEnded = true;
+    }
+}
+
 - (TraceId)traceId {
     return _span->traceId();
 }
@@ -50,6 +58,14 @@ using namespace bugsnag;
 
 - (BOOL)isValid {
     return !_isEnded;
+}
+
+- (void)addAttributes:(NSDictionary *)attributes {
+    _span->addAttributes(attributes);
+}
+
+- (BOOL)hasAttribute:(NSString *)attributeName withValue:(id)value {
+    return _span->hasAttribute(attributeName, value);
 }
 
 @end

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -25,27 +25,15 @@ using namespace bugsnag;
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 - (void)end {
-    if (_span) {
-        _span->end(CFAbsoluteTimeGetCurrent());
-        _span.reset();
-        _isEnded = true;
-    }
+    _span->end(CFAbsoluteTimeGetCurrent());
 }
 
 - (void)endWithEndTime:(NSDate *)endTime {
-    if (_span) {
-        _span->end(dateToAbsoluteTime(endTime));
-        _span.reset();
-        _isEnded = true;
-    }
+    _span->end(dateToAbsoluteTime(endTime));
 }
 
 - (void)endWithAbsoluteTime:(CFAbsoluteTime)endTime {
-    if (_span) {
-        _span->end(endTime);
-        _span.reset();
-        _isEnded = true;
-    }
+    _span->end(endTime);
 }
 
 - (TraceId)traceId {
@@ -57,7 +45,7 @@ using namespace bugsnag;
 }
 
 - (BOOL)isValid {
-    return !_isEnded;
+    return !_span->isEnded();
 }
 
 - (void)addAttributes:(NSDictionary *)attributes {

--- a/Tests/BugsnagPerformanceTests/BatchTests.mm
+++ b/Tests/BugsnagPerformanceTests/BatchTests.mm
@@ -21,7 +21,7 @@ using namespace bugsnag;
 
 @implementation BatchTests
 
-static std::unique_ptr<SpanData> newSpanData() {
+static std::shared_ptr<SpanData> newSpanData() {
     TraceId tid = {.value = 1};
     return std::make_unique<SpanData>(@"test", tid, 1, 0, 0, BSGFirstClassUnset);
 }

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -67,7 +67,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testEncodeRequestFirstClassYes {
-    std::vector<std::unique_ptr<SpanData>> spans;
+    std::vector<std::shared_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
     spans.push_back(std::make_unique<SpanData>(@"", tid, 1, 0, CFAbsoluteTimeGetCurrent(), BSGFirstClassYes));
     auto json = OtlpTraceEncoding::encode(spans, @{});
@@ -87,7 +87,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testEncodeRequestFirstClassNo {
-    std::vector<std::unique_ptr<SpanData>> spans;
+    std::vector<std::shared_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
     spans.push_back(std::make_unique<SpanData>(@"", tid, 1, 0, CFAbsoluteTimeGetCurrent(), BSGFirstClassNo));
     auto json = OtlpTraceEncoding::encode(spans, @{});
@@ -107,7 +107,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testEncodeRequestFirstClassUnset {
-    std::vector<std::unique_ptr<SpanData>> spans;
+    std::vector<std::shared_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
     spans.push_back(std::make_unique<SpanData>(@"", tid, 1, 0, CFAbsoluteTimeGetCurrent(), BSGFirstClassUnset));
     auto json = OtlpTraceEncoding::encode(spans, @{});
@@ -204,7 +204,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testBuildUploadPackage {
-    std::vector<std::unique_ptr<SpanData>> spans;
+    std::vector<std::shared_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
     spans.push_back(std::make_unique<SpanData>(@"test", tid, 1, 0, 0, BSGFirstClassUnset));
     auto resourceAttributes = @{};
@@ -221,7 +221,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testPValueHistogram1 {
-    std::vector<std::unique_ptr<SpanData>> spans;
+    std::vector<std::shared_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
     spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0, BSGFirstClassUnset));
     spans[0]->updateSamplingProbability(0.3);
@@ -234,7 +234,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testPValueHistogram2 {
-    std::vector<std::unique_ptr<SpanData>> spans;
+    std::vector<std::shared_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
     spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0, BSGFirstClassUnset));
     spans.push_back(std::make_unique<SpanData>(@"test2", tid, 2, 0, 0, BSGFirstClassUnset));
@@ -249,7 +249,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testPValueHistogram2Same {
-    std::vector<std::unique_ptr<SpanData>> spans;
+    std::vector<std::shared_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
     spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0, BSGFirstClassUnset));
     spans.push_back(std::make_unique<SpanData>(@"test2", tid, 2, 0, 0, BSGFirstClassUnset));
@@ -264,7 +264,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testPValueHistogram5 {
-    std::vector<std::unique_ptr<SpanData>> spans;
+    std::vector<std::shared_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
     spans.push_back(std::make_unique<SpanData>(@"test1", tid, 1, 0, 0, BSGFirstClassUnset));
     spans.push_back(std::make_unique<SpanData>(@"test2", tid, 2, 0, 0, BSGFirstClassUnset));
@@ -285,7 +285,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testPValueHistogram11 {
-    std::vector<std::unique_ptr<SpanData>> spans;
+    std::vector<std::shared_ptr<SpanData>> spans;
     TraceId tid = {.value=1};
     spans.push_back(std::make_unique<SpanData>(@"test0", tid, 1, 0, 0, BSGFirstClassUnset));
     spans.push_back(std::make_unique<SpanData>(@"test1", tid, 2, 0, 0, BSGFirstClassUnset));

--- a/Tests/BugsnagPerformanceTests/SpanContextStackTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanContextStackTests.mm
@@ -52,12 +52,12 @@ static BugsnagPerformanceSpan *newSpan() {
     
     sleep(1);
     const auto beginCount = SpanContextStack.current.stacks.count;
-
+    
     for (int i = 0; i < queue_count; i++) {
         NSString *name = [NSString stringWithFormat:@"test-%d", i];
         queues[i] = dispatch_queue_create(name.UTF8String, DISPATCH_QUEUE_CONCURRENT);
     }
-
+    
     for (int i = 0; i < queue_count; i++) {
         dispatch_async(queues[i], ^{
             for (int j = 0; j < iteration_count; j++) {
@@ -68,7 +68,7 @@ static BugsnagPerformanceSpan *newSpan() {
             }
         });
     }
-
+    
     sleep(5);
     XCTAssertEqual(SpanContextStack.current.stacks.count, beginCount);
 }
@@ -143,7 +143,7 @@ static BugsnagPerformanceSpan *newSpan() {
     [SpanContextStack.current push:span1];
     [SpanContextStack.current push:span2];
     [SpanContextStack.current push:span3];
-
+    
     usleep(400000);
     XCTAssertEqual(span3, SpanContextStack.current.context);
 }
@@ -153,14 +153,85 @@ static BugsnagPerformanceSpan *newSpan() {
     XCTAssertNotNil(SpanContextStack.current);
     auto span1 = newSpan();
     [SpanContextStack.current push:span1];
-
+    
     __block auto span2 = newSpan();
     dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [SpanContextStack.current push:span2];
     });
-
+    
     usleep(200000);
     XCTAssertEqual(span2, SpanContextStack.current.context);
+}
+
+- (void)testFindAttribute {
+    auto span_a = newSpan();
+    [span_a addAttributes:@{
+        @"a": @"1"
+    }];
+    [SpanContextStack.current push:span_a];
+    
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"z" value:@"1"]);
+    
+    auto span_b = newSpan();
+    [span_b addAttributes:@{
+        @"b": @"2"
+    }];
+    [SpanContextStack.current push:span_b];
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"z" value:@"1"]);
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"b" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"b" value:@"1"]);
+    
+    auto span_c = newSpan();
+    [span_c addAttributes:@{
+        @"c": @"2",
+        @"d": @"100",
+    }];
+    [SpanContextStack.current push:span_c];
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"z" value:@"1"]);
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"b" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"b" value:@"1"]);
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"c" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"c" value:@"1"]);
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"d" value:@"100"]);
+    
+    [span_a end];
+    [SpanContextStack current]; // Force a sweep
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"z" value:@"1"]);
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"b" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"b" value:@"1"]);
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"c" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"c" value:@"1"]);
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"d" value:@"100"]);
+    
+    [span_c end];
+    [SpanContextStack current]; // Force a sweep
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"z" value:@"1"]);
+    XCTAssertTrue([SpanContextStack.current hasSpanWithAttribute:@"b" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"b" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"c" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"c" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"d" value:@"100"]);
+    
+    [span_b end];
+    [SpanContextStack current]; // Force a sweep
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"a" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"z" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"b" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"b" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"c" value:@"2"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"c" value:@"1"]);
+    XCTAssertFalse([SpanContextStack.current hasSpanWithAttribute:@"d" value:@"100"]);
 }
 
 @end

--- a/Tests/BugsnagPerformanceTests/SpanContextStackTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanContextStackTests.mm
@@ -52,12 +52,12 @@ static BugsnagPerformanceSpan *newSpan() {
     
     sleep(1);
     const auto beginCount = SpanContextStack.current.stacks.count;
-    
+
     for (int i = 0; i < queue_count; i++) {
         NSString *name = [NSString stringWithFormat:@"test-%d", i];
         queues[i] = dispatch_queue_create(name.UTF8String, DISPATCH_QUEUE_CONCURRENT);
     }
-    
+
     for (int i = 0; i < queue_count; i++) {
         dispatch_async(queues[i], ^{
             for (int j = 0; j < iteration_count; j++) {
@@ -68,7 +68,7 @@ static BugsnagPerformanceSpan *newSpan() {
             }
         });
     }
-    
+
     sleep(5);
     XCTAssertEqual(SpanContextStack.current.stacks.count, beginCount);
 }
@@ -143,7 +143,7 @@ static BugsnagPerformanceSpan *newSpan() {
     [SpanContextStack.current push:span1];
     [SpanContextStack.current push:span2];
     [SpanContextStack.current push:span3];
-    
+
     usleep(400000);
     XCTAssertEqual(span3, SpanContextStack.current.context);
 }
@@ -153,12 +153,12 @@ static BugsnagPerformanceSpan *newSpan() {
     XCTAssertNotNil(SpanContextStack.current);
     auto span1 = newSpan();
     [SpanContextStack.current push:span1];
-    
+
     __block auto span2 = newSpan();
     dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [SpanContextStack.current push:span2];
     });
-    
+
     usleep(200000);
     XCTAssertEqual(span2, SpanContextStack.current.context);
 }

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -14,6 +14,7 @@ Feature: Automatic instrumentation spans
     * every span string attribute "bugsnag.app_start.type" equals "cold"
     * every span string attribute "bugsnag.app_start.first_view_name" equals "AutoInstrumentAppStartsScenarioView"
     * every span string attribute "bugsnag.span.category" equals "app_start"
+    * every span bool attribute "bugsnag.span.first_class" does not exist
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
@@ -31,6 +32,29 @@ Feature: Automatic instrumentation spans
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "view_load"
     * every span string attribute "bugsnag.view.name" equals "Fixture.AutoInstrumentViewLoadScenario_ViewController"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.type" equals "UIKit"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
+  Scenario: AutoInstrumentSubViewLoadScenario
+    Given I run "AutoInstrumentSubViewLoadScenario" and discard the initial p-value request
+    And I wait for 2 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * a span field "name" equals "ViewLoad/UIKit/Fixture.AutoInstrumentSubViewLoadScenario_ViewController"
+    * a span field "name" equals "ViewLoad/UIKit/Fixture.AutoInstrumentSubViewLoadScenario_SubViewController"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span string attribute "bugsnag.span.category" equals "view_load"
+    * a span string attribute "bugsnag.view.name" equals "Fixture.AutoInstrumentSubViewLoadScenario_ViewController"
+    * a span string attribute "bugsnag.view.name" equals "Fixture.AutoInstrumentSubViewLoadScenario_SubViewController"
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * a span bool attribute "bugsnag.span.first_class" is false
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.type" equals "UIKit"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
@@ -53,6 +77,7 @@ Feature: Automatic instrumentation spans
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" does not exist
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -42,7 +42,6 @@ Feature: Automatic instrumentation spans
     Given I run "AutoInstrumentSubViewLoadScenario" and discard the initial p-value request
     And I wait for 2 spans
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * a span field "name" equals "ViewLoad/UIKit/Fixture.AutoInstrumentSubViewLoadScenario_ViewController"
     * a span field "name" equals "ViewLoad/UIKit/Fixture.AutoInstrumentSubViewLoadScenario_SubViewController"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		CBC90C4329C466BD00280884 /* ForceUBSan.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC90C4229C466BD00280884 /* ForceUBSan.m */; };
 		CBC90CDE29CDCFF700280884 /* FirstClassNoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */; };
 		CBC90CE029CDD02800280884 /* FirstClassYesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */; };
+		CBC90CE429D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */; };
 		CBE43A9929A8EFA3000B4205 /* ProbabilityExpiryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */; };
 		CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
@@ -69,6 +70,7 @@
 		CBC90C4229C466BD00280884 /* ForceUBSan.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ForceUBSan.m; sourceTree = "<group>"; };
 		CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstClassNoScenario.swift; sourceTree = "<group>"; };
 		CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstClassYesScenario.swift; sourceTree = "<group>"; };
+		CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentSubViewLoadScenario.swift; sourceTree = "<group>"; };
 		CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProbabilityExpiryScenario.swift; sourceTree = "<group>"; };
 		CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSpanScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
@@ -145,10 +147,13 @@
 			children = (
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */,
+				CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */,
 				0185C47128F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift */,
 				CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */,
 				CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */,
 				CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */,
+				CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */,
+				CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */,
 				CBC90C4129C466BD00280884 /* ForceUBSan.h */,
 				CBC90C4229C466BD00280884 /* ForceUBSan.m */,
 				CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */,
@@ -163,8 +168,6 @@
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
-				CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */,
-				CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -271,6 +274,7 @@
 				CBC90CE029CDD02800280884 /* FirstClassYesScenario.swift in Sources */,
 				CBC90CDE29CDCFF700280884 /* FirstClassNoScenario.swift in Sources */,
 				CBC90C4329C466BD00280884 /* ForceUBSan.m in Sources */,
+				CBC90CE429D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift in Sources */,
 				01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */,
 				CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */,
 			);
@@ -428,7 +432,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -460,7 +464,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -464,7 +464,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/features/fixtures/ios/Fixture/Fixture.swift
+++ b/features/fixtures/ios/Fixture/Fixture.swift
@@ -8,30 +8,36 @@
 import Foundation
 
 func fetchAndExecuteCommand() {
+    NSLog("[Fixture] Preparing to load scenario from \(Scenario.mazeRunnerURL)/command")
     let url = URL(string: "\(Scenario.mazeRunnerURL)/command")!
     
     var request = URLRequest(url: url)
     request.setValue("application/json", forHTTPHeaderField: "Accept")
-    NSLog("[Fixture] \(request.httpMethod!) \(request) \(request.allHTTPHeaderFields!)")
+    NSLog("[Fixture] Sending command request \(request.httpMethod!) \(request) \(request.allHTTPHeaderFields!)")
     
     URLSession.shared.dataTask(with: request) { data, response, connectionError in
         if let response = response {
-            NSLog("[Fixture] \(response)")
+            if let ur = response as? HTTPURLResponse {
+                NSLog("[Fixture] Server responded: \(ur.statusCode)")
+            } else {
+                NSLog("[Fixture] Server responded: \(response)")
+            }
         } else if let error = connectionError {
-            NSLog("[Fixture] \(error)")
+            NSLog("[Fixture] Server responded with error: \(error)")
         }
         
         guard let data = data else { return }
-        NSLog("[Fixture] \(String(data: data, encoding: .utf8)!)")
+        NSLog("[Fixture] Server response data: \(String(data: data, encoding: .utf8)!)")
         
         let command: Command
         do {
             command = try JSONDecoder().decode(Command.self, from: data)
         } catch {
-            NSLog("[Fixture] \(error)")
+            NSLog("[Fixture] JSON decode error: \(error)")
             return
         }
         
+        NSLog("[Fixture] Response decoded. Dispatching command \(command.scenario) on main thread")
         DispatchQueue.main.async {
             run(command: command)
         }
@@ -39,12 +45,19 @@ func fetchAndExecuteCommand() {
 }
 
 func run(command: Command) {
+    NSLog("[Fixture] Running command: \(command.scenario)")
     let scenarioClass: AnyClass = NSClassFromString("Fixture.\(command.scenario)")!
+    NSLog("[Fixture] Loaded scenario class: \(scenarioClass)")
     let scenario = (scenarioClass as! NSObject.Type).init() as! Scenario
+    NSLog("[Fixture] Configuring scenario \(scenario)")
     scenario.configure()
+    NSLog("[Fixture] Clearing persistent data")
     scenario.clearPersistentData()
+    NSLog("[Fixture] Starting bugsnag")
     scenario.startBugsnag()
+    NSLog("[Fixture] Running scenario")
     scenario.run()
+    NSLog("[Fixture] Scenario complete")
 }
 
 struct Command: Decodable {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentSubViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentSubViewLoadScenario.swift
@@ -1,0 +1,55 @@
+//
+//  AutoInstrumentSubViewLoadScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 27.03.23.
+//
+
+import UIKit
+
+class AutoInstrumentSubViewLoadScenario: Scenario {
+    
+    override func startBugsnag() {
+        config.autoInstrumentViewControllers = true
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        UIApplication.shared.windows[0].rootViewController!.present(
+            AutoInstrumentViewLoadScenario_ViewController(), animated: true)
+    }
+}
+
+class AutoInstrumentSubViewLoadScenario_ViewController: UIViewController {
+    let subVC = AutoInstrumentSubViewLoadScenario_SubViewController()
+
+    override func viewDidLoad() {
+        add(childViewController:AutoInstrumentSubViewLoadScenario_SubViewController(), to:view)
+    }
+}
+
+class AutoInstrumentSubViewLoadScenario_SubViewController: UIViewController {
+    
+    override func loadView() {
+        let label = UILabel()
+        label.backgroundColor = .white
+        label.textAlignment = .center
+        label.text = String(describing: type(of: self))
+        view = label
+    }
+}
+
+extension UIViewController {
+    func add(childViewController viewController: UIViewController, to contentView: UIView) {
+        addChild(viewController)
+        viewController.view.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(viewController.view)
+        NSLayoutConstraint.activate([
+            viewController.view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            viewController.view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            viewController.view.topAnchor.constraint(equalTo: contentView.topAnchor),
+            viewController.view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+        viewController.didMove(toParent: self)
+    }
+}

--- a/features/fixtures/ios/Scenarios/AutoInstrumentSubViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentSubViewLoadScenario.swift
@@ -16,7 +16,7 @@ class AutoInstrumentSubViewLoadScenario: Scenario {
     
     override func run() {
         UIApplication.shared.windows[0].rootViewController!.present(
-            AutoInstrumentViewLoadScenario_ViewController(), animated: true)
+            AutoInstrumentSubViewLoadScenario_ViewController(), animated: true)
     }
 }
 

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -15,6 +15,7 @@ class Scenario: NSObject {
     var config = BugsnagPerformanceConfiguration.loadConfig()
     
     func configure() {
+        NSLog("Scenario.configure()")
         bsgp_autoTriggerExportOnBatchSize = 1;
         config.apiKey = "12312312312312312312312312312312"
         config.autoInstrumentAppStarts = false
@@ -31,19 +32,23 @@ class Scenario: NSObject {
     }
     
     func startBugsnag() {
+        NSLog("Scenario.startBugsnag()")
         BugsnagPerformance.start(configuration: config)
     }
     
     func run() {
+        NSLog("Scenario.run() has not been overridden!")
         fatalError("To be implemented by subclass")
     }
 
     func waitForInitialPResponse() {
+        NSLog("Scenario.waitForInitialPResponse()")
         // Guess that it won't take longer than 2 seconds
         Thread.sleep(forTimeInterval: 2.0)
     }
 
     func waitForCurrentBatch() {
+        NSLog("Scenario.waitForCurrentBatch()")
         // Wait long enough to allow the current batch to be packaged and sent
         Thread.sleep(forTimeInterval: 0.5)
     }

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -31,3 +31,15 @@ Then('every span bool attribute {string} does not exist') do |attribute|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   spans.map { |span| Maze.check.nil span['attributes'].find { |a| a['key'] == attribute } }
 end
+
+Then('a span bool attribute {string} is true') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'] == attribute }['value']['boolValue'] }
+  Maze.check.includes selected_attributes, true
+end
+
+Then('a span bool attribute {string} is false') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'] == attribute }['value']['boolValue'] }
+  Maze.check.includes selected_attributes, false
+end


### PR DESCRIPTION
## Goal

When the `first_class` span option is unset for a view controller, set it to `false` if there's any existing view span in the current hierarchy, otherwise set it to `true`.

## Design

We used to only use the C++ `Span` object from `Tracer` onwards for speed purposes, but it must now add the user-facing `BugsnagPerformanceSpan` to the current context stack based on the `makeContextCurrent` option, so `Tracer` is now aware of the ObjC class. This is only slightly heavier, however, since the rest of the span management is still done using the faster C++ objects.

We use an `NSPointerArray` in the context stack because it supports weak references.

`std::unique_ptr` unfortunately doesn't play nice with atomics, so I've had to change the `SpanData` pointers to use `std::shared_ptr` instead.

I've also added more logging to the base e2e fixture and scenario classes to make it easier to track down problems in the e2e tests.

## Testing

New unit tests and e2e test.