### PR TITLE
[PLAT-9658] Handle possibility that viewDidAppear doesn't get called

### DIFF
--- a/Sources/BugsnagPerformance/Private/Batch.h
+++ b/Sources/BugsnagPerformance/Private/Batch.h
@@ -97,6 +97,10 @@ public:
         onBatchFull = batchFullCallback;
     }
 
+    size_t count() noexcept {
+        return spans_->size();
+    }
+
 private:
     void (^onBatchFull)(){nullptr};
     bool drainIsAllowed_{false};

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -106,7 +106,9 @@ private:
     void uploadPackage(std::unique_ptr<OtlpPackage> package, bool isRetry) noexcept;
 
 public: // For testing
+    void testing_setProbability(double probability) { onProbabilityChanged(probability); };
     NSUInteger testing_getViewControllersToSpansCount() { return viewControllersToSpans_.count; };
+    NSUInteger testing_getBatchCount() { return batch_->count(); };
     static std::shared_ptr<BugsnagPerformanceImpl> testing_newInstance() {
         return std::shared_ptr<BugsnagPerformanceImpl>(new BugsnagPerformanceImpl(Reachability::testing_newReachability()));
     }

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.h
@@ -23,6 +23,7 @@ public:
     static std::shared_ptr<AppStartupInstrumentation> getAppStartupInstrumentation() noexcept;
     static std::shared_ptr<Reachability> getReachability() noexcept;
 
+    static void testing_reset();
 private:
     // Use GNU constructor attribute to auto-call functions before main() is called.
     // https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Function-Attributes.html

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
@@ -11,15 +11,15 @@
 using namespace bugsnag;
 
 [[clang::no_destroy]]
-static BugsnagPerformanceLibrary * instance;
+static std::shared_ptr<BugsnagPerformanceLibrary> instance;
 
 void BugsnagPerformanceLibrary::calledAsEarlyAsPossible() noexcept {
     // This will be called before main by the static initializer code, so threading is not an issue.
-    if (instance != nullptr) {
+    if (instance) {
         return;
     }
 
-    instance = new BugsnagPerformanceLibrary;
+    instance = std::shared_ptr<BugsnagPerformanceLibrary>(new BugsnagPerformanceLibrary);
 }
 
 void BugsnagPerformanceLibrary::calledRightBeforeMain() noexcept {
@@ -55,4 +55,10 @@ std::shared_ptr<AppStartupInstrumentation> BugsnagPerformanceLibrary::getAppStar
 
 std::shared_ptr<Reachability> BugsnagPerformanceLibrary::getReachability() noexcept {
     return instance->reachability_;
+}
+
+void BugsnagPerformanceLibrary::testing_reset() {
+    instance.reset();
+    calledAsEarlyAsPossible();
+    calledRightBeforeMain();
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -29,7 +29,10 @@ private:
     
     void onLoadView(UIViewController *viewController) noexcept;
     void onViewDidAppear(UIViewController *viewController) noexcept;
-    
+    void onViewWillDisappear(UIViewController *viewController) noexcept;
+
+    void endViewLoadSpan(UIViewController *viewController) noexcept;
+
     class Tracer &tracer_;
     BOOL (^ callback_)(UIViewController *viewController){nullptr};
     NSSet *observedClasses_{nil};

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceTests.mm
@@ -18,6 +18,9 @@
 - (void)setUp {
     auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
     config.endpoint = [NSURL URLWithString:@"http://localhost"];
+    config.autoInstrumentNetwork = NO;
+    config.autoInstrumentAppStarts = NO;
+    config.autoInstrumentViewControllers = NO;
     [BugsnagPerformance startWithConfiguration:config];
 }
 

--- a/Tests/BugsnagPerformanceTests/ViewControllerSpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/ViewControllerSpanTests.mm
@@ -8,8 +8,15 @@
 
 #import <XCTest/XCTest.h>
 #import "BugsnagPerformanceImpl.h"
+#import "BugsnagPerformanceLibrary.h"
 
 using namespace bugsnag;
+
+@interface MyTestViewController: UIViewController
+@end
+
+@implementation MyTestViewController
+@end
 
 @interface ViewControllerSpanTests : XCTestCase
 
@@ -52,6 +59,44 @@ using namespace bugsnag;
 
         XCTAssertLessThan(perf->testing_getViewControllersToSpansCount(), 100U);
     }
+}
+
+- (void)testAutoViewControllerDidAppear {
+    BugsnagPerformanceLibrary::testing_reset();
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"11111111111111111111111111111111"];
+    config.autoInstrumentViewControllers = YES;
+    config.autoInstrumentAppStarts = NO;
+    config.autoInstrumentNetwork = NO;
+    BugsnagPerformanceLibrary::configure(config);
+    auto perf = BugsnagPerformanceLibrary::getBugsnagPerformanceImpl();
+    perf->start();
+    perf->testing_setProbability(1);
+    XCTAssertEqual(0U, perf->testing_getBatchCount());
+    UIViewController *controller = [MyTestViewController new];
+    [controller loadView];
+    [controller viewDidLoad];
+    XCTAssertEqual(0U, perf->testing_getBatchCount());
+    [controller viewDidAppear:controller];
+    XCTAssertEqual(1U, perf->testing_getBatchCount());
+}
+
+- (void)testAutoViewControllerWillDisappear {
+    BugsnagPerformanceLibrary::testing_reset();
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"11111111111111111111111111111111"];
+    config.autoInstrumentViewControllers = YES;
+    config.autoInstrumentAppStarts = NO;
+    config.autoInstrumentNetwork = NO;
+    BugsnagPerformanceLibrary::configure(config);
+    auto perf = BugsnagPerformanceLibrary::getBugsnagPerformanceImpl();
+    perf->start();
+    perf->testing_setProbability(1);
+    XCTAssertEqual(0U, perf->testing_getBatchCount());
+    UIViewController *controller = [MyTestViewController new];
+    [controller loadView];
+    [controller viewDidLoad];
+    XCTAssertEqual(0U, perf->testing_getBatchCount());
+    [controller viewWillDisappear:controller];
+    XCTAssertEqual(1U, perf->testing_getBatchCount());
 }
 
 @end


### PR DESCRIPTION
**Note**: Review after https://github.com/bugsnag/bugsnag-cocoa-performance/pull/94 has been merged.

## Goal

It's possible for `viewDidAppear` to not be called in some circumstances. As a fallback, use `viewWillDisappear` to end the view load span.

## Testing

The library has been tweaked to allow starting and shutting down the entire library from within the unit testing framework. This allows more complex interactions such as method swizzling to be tested at the unit test level.

Added unit tests for auto view load instrumentation.
