### PR TITLE
Construct-config-start conversion part 2

### DIFF
--- a/Sources/BugsnagPerformance/Private/Batch.h
+++ b/Sources/BugsnagPerformance/Private/Batch.h
@@ -50,24 +50,6 @@ public:
         }
     }
 
-    /**
-     * Check if the batch is full, and call the "batch full" callback if it is.
-     * This code is duplicated to avoid an extra mutex lock requirement in add().
-     */
-    void checkFull() noexcept {
-        bool isFull = false;
-        {
-            std::lock_guard<std::mutex> guard(mutex_);
-            isFull = spans_->size() >= autoTriggerExportOnBatchSize_;
-            if (isFull) {
-                drainIsAllowed_ = true;
-            }
-        }
-        if (isFull) {
-            onBatchFull();
-        }
-    }
-
     void removeSpan(TraceId traceId, SpanId spanId) noexcept {
         std::lock_guard<std::mutex> guard(mutex_);
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
@@ -14,8 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BSGInternalConfiguration: NSObject
 
-// Force the sampler to use the configuration's probability, overriding the stored value.
-@property(nonatomic,readwrite) bool forceSamplingProbability;
+@property(nonatomic,readwrite) bool clearPersistenceOnStart;
 
 @property(nonatomic,readwrite) uint64_t autoTriggerExportOnBatchSize;
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
@@ -14,6 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BSGInternalConfiguration: NSObject
 
+// Force the sampler to use the configuration's probability, overriding the stored value.
+@property(nonatomic,readwrite) bool forceSamplingProbability;
+
 @property(nonatomic,readwrite) uint64_t autoTriggerExportOnBatchSize;
 
 @property(nonatomic,readwrite) NSTimeInterval performWorkInterval;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -64,6 +64,7 @@ private:
     BugsnagPerformanceImpl(std::shared_ptr<Reachability> reachability,
                            AppStateTracker *appStateTracker) noexcept;
 
+    std::shared_ptr<Persistence> persistence_;
     std::atomic<bool> isStarted_{false};
     SpanContextStack *spanContextStack_;
     std::shared_ptr<Batch> batch_;
@@ -71,7 +72,6 @@ private:
     Tracer tracer_;
     Worker *worker_{nil};
     BugsnagPerformanceConfiguration *configuration_;
-    std::shared_ptr<Persistence> persistence_;
     std::shared_ptr<PersistentState> persistentState_;
     std::shared_ptr<OtlpUploader> uploader_;
     std::unique_ptr<RetryQueue> retryQueue_;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -82,6 +82,8 @@ void BugsnagPerformanceImpl::start() noexcept {
 
     __block auto blockThis = this;
 
+    persistence_->start();
+
     if (configuration_.internal.clearPersistenceOnStart) {
         persistence_->clear();
     }
@@ -91,6 +93,7 @@ void BugsnagPerformanceImpl::start() noexcept {
     retryQueue_->setOnFilesystemError(^{
         blockThis->onFilesystemError();
     });
+    retryQueue_->start();
 
     uploader_ = std::make_shared<OtlpUploader>(configuration_.endpoint,
                                                configuration_.apiKey,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -133,6 +133,8 @@ void BugsnagPerformanceImpl::start() noexcept {
         blockThis->onConnectivityChanged(connectivity);
     });
 
+    batch_->checkFull();
+
     if (!configuration_.shouldSendReports) {
         BSGLogInfo("Note: No reports will be sent because releaseStage '%@' is not in enabledReleaseStages", configuration_.releaseStage);
     }

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
@@ -32,6 +32,11 @@ void BugsnagPerformanceLibrary::calledRightBeforeMain() noexcept {
 }
 
 void BugsnagPerformanceLibrary::configure(BugsnagPerformanceConfiguration *config) noexcept {
+    NSError *__autoreleasing error = nil;
+    if (![config validate:&error]) {
+        BSGLogError(@"Configuration validation failed with error: %@", error);
+    }
+
     sharedInstance().configureInstance(config);
 }
 

--- a/Sources/BugsnagPerformance/Private/Persistence.h
+++ b/Sources/BugsnagPerformance/Private/Persistence.h
@@ -15,7 +15,11 @@ namespace bugsnag {
 class Persistence {
 public:
     Persistence() = delete;
-    Persistence(NSString *topLevelDir) noexcept;
+    Persistence(NSString *topLevelDir) noexcept
+    : topLevelDir_(topLevelDir)
+    {}
+
+    void start() noexcept;
     NSError *clear(void) noexcept;
     NSString *topLevelDirectory(void) noexcept;
 private:

--- a/Sources/BugsnagPerformance/Private/Persistence.mm
+++ b/Sources/BugsnagPerformance/Private/Persistence.mm
@@ -14,11 +14,9 @@
 
 using namespace bugsnag;
 
-Persistence::Persistence(NSString *topLevelDir) noexcept
-: topLevelDir_(topLevelDir)
-{
+void Persistence::start() noexcept {
     NSError *error = nil;
-    if ((error = clear()) != nil) {
+    if ((error = [Filesystem ensurePathExists:topLevelDir_]) != nil) {
         BSGLogError(@"error while initializing persistence: %@", error);
     }
 }

--- a/Sources/BugsnagPerformance/Private/PersistentState.h
+++ b/Sources/BugsnagPerformance/Private/PersistentState.h
@@ -14,8 +14,14 @@ namespace bugsnag {
 
 class PersistentState {
 public:
-    PersistentState(NSString *jsonFilePath, void (^onPersistenceNeeded)()) noexcept;
     PersistentState() = delete;
+    PersistentState(NSString *jsonFilePath, void (^onPersistenceNeeded)()) noexcept
+    : jsonFilePath_(jsonFilePath)
+    , persistentStateDir_([jsonFilePath_ stringByDeletingLastPathComponent])
+    , probability_(0)
+    , probabilityIsValid_(false)
+    , onPersistenceNeeded_(onPersistenceNeeded)
+    {}
 
     void setProbability(double probability) noexcept;
     double probability(void) noexcept {return probability_;};
@@ -36,7 +42,7 @@ private:
     NSString *jsonFilePath_{nil};
     NSString *persistentStateDir_{nil};
     double probability_{0};
-    bool probabilityIsValid_;
+    bool probabilityIsValid_{false};
     void (^onPersistenceNeeded_)(){nil};
 };
 

--- a/Sources/BugsnagPerformance/Private/PersistentState.h
+++ b/Sources/BugsnagPerformance/Private/PersistentState.h
@@ -19,6 +19,7 @@ public:
 
     void setProbability(double probability) noexcept;
     double probability(void) noexcept {return probability_;};
+    bool probabilityIsValid() noexcept {return probabilityIsValid_;}
 
     /**
      * Save this object to persistent storage.
@@ -35,6 +36,7 @@ private:
     NSString *jsonFilePath_{nil};
     NSString *persistentStateDir_{nil};
     double probability_{0};
+    bool probabilityIsValid_;
     void (^onPersistenceNeeded_)(){nil};
 };
 

--- a/Sources/BugsnagPerformance/Private/PersistentState.mm
+++ b/Sources/BugsnagPerformance/Private/PersistentState.mm
@@ -51,6 +51,7 @@ NSError *PersistentState::load() noexcept {
     NSNumber *probability = getNumber(dict, @"probability");
     if (probability != nil) {
         probability_ = probability.doubleValue;
+        probabilityIsValid_= true;
     }
 
     return nil;

--- a/Sources/BugsnagPerformance/Private/PersistentState.mm
+++ b/Sources/BugsnagPerformance/Private/PersistentState.mm
@@ -17,14 +17,6 @@ static NSNumber *getNumber(NSDictionary* dict, NSString *key) {
     return [value isKindOfClass:[NSNumber class]] ? value : nil;
 }
 
-PersistentState::PersistentState(NSString *jsonFilePath, void (^onPersistenceNeeded)()) noexcept
-: jsonFilePath_(jsonFilePath)
-, persistentStateDir_([jsonFilePath_ stringByDeletingLastPathComponent])
-, probability_(0)
-, onPersistenceNeeded_(onPersistenceNeeded)
-{
-}
-
 void PersistentState::setProbability(double probability) noexcept {
     probability_ = probability;
     onPersistenceNeeded_();

--- a/Sources/BugsnagPerformance/Private/RetryQueue.h
+++ b/Sources/BugsnagPerformance/Private/RetryQueue.h
@@ -18,10 +18,15 @@ namespace bugsnag {
 
 class RetryQueue {
 public:
-    RetryQueue(NSString *path) noexcept;
     RetryQueue() = delete;
+    RetryQueue(NSString *path) noexcept
+    : baseDir_(path)
+    , onFilesystemError(^{})
+    {}
 
     void configure(BugsnagPerformanceConfiguration *config) noexcept;
+
+    void start() noexcept;
 
     /**
      * Sweep the retry queue, deleting any non-retry files and retries that are older than 24 hours.

--- a/Sources/BugsnagPerformance/Private/RetryQueue.mm
+++ b/Sources/BugsnagPerformance/Private/RetryQueue.mm
@@ -39,15 +39,12 @@ static dispatch_time_t timestampFromFilename(NSString *filename) {
     return strtoull(str.UTF8String, 0, 10);
 }
 
-RetryQueue::RetryQueue(NSString *path) noexcept
-: baseDir_(path)
-{
-    onFilesystemError = ^void() {};
-    [Filesystem ensurePathExists:path];
-}
-
 void RetryQueue::configure(BugsnagPerformanceConfiguration *config) noexcept {
     maxRetryAge_ = intervalToNanoseconds(config.internal.maxRetryAge);
+}
+
+void RetryQueue::start() noexcept {
+    [Filesystem ensurePathExists:baseDir_];
 }
 
 void RetryQueue::sweep() noexcept {

--- a/Sources/BugsnagPerformance/Private/Sampler.h
+++ b/Sources/BugsnagPerformance/Private/Sampler.h
@@ -9,6 +9,7 @@
 
 #import "IdGenerator.h"
 #import "SpanData.h"
+#import "Configurable.h"
 
 #import <Foundation/Foundation.h>
 #import <vector>
@@ -23,9 +24,12 @@ namespace bugsnag {
  */
 class Sampler {
 public:
-    Sampler(double fallbackProbability) noexcept;
-    
-    void setFallbackProbability(double value) noexcept;
+    // Sampler constructs with a probability of 1 so that it keeps everything until configured.
+    Sampler() noexcept
+    : probability_(1)
+    {}
+
+    void configure(BugsnagPerformanceConfiguration *config) noexcept;
 
     /**
      * Sets the probability value to use in all sampling for the next 24 hours.

--- a/Sources/BugsnagPerformance/Private/Sampler.h
+++ b/Sources/BugsnagPerformance/Private/Sampler.h
@@ -9,7 +9,6 @@
 
 #import "IdGenerator.h"
 #import "SpanData.h"
-#import "Configurable.h"
 
 #import <Foundation/Foundation.h>
 #import <vector>
@@ -18,25 +17,18 @@
 namespace bugsnag {
 
 /**
- * Samples spans based on either:
- * - A default fallback probability
- * - A value that was set using setProbability(), which expires after 24 hours
+ * Samples spans based on the currently configured probability
  */
 class Sampler {
 public:
-    // Sampler constructs with a probability of 1 so that it keeps everything until configured.
+    // Sampler constructs with a probability of 1 so that it keeps everything until explicitly configured.
     Sampler() noexcept
     : probability_(1)
     {}
 
-    void configure(BugsnagPerformanceConfiguration *config) noexcept;
+    void setProbability(double probability) noexcept {probability_ = probability;};
 
-    /**
-     * Sets the probability value to use in all sampling for the next 24 hours.
-     */
-    void setProbability(double probability) noexcept;
-
-    double getProbability() noexcept;
+    double getProbability() noexcept {return probability_;};
 
     /**
      * Samples the given span data, returning true if the span is to be kept.
@@ -52,6 +44,6 @@ public:
     sampled(std::unique_ptr<std::vector<std::shared_ptr<SpanData>>> spans) noexcept;
 
 private:
-    double probability_{0};
+    double probability_{1};
 };
 }

--- a/Sources/BugsnagPerformance/Private/Sampler.mm
+++ b/Sources/BugsnagPerformance/Private/Sampler.mm
@@ -10,49 +10,6 @@
 
 using namespace bugsnag;
 
-static NSString *kUserDefaultsKey = @"BugsnagPerformanceSampler";
-static NSString *kProbabilityKey = @"p";
-
-static double loadProbabilityOrDefault(double defaultProbability) {
-    NSDictionary *dict = [[NSUserDefaults standardUserDefaults]
-                          dictionaryForKey:kUserDefaultsKey];
-
-    if (dict != nil) {
-        id p = dict[kProbabilityKey];
-        if ([p isKindOfClass:[NSNumber class]]) {
-            return [p doubleValue];
-        }
-    }
-    return defaultProbability;
-}
-
-static void storeProbability(double probability) {
-    [[NSUserDefaults standardUserDefaults]
-     setObject:@{
-            kProbabilityKey: @(probability),
-        }
-     forKey:kUserDefaultsKey];
-}
-
-void Sampler::configure(BugsnagPerformanceConfiguration *config) noexcept {
-    if (config.internal.forceSamplingProbability) {
-        setProbability(config.samplingProbability);
-    } else {
-        probability_ = loadProbabilityOrDefault(config.samplingProbability);
-    }
-}
-
-double
-Sampler::getProbability() noexcept {
-        return probability_;
-}
-
-void
-Sampler::setProbability(double probability) noexcept {
-    probability_ = probability;
-    storeProbability(probability);
-}
-
 bool Sampler::sampled(SpanData &span) noexcept {
     auto p = getProbability();
     uint64_t idUpperBound;

--- a/Sources/BugsnagPerformance/Private/Sampler.mm
+++ b/Sources/BugsnagPerformance/Private/Sampler.mm
@@ -6,6 +6,7 @@
 //
 
 #import "Sampler.h"
+#import "BugsnagPerformanceConfiguration+Private.h"
 
 using namespace bugsnag;
 
@@ -33,13 +34,12 @@ static void storeProbability(double probability) {
      forKey:kUserDefaultsKey];
 }
 
-Sampler::Sampler(double fallbackProbability) noexcept
-: probability_(loadProbabilityOrDefault(fallbackProbability))
-{
-}
-
-void Sampler::setFallbackProbability(double value) noexcept {
-    probability_ = loadProbabilityOrDefault(value);
+void Sampler::configure(BugsnagPerformanceConfiguration *config) noexcept {
+    if (config.internal.forceSamplingProbability) {
+        setProbability(config.samplingProbability);
+    } else {
+        probability_ = loadProbabilityOrDefault(config.samplingProbability);
+    }
 }
 
 double

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -35,6 +35,14 @@ Tracer::configure(BugsnagPerformanceConfiguration *config) noexcept {
 
 void
 Tracer::start() noexcept {
+    // Up until now the sampler was unconfigured and sampling at 1.0 (keep everything).
+    // Now that the sampler has been configured, re-sample everything.
+    batch_->allowDrain();
+    auto unsampledBatch = batch_->drain();
+    for (auto spanData: *unsampledBatch) {
+        tryAddSpanToBatch(spanData);
+    }
+
     if (configuration.autoInstrumentViewControllers) {
         viewLoadInstrumentation_ = std::make_unique<ViewLoadInstrumentation>(*this, configuration.viewControllerInstrumentationCallback);
         viewLoadInstrumentation_->start();

--- a/Tests/BugsnagPerformanceTests/PersistenceTests.mm
+++ b/Tests/BugsnagPerformanceTests/PersistenceTests.mm
@@ -23,7 +23,9 @@ using namespace bugsnag;
     NSError *error = nil;
     auto persistence = Persistence(self.filePath);
     XCTAssertEqualObjects([self.filePath stringByAppendingPathComponent:@"v1"], persistence.topLevelDirectory());
+    XCTAssertFalse([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
 
+    persistence.start();
     XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
     XCTAssertTrue(isDir);
     XCTAssertEqual(0U, [fm contentsOfDirectoryAtPath:self.filePath error:&error].count);

--- a/Tests/BugsnagPerformanceTests/RetryQueueTests.mm
+++ b/Tests/BugsnagPerformanceTests/RetryQueueTests.mm
@@ -84,6 +84,9 @@ static inline dispatch_time_t currentTimeMinusNanoseconds(dispatch_time_t nanose
     XCTAssertFalse([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
 
     RetryQueue queue(self.filePath);
+    XCTAssertFalse([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
+
+    queue.start();
     XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
     XCTAssertTrue(isDir);
 }
@@ -93,6 +96,7 @@ static inline dispatch_time_t currentTimeMinusNanoseconds(dispatch_time_t nanose
     BOOL isDir = false;
 
     RetryQueue queue(self.filePath);
+    queue.start();
     XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
     XCTAssertTrue(isDir);
     __block int callCount = 0;
@@ -131,6 +135,7 @@ static inline dispatch_time_t currentTimeMinusNanoseconds(dispatch_time_t nanose
     XCTAssertTrue(isDir);
 
     RetryQueue queue(self.filePath);
+    queue.start();
     XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
     XCTAssertTrue(isDir);
 }
@@ -145,6 +150,7 @@ static inline dispatch_time_t currentTimeMinusNanoseconds(dispatch_time_t nanose
     XCTAssertFalse(isDir);
 
     RetryQueue queue(self.filePath);
+    queue.start();
     XCTAssertTrue([fm fileExistsAtPath:self.filePath isDirectory:&isDir]);
     XCTAssertFalse(isDir);
 

--- a/Tests/BugsnagPerformanceTests/SamplerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SamplerTests.mm
@@ -29,34 +29,27 @@ using namespace bugsnag;
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"BugsnagPerformanceSampler"];
 }
 
-- (void)testProbabilityPersistence {
-    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"11111111111111111111111111111111"];
-    config.samplingProbability = 1.0;
-    config.internal.forceSamplingProbability = true;
+- (void)testProbability {
     Sampler sampler;
-    sampler.configure(config);
+    sampler.setProbability(1.0);
     XCTAssertEqual(sampler.getProbability(), 1.0);
     
     sampler.setProbability(0.5);
     XCTAssertEqual(sampler.getProbability(), 0.5);
 
-    config.internal.forceSamplingProbability = false;
     Sampler sampler2;
-    sampler2.configure(config);
-    XCTAssertEqual(sampler2.getProbability(), 0.5);
+    sampler2.setProbability(0.8);
+    XCTAssertEqual(sampler2.getProbability(), 0.8);
+    XCTAssertEqual(sampler.getProbability(), 0.5);
 }
 
 - (void)testProbabilityAccuracy {
     // The RNG prior to ios 12 is too streaky
     if (@available(ios 12.0, *)) {
-        auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"11111111111111111111111111111111"];
-        config.internal.forceSamplingProbability = true;
-
         std::vector<double> values { 0.0, 1.0 / 3.0, 0.5, 2.0 / 3.0, 1.0 };
         for (auto p : values) {
-            config.samplingProbability = p;
             Sampler sampler;
-            sampler.configure(config);
+            sampler.setProbability(p);
             [self assertSampler:sampler samplesWithProbability:p];
         }
     }

--- a/features/fixtures/ios/Fixture/Fixture.swift
+++ b/features/fixtures/ios/Fixture/Fixture.swift
@@ -55,9 +55,9 @@ func run(command: Command) {
     scenario.clearPersistentData()
     NSLog("[Fixture] Starting bugsnag")
     scenario.startBugsnag()
-    NSLog("[Fixture] Running scenario")
+    NSLog("[Fixture] Running scenario \(scenarioClass)")
     scenario.run()
-    NSLog("[Fixture] Scenario complete")
+    NSLog("[Fixture] Scenario \(scenarioClass) complete")
 }
 
 struct Command: Decodable {

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -16,7 +16,8 @@ class Scenario: NSObject {
     
     func configure() {
         NSLog("Scenario.configure()")
-        config.internal.autoTriggerExportOnBatchSize = 1;
+        config.internal.clearPersistenceOnStart = true
+        config.internal.autoTriggerExportOnBatchSize = 1
         config.apiKey = "12312312312312312312312312312312"
         config.autoInstrumentAppStarts = false
         config.autoInstrumentNetwork = false


### PR DESCRIPTION
## Goal

Some design issues were still present after the last PR:
* Some classes hadn't been changed over to the construct-config-start approach.
* `Persistence` was clearing on every run instead of just making sure the TLD exists.
* `Sampler` no longer maintains its own persistence.
* `Tracer` now drains the initial batch (which until configuration samples at 1.0) and re-adds them at the current sampling probability.

Also reverted `Batch` changes that allowed a null span.

## Testing

Updated existing tests.
