### PR TITLE
Move all swizzle code to a single class to better understand where swizzling is used

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		CBE8EA1A294B5AB800702950 /* Worker.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA18294B5AB800702950 /* Worker.h */; };
 		CBE8EA1B294B5AB800702950 /* Worker.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBE8EA19294B5AB800702950 /* Worker.mm */; };
 		CBE8EA1E294B5E1500702950 /* Batch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA1C294B5E1500702950 /* Batch.h */; };
+		CBEBE59229F2783C00BF0B4F /* Swizzle.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEBE59029F2783C00BF0B4F /* Swizzle.mm */; };
+		CBEBE59329F2783C00BF0B4F /* Swizzle.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEBE59129F2783C00BF0B4F /* Swizzle.h */; };
 		CBEC51B8296D8386009C0CE3 /* Persistence.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEC51B6296D8386009C0CE3 /* Persistence.h */; };
 		CBEC51B9296D8386009C0CE3 /* Persistence.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51B7296D8386009C0CE3 /* Persistence.mm */; };
 		CBEC51BC296D9EEE009C0CE3 /* PersistentState.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEC51BA296D9EED009C0CE3 /* PersistentState.h */; };
@@ -234,6 +236,8 @@
 		CBE8EA18294B5AB800702950 /* Worker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Worker.h; sourceTree = "<group>"; };
 		CBE8EA19294B5AB800702950 /* Worker.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Worker.mm; sourceTree = "<group>"; };
 		CBE8EA1C294B5E1500702950 /* Batch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Batch.h; sourceTree = "<group>"; };
+		CBEBE59029F2783C00BF0B4F /* Swizzle.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Swizzle.mm; sourceTree = "<group>"; };
+		CBEBE59129F2783C00BF0B4F /* Swizzle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Swizzle.h; sourceTree = "<group>"; };
 		CBEC51B6296D8386009C0CE3 /* Persistence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Persistence.h; sourceTree = "<group>"; };
 		CBEC51B7296D8386009C0CE3 /* Persistence.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Persistence.mm; sourceTree = "<group>"; };
 		CBEC51BA296D9EED009C0CE3 /* PersistentState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PersistentState.h; sourceTree = "<group>"; };
@@ -398,6 +402,8 @@
 				0122C22129019770002D243C /* SpanData.mm */,
 				0122C22329019770002D243C /* SpanKind.h */,
 				CB7FD935299D330500499E13 /* SpanOptions.h */,
+				CBEBE59129F2783C00BF0B4F /* Swizzle.h */,
+				CBEBE59029F2783C00BF0B4F /* Swizzle.mm */,
 				CBC90C4429C84DEB00280884 /* Targets.h */,
 				0122C23329019770002D243C /* Tracer.h */,
 				0122C22529019770002D243C /* Tracer.mm */,
@@ -567,6 +573,7 @@
 				967F6F1829C3783B0054EED8 /* BugsnagPerformanceConfiguration+Private.h in Headers */,
 				0122C24129019770002D243C /* IdGenerator.h in Headers */,
 				CBE8EA1E294B5E1500702950 /* Batch.h in Headers */,
+				CBEBE59329F2783C00BF0B4F /* Swizzle.h in Headers */,
 				CBEC51BC296D9EEE009C0CE3 /* PersistentState.h in Headers */,
 				0122C23829019770002D243C /* BugsnagPerformanceSpan.h in Headers */,
 				CB0AD76A296573FC002A3FB6 /* BugsnagPerformanceErrors.h in Headers */,
@@ -788,6 +795,7 @@
 				CBE8EA1B294B5AB800702950 /* Worker.mm in Sources */,
 				CB78819C29E587CE00A58906 /* BugsnagPerformanceLibrary.mm in Sources */,
 				0122C23C29019770002D243C /* BugsnagPerformanceConfiguration.mm in Sources */,
+				CBEBE59229F2783C00BF0B4F /* Swizzle.mm in Sources */,
 				01A58C0F29092D25006E4DF7 /* Sampler.mm in Sources */,
 				CBEC51C1296DB312009C0CE3 /* JSON.mm in Sources */,
 				0122C24029019770002D243C /* SpanData.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -23,7 +23,6 @@ private:
     static std::vector<const char *> imagesToInstrument() noexcept;
     static std::vector<Class> viewControllerSubclasses(const char *image) noexcept;
     static bool isViewControllerSubclass(Class subclass) noexcept;
-    static IMP overrideImplementation(Class cls, SEL name, id block) noexcept;
     
     void instrument(Class cls) noexcept;
     

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -10,6 +10,7 @@
 #import "../BugsnagPerformanceSpan+Private.h"
 #import "../Span.h"
 #import "../Tracer.h"
+#import "../Swizzle.h"
 
 #import <objc/runtime.h>
 
@@ -145,7 +146,7 @@ void
 ViewLoadInstrumentation::instrument(Class cls) noexcept {
     SEL selector = @selector(loadView);
     IMP loadView __block = nullptr;
-    loadView = overrideImplementation(cls, selector, ^(id self){
+    loadView = ObjCSwizzle::setMethodOverride(cls, selector, ^(id self){
         Trace(@"%@   -[%s %s]", self, class_getName(cls), sel_getName(selector));
         onLoadView(self);
         reinterpret_cast<void (*)(id, SEL)>(loadView)(self, selector);
@@ -156,7 +157,7 @@ ViewLoadInstrumentation::instrument(Class cls) noexcept {
 
     selector = @selector(viewDidAppear:);
     IMP viewDidAppear __block = nullptr;
-    viewDidAppear = overrideImplementation(cls, selector, ^(id self, BOOL animated){
+    viewDidAppear = ObjCSwizzle::setMethodOverride(cls, selector, ^(id self, BOOL animated){
         Trace(@"%@   -[%s %s]", self, class_getName(cls), sel_getName(selector));
         reinterpret_cast<void (*)(id, SEL, BOOL)>(viewDidAppear)(self, selector, animated);
         onViewDidAppear(self);
@@ -164,36 +165,12 @@ ViewLoadInstrumentation::instrument(Class cls) noexcept {
 
     selector = @selector(viewWillDisappear:);
     IMP viewWillDisappear __block = nullptr;
-    viewWillDisappear = overrideImplementation(cls, selector, ^(id self, BOOL animated){
+    viewWillDisappear = ObjCSwizzle::setMethodOverride(cls, selector, ^(id self, BOOL animated){
         Trace(@"%@   -[%s %s]", self, class_getName(cls), sel_getName(selector));
         reinterpret_cast<void (*)(id, SEL, BOOL)>(viewDidAppear)(self, selector, animated);
         onViewWillDisappear(self);
     });
 }
 
-IMP
-ViewLoadInstrumentation::overrideImplementation(Class cls, SEL name, id block) noexcept {
-    Method method = nullptr;
-    
-    // Not using class_getInstanceMethod because we don't want to modify the
-    // superclass's implementation.
-    auto methodCount = 0U;
-    Method *methods = class_copyMethodList(cls, &methodCount);
-    if (methods) {
-        for (auto i = 0U; i < methodCount; i++) {
-            if (sel_isEqual(method_getName(methods[i]), name)) {
-                method = methods[i];
-                break;
-            }
-        }
-        free(methods);
-    }
-    
-    if (!method) {
-        return nullptr;
-    }
-    
-    return method_setImplementation(method, imp_implementationWithBlock(block));
-}
 
 // NOLINTEND(cppcoreguidelines-*)

--- a/Sources/BugsnagPerformance/Private/Swizzle.h
+++ b/Sources/BugsnagPerformance/Private/Swizzle.h
@@ -1,0 +1,36 @@
+//
+//  Swizzle.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 21.04.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+namespace bugsnag {
+
+class ObjCSwizzle {
+public:
+    /**
+     * Replace a class's current method implementation with a new implementation block, returning the replaced one.
+     * Returns nil if the method was not found (in the class or any superclass).
+     */
+    static IMP _Nullable setMethodImplementation(Class _Nonnull clazz, SEL _Nonnull selector, id _Nonnull implementationBlock) noexcept;
+
+    /**
+     * Replace a class's override of a method (i.e. only if this class overrides the method). No superclass implementation is replaced.
+     * Returns nil if no method was replaced (either method not found, or this class doesn't overrde the method).
+     */
+    static IMP _Nullable setMethodOverride(Class _Nonnull cls, SEL _Nonnull name, id _Nonnull block) noexcept;
+
+    /**
+     * Get any classes or superclasses that implement the specified selector.
+     */
+    static NSArray<Class> * _Nonnull getClassesWithSelector(Class _Nullable cls, SEL _Nonnull selector) noexcept;
+
+};
+
+}

--- a/Sources/BugsnagPerformance/Private/Swizzle.mm
+++ b/Sources/BugsnagPerformance/Private/Swizzle.mm
@@ -1,0 +1,69 @@
+//
+//  Swizzle.mm
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 21.04.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "Swizzle.h"
+#import "Utils.h"
+#import <objc/runtime.h>
+
+namespace bugsnag {
+
+IMP ObjCSwizzle::setMethodImplementation(Class _Nonnull clazz, SEL selector, id _Nonnull implementationBlock) noexcept {
+    Method method = class_getClassMethod(clazz, selector);
+    if (method) {
+        return method_setImplementation(method, imp_implementationWithBlock(implementationBlock));
+    } else {
+        BSGLogWarning(@"Could not set IMP for selector %s on class %@", sel_getName(selector), clazz);
+        return nil;
+    }
+}
+
+IMP ObjCSwizzle::setMethodOverride(Class clazz, SEL selector, id block) noexcept {
+    Method method = nullptr;
+
+    // Not using class_getInstanceMethod because we don't want to modify the
+    // superclass's implementation.
+    auto methodCount = 0U;
+    Method *methods = class_copyMethodList(clazz, &methodCount);
+    if (methods) {
+        for (auto i = 0U; i < methodCount; i++) {
+            if (sel_isEqual(method_getName(methods[i]), selector)) {
+                method = methods[i];
+                break;
+            }
+        }
+        free(methods);
+    }
+
+    if (!method) {
+        // This is not considered an error.
+        return nil;
+    }
+
+    return method_setImplementation(method, imp_implementationWithBlock(block));
+}
+
+NSArray<Class> *ObjCSwizzle::getClassesWithSelector(Class cls, SEL selector) noexcept {
+    NSMutableArray<Class> *result = [NSMutableArray new];
+    for (; class_getInstanceMethod(cls, selector); cls = [cls superclass]) {
+        if (!cls) {
+            break;
+        }
+        Class superCls = [cls superclass];
+        Method classMethod = class_getInstanceMethod(cls, selector);
+        Method superMethod = class_getInstanceMethod(superCls, selector);
+        IMP classIMP = classMethod ? method_getImplementation(classMethod) : nil;
+        IMP superIMP = superMethod ? method_getImplementation(superMethod) : nil;
+        if (classIMP != superIMP) {
+            [result addObject:(Class _Nonnull)cls];
+        }
+    }
+    return result;
+};
+
+
+}


### PR DESCRIPTION
## Goal

There's a mix of swizzling code in some of the auto-instrumentation classes. This PR moves the fundamental operations to a centralized `ObjCSwizzle` class as static methods to namespace them and make it easier to find where swizzling is used in the project.

This is important for prospective users who are wary of swizzling so that they can have confidence that Bugsnag won't swizzle their code unless the features that require it are enabled in the configuration.

## Testing

No new tests necessary since this is just moving code around.
