### PR TITLE
Ensure numeric values are always encoded as strings

### DIFF
--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -176,7 +176,7 @@ OtlpTraceEncoding::encode(NSDictionary *attributes) noexcept {
                     case kCFNumberCharType:
                     case kCFNumberShortType:
                     case kCFNumberIntType:
-                        [result addObject:@{@"key": key, @"value": @{@"intValue": value}}];
+                        [result addObject:@{@"key": key, @"value": @{@"intValue": [value stringValue]}}];
                         break;
                         
                     case kCFNumberLongType:
@@ -194,7 +194,7 @@ OtlpTraceEncoding::encode(NSDictionary *attributes) noexcept {
                     case kCFNumberFloatType:
                     case kCFNumberDoubleType:
                     case kCFNumberCGFloatType:
-                        [result addObject:@{@"key": key, @"value": @{@"doubleValue": value}}];
+                        [result addObject:@{@"key": key, @"value": @{@"doubleValue": [value stringValue]}}];
                         break;
                         
                     default: break;

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -48,14 +48,14 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testEncodeDoubleValue {
-    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @1.23}), (@[@{@"key": @"key", @"value": @{@"doubleValue": @1.23}}]));
-    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @1.f}), (@[@{@"key": @"key", @"value": @{@"doubleValue": @1.f}}]));
+    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @1.23}), (@[@{@"key": @"key", @"value": @{@"doubleValue": @"1.23"}}]));
+    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @1.f}), (@[@{@"key": @"key", @"value": @{@"doubleValue": @"1"}}]));
 }
 
 - (void)testEncodeInt32Value {
-    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @0}), (@[@{@"key": @"key", @"value": @{@"intValue": @0}}]));
-    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @1}), (@[@{@"key": @"key", @"value": @{@"intValue": @1}}]));
-    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @2147483647}), (@[@{@"key": @"key", @"value": @{@"intValue": @2147483647}}]));
+    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @0}), (@[@{@"key": @"key", @"value": @{@"intValue": @"0"}}]));
+    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @1}), (@[@{@"key": @"key", @"value": @{@"intValue": @"1"}}]));
+    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @2147483647}), (@[@{@"key": @"key", @"value": @{@"intValue": @"2147483647"}}]));
 }
 
 - (void)testEncodeInt64Value {


### PR DESCRIPTION
## Goal

Numeric values must always be encoded as strings in JSON.

## Changeset

Updated `OtlpTraceEncoding.mm` to always encode numbers as strings.
