### PR TITLE
Move instrumentation management into Instrumentation class

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		CBE8EA1E294B5E1500702950 /* Batch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA1C294B5E1500702950 /* Batch.h */; };
 		CBEBE59229F2783C00BF0B4F /* Swizzle.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEBE59029F2783C00BF0B4F /* Swizzle.mm */; };
 		CBEBE59329F2783C00BF0B4F /* Swizzle.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEBE59129F2783C00BF0B4F /* Swizzle.h */; };
+		CBEBE59A29F671A800BF0B4F /* Instrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEBE59829F671A800BF0B4F /* Instrumentation.h */; };
+		CBEBE59B29F671A800BF0B4F /* Instrumentation.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEBE59929F671A800BF0B4F /* Instrumentation.mm */; };
 		CBEC51B8296D8386009C0CE3 /* Persistence.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEC51B6296D8386009C0CE3 /* Persistence.h */; };
 		CBEC51B9296D8386009C0CE3 /* Persistence.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBEC51B7296D8386009C0CE3 /* Persistence.mm */; };
 		CBEC51BC296D9EEE009C0CE3 /* PersistentState.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEC51BA296D9EED009C0CE3 /* PersistentState.h */; };
@@ -236,6 +238,7 @@
 		CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCUtils.h; sourceTree = "<group>"; };
 		CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCUtils.mm; sourceTree = "<group>"; };
 		CBC90C4429C84DEB00280884 /* Targets.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Targets.h; sourceTree = "<group>"; };
+		CBE0872129F6C6A3007455F2 /* Startable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Startable.h; sourceTree = "<group>"; };
 		CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceImpl.h; sourceTree = "<group>"; };
 		CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceImpl.mm; sourceTree = "<group>"; };
 		CBE8EA18294B5AB800702950 /* Worker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Worker.h; sourceTree = "<group>"; };
@@ -243,6 +246,8 @@
 		CBE8EA1C294B5E1500702950 /* Batch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Batch.h; sourceTree = "<group>"; };
 		CBEBE59029F2783C00BF0B4F /* Swizzle.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Swizzle.mm; sourceTree = "<group>"; };
 		CBEBE59129F2783C00BF0B4F /* Swizzle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Swizzle.h; sourceTree = "<group>"; };
+		CBEBE59829F671A800BF0B4F /* Instrumentation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Instrumentation.h; sourceTree = "<group>"; };
+		CBEBE59929F671A800BF0B4F /* Instrumentation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Instrumentation.mm; sourceTree = "<group>"; };
 		CBEC51B6296D8386009C0CE3 /* Persistence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Persistence.h; sourceTree = "<group>"; };
 		CBEC51B7296D8386009C0CE3 /* Persistence.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Persistence.mm; sourceTree = "<group>"; };
 		CBEC51BA296D9EED009C0CE3 /* PersistentState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PersistentState.h; sourceTree = "<group>"; };
@@ -401,6 +406,8 @@
 				0122C23529019770002D243C /* Span.h */,
 				01A414CB2913C0F0003152A4 /* SpanAttributes.h */,
 				01A414CC2913C0F0003152A4 /* SpanAttributes.mm */,
+				96D4160D29F276FE00AEE435 /* SpanAttributesProvider.h */,
+				96D4160B29F276E400AEE435 /* SpanAttributesProvider.mm */,
 				CB747D22299F6E03003CA1B4 /* SpanContextStack.h */,
 				CB747D23299F6E03003CA1B4 /* SpanContextStack.mm */,
 				CB85404529D5D395008B58D6 /* SpanContextStack+Private.h */,
@@ -408,6 +415,7 @@
 				0122C22129019770002D243C /* SpanData.mm */,
 				0122C22329019770002D243C /* SpanKind.h */,
 				CB7FD935299D330500499E13 /* SpanOptions.h */,
+				CBE0872129F6C6A3007455F2 /* Startable.h */,
 				CBEBE59129F2783C00BF0B4F /* Swizzle.h */,
 				CBEBE59029F2783C00BF0B4F /* Swizzle.mm */,
 				CBC90C4429C84DEB00280884 /* Targets.h */,
@@ -418,8 +426,6 @@
 				015836C3291264E0002F54C8 /* Version.h */,
 				CBE8EA18294B5AB800702950 /* Worker.h */,
 				CBE8EA19294B5AB800702950 /* Worker.mm */,
-				96D4160D29F276FE00AEE435 /* SpanAttributesProvider.h */,
-				96D4160B29F276E400AEE435 /* SpanAttributesProvider.mm */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -429,6 +435,8 @@
 			children = (
 				0122C22C29019770002D243C /* AppStartupInstrumentation.h */,
 				0122C22B29019770002D243C /* AppStartupInstrumentation.mm */,
+				CBEBE59829F671A800BF0B4F /* Instrumentation.h */,
+				CBEBE59929F671A800BF0B4F /* Instrumentation.mm */,
 				CB34771929068C350033759C /* NetworkInstrumentation */,
 				0122C22E29019770002D243C /* NetworkInstrumentation.h */,
 				0122C22A29019770002D243C /* NetworkInstrumentation.mm */,
@@ -581,6 +589,7 @@
 				CBE8EA16294B528100702950 /* BugsnagPerformanceImpl.h in Headers */,
 				967F6F1829C3783B0054EED8 /* BugsnagPerformanceConfiguration+Private.h in Headers */,
 				0122C24129019770002D243C /* IdGenerator.h in Headers */,
+				CBEBE59A29F671A800BF0B4F /* Instrumentation.h in Headers */,
 				CBE8EA1E294B5E1500702950 /* Batch.h in Headers */,
 				CBEBE59329F2783C00BF0B4F /* Swizzle.h in Headers */,
 				CBEC51BC296D9EEE009C0CE3 /* PersistentState.h in Headers */,
@@ -807,6 +816,7 @@
 				CBEBE59229F2783C00BF0B4F /* Swizzle.mm in Sources */,
 				01A58C0F29092D25006E4DF7 /* Sampler.mm in Sources */,
 				CBEC51C1296DB312009C0CE3 /* JSON.mm in Sources */,
+				CBEBE59B29F671A800BF0B4F /* Instrumentation.mm in Sources */,
 				0122C24029019770002D243C /* SpanData.mm in Sources */,
 				96D4160C29F276E400AEE435 /* SpanAttributesProvider.mm in Sources */,
 				CBF7C5E2297A8E9100D47719 /* Gzip.m in Sources */,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -22,11 +22,12 @@
 #import "RetryQueue.h"
 #import "AppStateTracker.h"
 #import "Configurable.h"
+#import "Startable.h"
 
 #import <mutex>
 
 namespace bugsnag {
-class BugsnagPerformanceImpl: public Configurable {
+class BugsnagPerformanceImpl: public Configurable, public Startable {
     friend class BugsnagPerformanceLibrary;
 public:
     virtual ~BugsnagPerformanceImpl();
@@ -34,7 +35,7 @@ public:
     void start() noexcept;
 
     void reportNetworkSpan(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept {
-        tracer_.reportNetworkSpan(task, metrics);
+        tracer_->reportNetworkSpan(task, metrics);
     }
 
     BugsnagPerformanceSpan *startSpan(NSString *name) noexcept;
@@ -53,7 +54,7 @@ public:
     void endViewLoadSpan(UIViewController *controller, NSDate *endTime) noexcept;
 
     void reportNetworkRequestSpan(NSURLSessionTask * task, NSURLSessionTaskMetrics *metrics) noexcept {
-        tracer_.reportNetworkSpan(task, metrics);
+        tracer_->reportNetworkSpan(task, metrics);
     }
 
     BugsnagPerformanceSpan *startAppStartSpan(NSString *name, SpanOptions options) noexcept;
@@ -69,7 +70,7 @@ private:
     SpanContextStack *spanContextStack_;
     std::shared_ptr<Batch> batch_;
     std::shared_ptr<class Sampler> sampler_;
-    Tracer tracer_;
+    std::shared_ptr<Tracer> tracer_;
     Worker *worker_{nil};
     BugsnagPerformanceConfiguration *configuration_;
     std::shared_ptr<PersistentState> persistentState_;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.h
@@ -8,17 +8,20 @@
 #pragma once
 
 #import "BugsnagPerformanceImpl.h"
-#import "Instrumentation/AppStartupInstrumentation.h"
 #import "AppStateTracker.h"
+#import "Instrumentation/Instrumentation.h"
+#import "Configurable.h"
+#import "Startable.h"
 
 namespace bugsnag {
 
 /**
  * This singleton instance class ensures the correct initialization order and configuration of all library components.
  */
-class BugsnagPerformanceLibrary {
+class BugsnagPerformanceLibrary: private Configurable, private Startable {
 public:
-    static void configure(BugsnagPerformanceConfiguration *config) noexcept;
+    static void configureLibrary(BugsnagPerformanceConfiguration *config) noexcept;
+    static void startLibrary() noexcept;
 
     static std::shared_ptr<BugsnagPerformanceImpl> getBugsnagPerformanceImpl() noexcept;
     static std::shared_ptr<AppStartupInstrumentation> getAppStartupInstrumentation() noexcept;
@@ -39,13 +42,15 @@ private:
 
     static BugsnagPerformanceLibrary &sharedInstance() noexcept;
 
-    void configureInstance(BugsnagPerformanceConfiguration *config) noexcept;
+    void configure(BugsnagPerformanceConfiguration *config) noexcept;
+    void start() noexcept;
 
     BugsnagPerformanceLibrary();
     AppStateTracker *appStateTracker_;
     std::shared_ptr<Reachability> reachability_;
     std::shared_ptr<BugsnagPerformanceImpl> bugsnagPerformanceImpl_;
     std::shared_ptr<AppStartupInstrumentation> appStartupInstrumentation_;
+    std::shared_ptr<Instrumentation> instrumentation_;
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <mutex>
 #import "../Configurable.h"
+#import "../Startable.h"
 #import "../SpanAttributesProvider.h"
 
 @class BugsnagPerformanceSpan;
@@ -16,21 +17,22 @@ namespace bugsnag {
 
 class BugsnagPerformanceImpl;
 
-class AppStartupInstrumentation: public Configurable {
+class AppStartupInstrumentation: public Configurable, public Startable {
     friend class BugsnagPerformanceLibrary;
 public:
     void configure(BugsnagPerformanceConfiguration *config) noexcept;
+    void start() noexcept;
 
     void didStartViewLoadSpan(NSString *name) noexcept;
 
 private:
+    bool isEnabled_{true}; // AppStartupInstrumentation starts out enabled
     std::shared_ptr<BugsnagPerformanceImpl> bugsnagPerformance_;
     std::shared_ptr<SpanAttributesProvider> spanAttributesProvider_;
     CFAbsoluteTime didStartProcessAtTime_{0};
     CFAbsoluteTime didCallMainFunctionAtTime_{0};
     CFAbsoluteTime didBecomeActiveAtTime_{0};
     CFAbsoluteTime didFinishLaunchingAtTime_{0};
-    bool isDisabled_{false};
     bool isColdLaunch_{false};
     bool shouldRespondToAppDidFinishLaunching_{false};
     bool shouldRespondToAppDidBecomeActive_{false};

--- a/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
@@ -1,0 +1,35 @@
+//
+//  Instrumentation.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 24.04.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import "../Configurable.h"
+#import "../Startable.h"
+#import "../Instrumentation/AppStartupInstrumentation.h"
+#import "../Instrumentation/NetworkInstrumentation.h"
+#import "../Instrumentation/ViewLoadInstrumentation.h"
+
+namespace bugsnag {
+
+class Instrumentation: public Configurable, public Startable {
+public:
+    Instrumentation(std::shared_ptr<AppStartupInstrumentation> appStartupInstrumentation, std::shared_ptr<Tracer> tracer) noexcept
+    : appStartupInstrumentation_(appStartupInstrumentation)
+    , viewLoadInstrumentation_(std::make_shared<ViewLoadInstrumentation>(tracer))
+    , networkInstrumentation_(std::make_shared<NetworkInstrumentation>(tracer))
+    {}
+
+    void configure(BugsnagPerformanceConfiguration *config) noexcept;
+    void start() noexcept;
+private:
+    std::shared_ptr<class AppStartupInstrumentation> appStartupInstrumentation_;
+    std::shared_ptr<class ViewLoadInstrumentation> viewLoadInstrumentation_;
+    std::shared_ptr<class NetworkInstrumentation> networkInstrumentation_;
+};
+
+}

--- a/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.mm
@@ -1,0 +1,23 @@
+//
+//  Instrumentation.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 24.04.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "Instrumentation.h"
+
+using namespace bugsnag;
+
+void Instrumentation::configure(BugsnagPerformanceConfiguration *config) noexcept {
+    appStartupInstrumentation_->configure(config);
+    viewLoadInstrumentation_->configure(config);
+    networkInstrumentation_->configure(config);
+}
+
+void Instrumentation::start() noexcept {
+    appStartupInstrumentation_->start();
+    viewLoadInstrumentation_->start();
+    networkInstrumentation_->start();
+}

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 #import "../Tracer.h"
+#import "../Configurable.h"
+#import "../Startable.h"
 
 @interface BSGURLSessionPerformanceDelegate : NSObject
 @end
@@ -14,13 +16,20 @@
 namespace bugsnag {
 class Tracer;
 
-class NetworkInstrumentation {
+class NetworkInstrumentation: public Configurable, public Startable {
 public:
-    NetworkInstrumentation(Tracer &tracer, NSURL * _Nonnull baseEndpoint) noexcept;
+    NetworkInstrumentation(std::shared_ptr<Tracer> tracer) noexcept
+    : isEnabled(false)
+    , tracer_(tracer)
+    {}
+    virtual ~NetworkInstrumentation() {}
+
+    void configure(BugsnagPerformanceConfiguration * _Nonnull config) noexcept;
     void start() noexcept;
     
 private:
-    BSGURLSessionPerformanceDelegate * _Nonnull delegate_;
-    Tracer &tracer_;
+    bool isEnabled{false};
+    BSGURLSessionPerformanceDelegate * _Nullable delegate_;
+    std::shared_ptr<Tracer> tracer_;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSession+Instrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSession+Instrumentation.mm
@@ -50,6 +50,7 @@ static void replace_NSURLSession_sharedSession() {
     });
 }
 
+
 void bsg_installNSURLSessionPerformance(id<NSURLSessionTaskDelegate> taskDelegate) {
     replace_NSURLSession_sessionWithConfigurationDelegateQueue(taskDelegate);
     replace_NSURLSession_sharedSession();

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -6,17 +6,20 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "../Configurable.h"
+#import "../Tracer.h"
 
 #import <vector>
 
 namespace bugsnag {
 class ViewLoadInstrumentation {
 public:
-    ViewLoadInstrumentation(class Tracer &tracer, BOOL (^ callback)(UIViewController *)) noexcept
-    : tracer_(tracer)
-    , callback_(callback)
+    ViewLoadInstrumentation(std::shared_ptr<Tracer> tracer) noexcept
+    : isEnabled_(false)
+    , tracer_(tracer)
     {}
-    
+
+    void configure(BugsnagPerformanceConfiguration *config) noexcept;
     void start() noexcept;
     
 private:
@@ -32,7 +35,8 @@ private:
 
     void endViewLoadSpan(UIViewController *viewController) noexcept;
 
-    class Tracer &tracer_;
+    bool isEnabled_{false};
+    std::shared_ptr<Tracer> tracer_;
     BOOL (^ callback_)(UIViewController *viewController){nullptr};
     NSSet *observedClasses_{nil};
 };

--- a/Sources/BugsnagPerformance/Private/Startable.h
+++ b/Sources/BugsnagPerformance/Private/Startable.h
@@ -1,0 +1,25 @@
+//
+//  Startable.h
+//  BugsnagPerformance
+//
+//  Created by Karl Stenerud on 24.04.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+namespace bugsnag {
+
+class Startable {
+public:
+    virtual void start() noexcept = 0;
+    virtual ~Startable() {}
+};
+
+}
+
+@protocol BSGStartable
+
+- (void)start;
+
+@end

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -9,14 +9,12 @@
 
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
-#import "Instrumentation/AppStartupInstrumentation.h"
-#import "Instrumentation/NetworkInstrumentation.h"
-#import "Instrumentation/ViewLoadInstrumentation.h"
 #import "Span.h"
 #import "Sampler.h"
 #import "Batch.h"
 #import "SpanOptions.h"
 #import "Configurable.h"
+#import "Startable.h"
 #import "SpanContextStack.h"
 #import "SpanAttributesProvider.h"
 
@@ -28,7 +26,7 @@ namespace bugsnag {
 /**
  * Tracer starts all spans, then samples them and routes them to the batch when they end.
  */
-class Tracer: public Configurable {
+class Tracer: public Configurable, public Startable {
 public:
     Tracer(SpanContextStack *spanContextStack,
            std::shared_ptr<Sampler> sampler,
@@ -57,8 +55,6 @@ public:
 
 private:
     std::shared_ptr<Sampler> sampler_;
-    std::unique_ptr<class ViewLoadInstrumentation> viewLoadInstrumentation_;
-    std::unique_ptr<class NetworkInstrumentation> networkInstrumentation_;
     SpanContextStack *spanContextStack_;
     std::shared_ptr<SpanAttributesProvider> spanAttributesProvider_;
     

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -44,16 +44,6 @@ Tracer::start() noexcept {
     for (auto spanData: *unsampledBatch) {
         tryAddSpanToBatch(spanData);
     }
-
-    if (configuration.autoInstrumentViewControllers) {
-        viewLoadInstrumentation_ = std::make_unique<ViewLoadInstrumentation>(*this, configuration.viewControllerInstrumentationCallback);
-        viewLoadInstrumentation_->start();
-    }
-    
-    if (configuration.autoInstrumentNetworkRequests) {
-        networkInstrumentation_ = std::make_unique<NetworkInstrumentation>(*this, configuration.endpoint);
-        networkInstrumentation_->start();
-    }
 }
 
 BugsnagPerformanceSpan *

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -18,8 +18,8 @@ using namespace bugsnag;
 }
 
 + (void)startWithConfiguration:(BugsnagPerformanceConfiguration *)configuration {
-    BugsnagPerformanceLibrary::configure(configuration);
-    BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->start();
+    BugsnagPerformanceLibrary::configureLibrary(configuration);
+    BugsnagPerformanceLibrary::startLibrary();
 }
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name {

--- a/Tests/BugsnagPerformanceTests/ViewControllerSpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/ViewControllerSpanTests.mm
@@ -26,6 +26,12 @@ using namespace bugsnag;
 
 - (void)testNormalUsage {
     BugsnagPerformanceLibrary::testing_reset();
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"11111111111111111111111111111111"];
+    config.autoInstrumentViewControllers = NO;
+    config.autoInstrumentAppStarts = NO;
+    config.autoInstrumentNetworkRequests = NO;
+    BugsnagPerformanceLibrary::configureLibrary(config);
+    BugsnagPerformanceLibrary::startLibrary();
     auto perf = BugsnagPerformanceLibrary::getBugsnagPerformanceImpl();
     @autoreleasepool {
         UIViewController *controller = [UIViewController new];
@@ -38,6 +44,12 @@ using namespace bugsnag;
 
 - (void)testForgotToEnd {
     BugsnagPerformanceLibrary::testing_reset();
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"11111111111111111111111111111111"];
+    config.autoInstrumentViewControllers = NO;
+    config.autoInstrumentAppStarts = NO;
+    config.autoInstrumentNetworkRequests = NO;
+    BugsnagPerformanceLibrary::configureLibrary(config);
+    BugsnagPerformanceLibrary::startLibrary();
     auto perf = BugsnagPerformanceLibrary::getBugsnagPerformanceImpl();
     @autoreleasepool {
         UIViewController *controller = [UIViewController new];
@@ -70,9 +82,9 @@ using namespace bugsnag;
     config.autoInstrumentViewControllers = YES;
     config.autoInstrumentAppStarts = NO;
     config.autoInstrumentNetworkRequests = NO;
-    BugsnagPerformanceLibrary::configure(config);
+    BugsnagPerformanceLibrary::configureLibrary(config);
+    BugsnagPerformanceLibrary::startLibrary();
     auto perf = BugsnagPerformanceLibrary::getBugsnagPerformanceImpl();
-    perf->start();
     perf->testing_setProbability(1);
     XCTAssertEqual(0U, perf->testing_getBatchCount());
     UIViewController *controller = [MyTestViewController new];


### PR DESCRIPTION
## Goal

This PR moves management of the various instrumentation classes into a new `Instrumentation` class, which is owned by `BugsnagPerformanceLibrary`.

* Instrumentation classes are now `Configurable` and `Startable`, and follow the construct-configure-start pattern.
* `Tracer` instance is now a shared pointer.

These changes are necessary to support upcoming changes to record network spans across their durations rather than as a span recorded at the end (which is prone to incorrect span parentage).

## Testing

No fundamental change in functionality, so existing tests must pass.