### PR TITLE
Refactoring for network span support

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.h
@@ -24,7 +24,6 @@ public:
     static void startLibrary() noexcept;
 
     static std::shared_ptr<BugsnagPerformanceImpl> getBugsnagPerformanceImpl() noexcept;
-    static std::shared_ptr<AppStartupInstrumentation> getAppStartupInstrumentation() noexcept;
     static std::shared_ptr<Reachability> getReachability() noexcept;
     static AppStateTracker *getAppStateTracker() noexcept;
 
@@ -49,8 +48,6 @@ private:
     AppStateTracker *appStateTracker_;
     std::shared_ptr<Reachability> reachability_;
     std::shared_ptr<BugsnagPerformanceImpl> bugsnagPerformanceImpl_;
-    std::shared_ptr<AppStartupInstrumentation> appStartupInstrumentation_;
-    std::shared_ptr<Instrumentation> instrumentation_;
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
@@ -10,6 +10,7 @@
 #import "../Configurable.h"
 #import "../Startable.h"
 #import "../SpanAttributesProvider.h"
+#import "../Tracer.h"
 
 @class BugsnagPerformanceSpan;
 
@@ -18,16 +19,18 @@ namespace bugsnag {
 class BugsnagPerformanceImpl;
 
 class AppStartupInstrumentation: public Configurable, public Startable {
-    friend class BugsnagPerformanceLibrary;
 public:
+    AppStartupInstrumentation(std::shared_ptr<Tracer> tracer,
+                              std::shared_ptr<SpanAttributesProvider> spanAttributesProvider) noexcept;
     void configure(BugsnagPerformanceConfiguration *config) noexcept;
     void start() noexcept;
 
     void didStartViewLoadSpan(NSString *name) noexcept;
+    void willCallMainFunction() noexcept;
 
 private:
     bool isEnabled_{true}; // AppStartupInstrumentation starts out enabled
-    std::shared_ptr<BugsnagPerformanceImpl> bugsnagPerformance_;
+    std::shared_ptr<Tracer> tracer_;
     std::shared_ptr<SpanAttributesProvider> spanAttributesProvider_;
     CFAbsoluteTime didStartProcessAtTime_{0};
     CFAbsoluteTime didCallMainFunctionAtTime_{0};
@@ -45,8 +48,6 @@ private:
 
 private:
     AppStartupInstrumentation() = delete;
-    AppStartupInstrumentation(std::shared_ptr<BugsnagPerformanceImpl> bugsnagPerformance,
-                              std::shared_ptr<SpanAttributesProvider> spanAttributesProvider) noexcept;
 
     // Disable app startup instrumentation and cancel any already-created spans.
     void disable() noexcept;
@@ -63,7 +64,6 @@ private:
                                         const void *object,
                                         CFDictionaryRef userInfo) noexcept;
 
-    void willCallMainFunction() noexcept;
     void onAppDidFinishLaunching() noexcept;
     void onAppDidBecomeActive() noexcept;
     void beginAppStartSpan() noexcept;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
@@ -18,15 +18,21 @@ namespace bugsnag {
 
 class Instrumentation: public Configurable, public Startable {
 public:
-    Instrumentation(std::shared_ptr<AppStartupInstrumentation> appStartupInstrumentation, std::shared_ptr<Tracer> tracer) noexcept
-    : appStartupInstrumentation_(appStartupInstrumentation)
-    , viewLoadInstrumentation_(std::make_shared<ViewLoadInstrumentation>(tracer))
-    , networkInstrumentation_(std::make_shared<NetworkInstrumentation>(tracer))
+    Instrumentation(std::shared_ptr<Tracer> tracer, std::shared_ptr<SpanAttributesProvider> spanAttributesProvider) noexcept
+    : appStartupInstrumentation_(std::make_shared<AppStartupInstrumentation>(tracer, spanAttributesProvider))
+    , viewLoadInstrumentation_(std::make_shared<ViewLoadInstrumentation>(tracer, spanAttributesProvider))
+    , networkInstrumentation_(std::make_shared<NetworkInstrumentation>(tracer, spanAttributesProvider))
     {}
 
     void configure(BugsnagPerformanceConfiguration *config) noexcept;
     void start() noexcept;
+
+    void didStartViewLoadSpan(NSString *name) noexcept { appStartupInstrumentation_->didStartViewLoadSpan(name); }
+    void willCallMainFunction() noexcept { appStartupInstrumentation_->willCallMainFunction(); }
+
 private:
+    Instrumentation() = delete;
+
     std::shared_ptr<class AppStartupInstrumentation> appStartupInstrumentation_;
     std::shared_ptr<class ViewLoadInstrumentation> viewLoadInstrumentation_;
     std::shared_ptr<class NetworkInstrumentation> networkInstrumentation_;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.h
@@ -18,18 +18,21 @@ class Tracer;
 
 class NetworkInstrumentation: public Configurable, public Startable {
 public:
-    NetworkInstrumentation(std::shared_ptr<Tracer> tracer) noexcept
+    NetworkInstrumentation(std::shared_ptr<Tracer> tracer,
+                           std::shared_ptr<SpanAttributesProvider> spanAttributesProvider) noexcept
     : isEnabled(false)
     , tracer_(tracer)
+    , spanAttributesProvider_(spanAttributesProvider)
     {}
     virtual ~NetworkInstrumentation() {}
 
     void configure(BugsnagPerformanceConfiguration * _Nonnull config) noexcept;
     void start() noexcept;
-    
+
 private:
     bool isEnabled{false};
     BSGURLSessionPerformanceDelegate * _Nullable delegate_;
     std::shared_ptr<Tracer> tracer_;
+    std::shared_ptr<SpanAttributesProvider> spanAttributesProvider_;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
@@ -8,7 +8,9 @@
 #import "NetworkInstrumentation.h"
 #import "NetworkInstrumentation/NSURLSession+Instrumentation.h"
 
+#import "../BugsnagPerformanceSpan+Private.h"
 #import "../Span.h"
+#import "../SpanAttributesProvider.h"
 
 #import <objc/runtime.h>
 
@@ -23,17 +25,23 @@ using namespace bugsnag;
 @interface BSGURLSessionPerformanceDelegate () <NSURLSessionTaskDelegate>
 
 @property(readonly,nonatomic) std::shared_ptr<Tracer> tracer;
+@property(readonly,nonatomic) std::shared_ptr<SpanAttributesProvider> spanAttributesProvider;
 @property(readonly,strong,nonatomic) NSString * _Nonnull baseEndpointStr;
 
-- (instancetype) initWithTracer:(std::shared_ptr<Tracer>)tracer  baseEndpoint:(NSURL * _Nonnull)baseEndpoint;
+- (instancetype) initWithTracer:(std::shared_ptr<Tracer>)tracer
+         spanAttributesProvider:(std::shared_ptr<SpanAttributesProvider>)spanAttributesProvider
+                   baseEndpoint:(NSURL * _Nonnull)baseEndpoint;
 
 @end
 
 @implementation BSGURLSessionPerformanceDelegate
 
-- (instancetype) initWithTracer:(std::shared_ptr<Tracer>)tracer baseEndpoint:(NSURL * _Nonnull)baseEndpoint {
+- (instancetype) initWithTracer:(std::shared_ptr<Tracer>)tracer
+         spanAttributesProvider:(std::shared_ptr<SpanAttributesProvider>)spanAttributesProvider
+                   baseEndpoint:(NSURL * _Nonnull)baseEndpoint {
     if ((self = [super init]) != nil) {
         _tracer = tracer;
+        _spanAttributesProvider = spanAttributesProvider;
         _baseEndpointStr = (NSString * _Nonnull)baseEndpoint.absoluteString;
     }
     return self;
@@ -46,14 +54,22 @@ API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0)) {
         return;
     }
 
-    self.tracer->reportNetworkSpan(task, metrics);
+    auto interval = metrics.taskInterval;
+    auto name = task.originalRequest.HTTPMethod;
+    SpanOptions options;
+    options.startTime = dateToAbsoluteTime(interval.startDate);
+    auto span = self.tracer->startNetworkSpan(name, options);
+    [span addAttributes:self.spanAttributesProvider->networkSpanAttributes(task, metrics)];
+    [span endWithEndTime:interval.endDate];
 }
 
 @end
 
 void NetworkInstrumentation::configure(BugsnagPerformanceConfiguration *config) noexcept {
     isEnabled = config.autoInstrumentNetworkRequests;
-    delegate_ = [[BSGURLSessionPerformanceDelegate alloc] initWithTracer:tracer_ baseEndpoint:(NSURL * _Nonnull)config.endpoint];
+    delegate_ = [[BSGURLSessionPerformanceDelegate alloc] initWithTracer:tracer_
+                                                  spanAttributesProvider:spanAttributesProvider_
+                                                            baseEndpoint:(NSURL * _Nonnull)config.endpoint];
 }
 
 void

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -14,9 +14,10 @@
 namespace bugsnag {
 class ViewLoadInstrumentation {
 public:
-    ViewLoadInstrumentation(std::shared_ptr<Tracer> tracer) noexcept
+    ViewLoadInstrumentation(std::shared_ptr<Tracer> tracer, std::shared_ptr<SpanAttributesProvider> spanAttributesProvider) noexcept
     : isEnabled_(false)
     , tracer_(tracer)
+    , spanAttributesProvider_(spanAttributesProvider)
     {}
 
     void configure(BugsnagPerformanceConfiguration *config) noexcept;
@@ -39,5 +40,6 @@ private:
     std::shared_ptr<Tracer> tracer_;
     BOOL (^ callback_)(UIViewController *viewController){nullptr};
     NSSet *observedClasses_{nil};
+    std::shared_ptr<SpanAttributesProvider> spanAttributesProvider_;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Reachability.h
+++ b/Sources/BugsnagPerformance/Private/Reachability.h
@@ -15,8 +15,8 @@
 
 namespace bugsnag {
 class Reachability {
-    friend class BugsnagPerformanceLibrary;
 public:
+    Reachability() noexcept;
     ~Reachability();
 
     enum Connectivity {
@@ -31,8 +31,6 @@ public:
     void addCallback(void (^)(Connectivity));
     
 private:
-    Reachability() noexcept;
-
     static void callback(SCNetworkReachabilityRef target,
                          SCNetworkReachabilityFlags flags,
                          void *info) noexcept;
@@ -52,11 +50,6 @@ private:
     };
     SCNetworkReachabilityRef target_{nullptr};
     Connectivity connectivity_{Connectivity::Unknown};
-
-public:
-    static std::shared_ptr<Reachability> testing_newReachability() {
-        return std::shared_ptr<Reachability>(new Reachability);
-    }
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -31,8 +31,7 @@ public:
     Tracer(SpanContextStack *spanContextStack,
            std::shared_ptr<Sampler> sampler,
            std::shared_ptr<Batch> batch,
-           void (^onSpanStarted)(),
-           std::shared_ptr<SpanAttributesProvider> spanAttributesProvider) noexcept;
+           void (^onSpanStarted)()) noexcept;
     ~Tracer() {};
 
     void configure(BugsnagPerformanceConfiguration *configuration) noexcept;
@@ -49,14 +48,13 @@ public:
                                               NSString *className,
                                               SpanOptions options) noexcept;
 
-    void reportNetworkSpan(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept;
+    BugsnagPerformanceSpan *startNetworkSpan(NSString *httpMethod, SpanOptions options) noexcept;
 
     void cancelQueuedSpan(BugsnagPerformanceSpan *span) noexcept;
 
 private:
     std::shared_ptr<Sampler> sampler_;
     SpanContextStack *spanContextStack_;
-    std::shared_ptr<SpanAttributesProvider> spanAttributesProvider_;
     
     std::shared_ptr<Batch> batch_;
     void (^onSpanStarted_)(){nil};


### PR DESCRIPTION
## Goal

Part 2 preparing for better network span support (part 1 here: https://github.com/bugsnag/bugsnag-cocoa-performance/pull/116)

* Removed some deep accesses (`object.subobject.subsubobject` and the like) and replaced them with forwarder functions.
* Some existing forwarder functions and roundabout access were unnecessary after refactoring.
* The code in `BugsnagPerformanceImpl::reportNetworkSpan` is duplicated for now, but one copy will be removed in a future PR that changes the functionality.

## Testing

No functionality changes, so existing tests must pass as-is.
