### PR TITLE
[PLAT-9743] Start and stop network spans at correct points instead of starting and stopping at the end

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -87,6 +87,8 @@
 		CB7FD934299D31D300499E13 /* BugsnagPerformanceSpanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7FD933299D309B00499E13 /* BugsnagPerformanceSpanContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBB48A3C295EE1E10044E9AC /* ObjCUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */; };
 		CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */; };
+		CBE0872829F806C2007455F2 /* NSURLSessionTask+Instrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE0872629F806C2007455F2 /* NSURLSessionTask+Instrumentation.h */; };
+		CBE0872929F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBE0872729F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm */; };
 		CBE8EA16294B528100702950 /* BugsnagPerformanceImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */; };
 		CBE8EA17294B528100702950 /* BugsnagPerformanceImpl.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */; };
 		CBE8EA1A294B5AB800702950 /* Worker.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA18294B5AB800702950 /* Worker.h */; };
@@ -239,6 +241,8 @@
 		CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCUtils.mm; sourceTree = "<group>"; };
 		CBC90C4429C84DEB00280884 /* Targets.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Targets.h; sourceTree = "<group>"; };
 		CBE0872129F6C6A3007455F2 /* Startable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Startable.h; sourceTree = "<group>"; };
+		CBE0872629F806C2007455F2 /* NSURLSessionTask+Instrumentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSessionTask+Instrumentation.h"; sourceTree = "<group>"; };
+		CBE0872729F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSURLSessionTask+Instrumentation.mm"; sourceTree = "<group>"; };
 		CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceImpl.h; sourceTree = "<group>"; };
 		CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceImpl.mm; sourceTree = "<group>"; };
 		CBE8EA18294B5AB800702950 /* Worker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Worker.h; sourceTree = "<group>"; };
@@ -544,6 +548,8 @@
 				CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */,
 				CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */,
 				CB34771A29068C350033759C /* NSURLSession+Instrumentation.mm */,
+				CBE0872629F806C2007455F2 /* NSURLSessionTask+Instrumentation.h */,
+				CBE0872729F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm */,
 			);
 			path = NetworkInstrumentation;
 			sourceTree = "<group>";
@@ -599,6 +605,7 @@
 				0122C24B29019770002D243C /* ViewLoadInstrumentation.h in Headers */,
 				CBEC51B8296D8386009C0CE3 /* Persistence.h in Headers */,
 				CB34772129068C350033759C /* NSURLSession+Instrumentation.h in Headers */,
+				CBE0872829F806C2007455F2 /* NSURLSessionTask+Instrumentation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -826,6 +833,7 @@
 				01A414D22913C238003152A4 /* Reachability.mm in Sources */,
 				CB34771F29068C350033759C /* BSGURLSessionPerformanceProxy.m in Sources */,
 				CB04969C2915194E0097E526 /* OtlpUploader.mm in Sources */,
+				CBE0872929F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm in Sources */,
 				CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSession+Instrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSession+Instrumentation.mm
@@ -17,7 +17,7 @@ static void replace_NSURLSession_sessionWithConfigurationDelegateQueue(id<NSURLS
     SEL selector = @selector(sessionWithConfiguration:delegate:delegateQueue:);
     typedef NSURLSession *(*IMPPrototype)(id, SEL, NSURLSessionConfiguration *,
                                           id<NSURLSessionDelegate>, NSOperationQueue *);
-    __block IMPPrototype originalIMP = (IMPPrototype)ObjCSwizzle::setMethodImplementation(clazz,
+    __block IMPPrototype originalIMP = (IMPPrototype)ObjCSwizzle::setClassMethodImplementation(clazz,
                                                                    selector,
                                                                    ^(id self,
                                                                      NSURLSessionConfiguration *configuration,
@@ -33,7 +33,7 @@ static void replace_NSURLSession_sessionWithConfigurationDelegateQueue(id<NSURLS
 }
 
 static void replace_NSURLSession_sharedSession() {
-    ObjCSwizzle::setMethodImplementation(NSURLSession.class, @selector(sharedSession), ^(__unused id self) {
+    ObjCSwizzle::setClassMethodImplementation(NSURLSession.class, @selector(sharedSession), ^(__unused id self) {
         static NSURLSession *session;
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSessionTask+Instrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSessionTask+Instrumentation.h
@@ -1,0 +1,18 @@
+//
+//  NSURLSessionTask+Instrumentation.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 25.04.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import "../../Tracer.h"
+
+#import <memory>
+
+void bsg_installNSURLSessionTaskPerformance(std::shared_ptr<bugsnag::Tracer> tracer) noexcept;
+
+extern const void *bsg_associatedNetworkSpanKey;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSessionTask+Instrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSessionTask+Instrumentation.mm
@@ -1,0 +1,64 @@
+//
+//  NSURLSessionTask+Instrumentation.mm
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 25.04.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "NSURLSessionTask+Instrumentation.h"
+#import "../../Swizzle.h"
+#import <objc/runtime.h>
+
+using namespace bugsnag;
+
+static const int associatedSpan = 0;
+const void *bsg_associatedNetworkSpanKey = &associatedSpan;
+
+static NSArray<Class> *getURLSessionTaskClassesWithResumeMethod() {
+    // Modeled after:
+    // https://github.com/AFNetworking/AFNetworking/blob/master/AFNetworking/AFURLSessionManager.m#L355
+
+    if (!NSClassFromString(@"NSURLSessionTask")) {
+        return @[];
+    }
+
+    /* iOS prior to 14 used various CF classes (such as __NSCFURLSessionTask) to implement
+     * the class cluster, after which everything was moved out of Core Framework.
+     *
+     * To account for this, we walk the inheritance chain to find all classes that implement
+     * the methods we're interested in.
+     */
+
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
+    NSURLSessionDataTask *dataTask = [session dataTaskWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@""]];
+
+    auto classes = ObjCSwizzle::getClassesWithSelector(dataTask.class, @selector(resume));
+
+    [dataTask cancel];
+    [session finishTasksAndInvalidate];
+
+    return classes;
+}
+
+static void replace_NSURLSessionTask_resume(Class cls, std::shared_ptr<Tracer> tracer) {
+    SEL selector = @selector(resume);
+    typedef void (*IMPPrototype)(id, SEL);
+    __block IMPPrototype originalIMP = (IMPPrototype)ObjCSwizzle::replaceInstanceMethodOverride(cls,
+                                                                                            selector,
+                                                                                            ^(id self) {
+        SpanOptions options;
+        auto span = tracer->startNetworkSpan([self originalRequest].HTTPMethod, options);
+        objc_setAssociatedObject(self, bsg_associatedNetworkSpanKey, span,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+        originalIMP(self, selector);
+    });
+}
+
+void bsg_installNSURLSessionTaskPerformance(std::shared_ptr<Tracer> tracer) noexcept {
+    for (Class cls in getURLSessionTaskClassesWithResumeMethod()) {
+        replace_NSURLSessionTask_resume(cls, tracer);
+    }
+}

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -172,7 +172,7 @@ void
 ViewLoadInstrumentation::instrument(Class cls) noexcept {
     SEL selector = @selector(loadView);
     IMP loadView __block = nullptr;
-    loadView = ObjCSwizzle::setMethodOverride(cls, selector, ^(id self){
+    loadView = ObjCSwizzle::replaceInstanceMethodOverride(cls, selector, ^(id self){
         Trace(@"%@   -[%s %s]", self, class_getName(cls), sel_getName(selector));
         onLoadView(self);
         reinterpret_cast<void (*)(id, SEL)>(loadView)(self, selector);
@@ -183,7 +183,7 @@ ViewLoadInstrumentation::instrument(Class cls) noexcept {
 
     selector = @selector(viewDidAppear:);
     IMP viewDidAppear __block = nullptr;
-    viewDidAppear = ObjCSwizzle::setMethodOverride(cls, selector, ^(id self, BOOL animated){
+    viewDidAppear = ObjCSwizzle::replaceInstanceMethodOverride(cls, selector, ^(id self, BOOL animated){
         Trace(@"%@   -[%s %s]", self, class_getName(cls), sel_getName(selector));
         reinterpret_cast<void (*)(id, SEL, BOOL)>(viewDidAppear)(self, selector, animated);
         onViewDidAppear(self);
@@ -191,7 +191,7 @@ ViewLoadInstrumentation::instrument(Class cls) noexcept {
 
     selector = @selector(viewWillDisappear:);
     IMP viewWillDisappear __block = nullptr;
-    viewWillDisappear = ObjCSwizzle::setMethodOverride(cls, selector, ^(id self, BOOL animated){
+    viewWillDisappear = ObjCSwizzle::replaceInstanceMethodOverride(cls, selector, ^(id self, BOOL animated){
         Trace(@"%@   -[%s %s]", self, class_getName(cls), sel_getName(selector));
         reinterpret_cast<void (*)(id, SEL, BOOL)>(viewDidAppear)(self, selector, animated);
         onViewWillDisappear(self);

--- a/Sources/BugsnagPerformance/Private/Swizzle.h
+++ b/Sources/BugsnagPerformance/Private/Swizzle.h
@@ -18,13 +18,13 @@ public:
      * Replace a class's current method implementation with a new implementation block, returning the replaced one.
      * Returns nil if the method was not found (in the class or any superclass).
      */
-    static IMP _Nullable setMethodImplementation(Class _Nonnull clazz, SEL _Nonnull selector, id _Nonnull implementationBlock) noexcept;
+    static IMP _Nullable setClassMethodImplementation(Class _Nonnull clazz, SEL _Nonnull selector, id _Nonnull implementationBlock) noexcept;
 
     /**
      * Replace a class's override of a method (i.e. only if this class overrides the method). No superclass implementation is replaced.
      * Returns nil if no method was replaced (either method not found, or this class doesn't overrde the method).
      */
-    static IMP _Nullable setMethodOverride(Class _Nonnull cls, SEL _Nonnull name, id _Nonnull block) noexcept;
+    static IMP _Nullable replaceInstanceMethodOverride(Class _Nonnull cls, SEL _Nonnull name, id _Nonnull block) noexcept;
 
     /**
      * Get any classes or superclasses that implement the specified selector.

--- a/Sources/BugsnagPerformance/Private/Swizzle.mm
+++ b/Sources/BugsnagPerformance/Private/Swizzle.mm
@@ -12,7 +12,7 @@
 
 namespace bugsnag {
 
-IMP ObjCSwizzle::setMethodImplementation(Class _Nonnull clazz, SEL selector, id _Nonnull implementationBlock) noexcept {
+IMP ObjCSwizzle::setClassMethodImplementation(Class _Nonnull clazz, SEL selector, id _Nonnull implementationBlock) noexcept {
     Method method = class_getClassMethod(clazz, selector);
     if (method) {
         return method_setImplementation(method, imp_implementationWithBlock(implementationBlock));
@@ -22,7 +22,7 @@ IMP ObjCSwizzle::setMethodImplementation(Class _Nonnull clazz, SEL selector, id 
     }
 }
 
-IMP ObjCSwizzle::setMethodOverride(Class clazz, SEL selector, id block) noexcept {
+IMP ObjCSwizzle::replaceInstanceMethodOverride(Class clazz, SEL selector, id block) noexcept {
     Method method = nullptr;
 
     // Not using class_getInstanceMethod because we don't want to modify the

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -65,25 +65,50 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
 
-  Scenario: Automatically start a network span
-    Given I run "AutoInstrumentNetworkScenario" and discard the initial p-value request
-    And I wait for 1 span
+  Scenario: Automatically start a network span that has a parent
+    Given I run "AutoInstrumentNetworkWithParentScenario" and discard the initial p-value request
+    And I wait for 2 spans
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "[HTTP/GET]"
-    * every span string attribute "http.flavor" exists
-    * every span string attribute "http.url" matches the regex "http://.*:9340/reflect/"
-    * every span string attribute "http.method" equals "GET"
-    * every span integer attribute "http.status_code" is greater than 0
-    * every span integer attribute "http.response_content_length" is greater than 0
-    * every span string attribute "net.host.connection.type" equals "wifi"
-    * every span string attribute "net.host.connection.subtype" does not exist
+    * a span field "parentSpanId" exists
+    * a span field "parentSpanId" is greater than 0
+    * a span field "parentSpanId" does not exist
+    * a span field "name" equals "[HTTP/GET]"
+    * a span string attribute "http.flavor" exists
+    * a span string attribute "http.url" matches the regex "http://.*:9340/reflect/"
+    * a span string attribute "http.method" equals "GET"
+    * a span integer attribute "http.status_code" is greater than 0
+    * a span integer attribute "http.response_content_length" is greater than 0
+    * a span string attribute "net.host.connection.type" equals "wifi"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span bool attribute "bugsnag.span.first_class" does not exist
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * a span bool attribute "bugsnag.span.first_class" does not exist
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
+  Scenario: Automatically start a network span that has no parent
+    Given I run "AutoInstrumentNetworkNoParentScenario" and discard the initial p-value request
+    And I wait for 2 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * every span field "parentSpanId" does not exist
+    * a span field "name" equals "[HTTP/GET]"
+    * a span string attribute "http.flavor" exists
+    * a span string attribute "http.url" matches the regex "http://.*:9340/reflect/"
+    * a span string attribute "http.method" equals "GET"
+    * a span integer attribute "http.status_code" is greater than 0
+    * a span integer attribute "http.response_content_length" is greater than 0
+    * a span string attribute "net.host.connection.type" equals "wifi"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * a span bool attribute "bugsnag.span.first_class" does not exist
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
-		CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */; };
+		CB3477182901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */; };
 		CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */; };
 		CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */; };
 		CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */; };
@@ -34,6 +34,7 @@
 		CBC90CDE29CDCFF700280884 /* FirstClassNoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */; };
 		CBC90CE029CDD02800280884 /* FirstClassYesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */; };
 		CBC90CE429D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */; };
+		CBE0872B29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */; };
 		CBE43A9929A8EFA3000B4205 /* ProbabilityExpiryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */; };
 		CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
@@ -62,7 +63,7 @@
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
 		CB211D0629EEB615008F748D /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "BugsnagPerformanceConfiguration+Private.h"; path = "../../../../Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
-		CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkScenario.swift; sourceTree = "<group>"; };
+		CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkWithParentScenario.swift; sourceTree = "<group>"; };
 		CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundForegroundScenario.swift; sourceTree = "<group>"; };
 		CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualUIViewLoadScenario.swift; sourceTree = "<group>"; };
 		CBAAE25429125F5F006D4AA0 /* Fixture-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fixture-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -72,6 +73,7 @@
 		CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstClassNoScenario.swift; sourceTree = "<group>"; };
 		CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstClassYesScenario.swift; sourceTree = "<group>"; };
 		CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentSubViewLoadScenario.swift; sourceTree = "<group>"; };
+		CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkNoParentScenario.swift; sourceTree = "<group>"; };
 		CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProbabilityExpiryScenario.swift; sourceTree = "<group>"; };
 		CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSpanScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
@@ -146,7 +148,8 @@
 			isa = PBXGroup;
 			children = (
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
-				CB3477172901481F0033759C /* AutoInstrumentNetworkScenario.swift */,
+				CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */,
+				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
 				CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */,
 				0185C47128F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift */,
 				CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */,
@@ -252,6 +255,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CBE43A9929A8EFA3000B4205 /* ProbabilityExpiryScenario.swift in Sources */,
+				CBE0872B29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift in Sources */,
 				0185C47228F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */,
@@ -263,7 +267,7 @@
 				01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */,
 				CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */,
 				CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */,
-				CB3477182901481F0033759C /* AutoInstrumentNetworkScenario.swift in Sources */,
+				CB3477182901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift in Sources */,
 				CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */,
 				01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */,
 				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkNoParentScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkNoParentScenario.swift
@@ -1,0 +1,34 @@
+//
+//  AutoInstrumentNetworkNoParentScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 25.04.23.
+//
+
+import Foundation
+
+class AutoInstrumentNetworkNoParentScenario: Scenario {
+
+    lazy var baseURL: URL = {
+        var components = URLComponents(string: Scenario.mazeRunnerURL)!
+        components.port = 9340 // `/reflect` listens on a different port :-((
+        return components.url!
+    }()
+
+    override func startBugsnag() {
+        config.autoInstrumentNetworkRequests = true
+        super.startBugsnag()
+    }
+
+    func query(string: String) {
+        let url = URL(string: string, relativeTo: baseURL)!
+        URLSession.shared.dataTask(with: url).resume()
+    }
+
+    override func run() {
+        waitForCurrentBatch()
+        let span = BugsnagPerformance.startSpan(name: "parentSpan")
+        span.end();
+        query(string: "/reflect/?status=200")
+    }
+}

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkWithParentScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkWithParentScenario.swift
@@ -1,5 +1,5 @@
 //
-//  AutoInstrumentNetworkScenario.swift
+//  AutoInstrumentNetworkWithParentScenario.swift
 //  Fixture
 //
 //  Created by Karl Stenerud on 20.10.22.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class AutoInstrumentNetworkScenario: Scenario {
+class AutoInstrumentNetworkWithParentScenario: Scenario {
 
     lazy var baseURL: URL = {
         var components = URLComponents(string: Scenario.mazeRunnerURL)!
@@ -26,7 +26,9 @@ class AutoInstrumentNetworkScenario: Scenario {
     }
 
     override func run() {
-        query(string: "/reflect/?status=200")
         waitForCurrentBatch()
+        let span = BugsnagPerformance.startSpan(name: "parentSpan")
+        query(string: "/reflect/?status=200")
+        span.end();
     }
 }

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -16,10 +16,20 @@ When("I run {string} and discard the initial p-value request") do |scenario|
   }
 end
 
+# Note:
+# every = every single span must have this field, and each must match the expected value
+# all   = every span that has this field must match the expected value
+# a     = at least one span must have this field that matches the expected value
+
 Then('every span field {string} equals {int}') do |key, expected|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   selected_keys = spans.map { |span| span[key] == expected }
   Maze.check.not_includes selected_keys, false
+end
+
+Then('every span field {string} does not exist') do |key|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze.check.nil span['key'] }
 end
 
 Then('every span bool attribute {string} is false') do |attribute|
@@ -37,14 +47,66 @@ Then('every span string attribute {string} does not exist') do |attribute|
   spans.map { |span| Maze.check.nil span['attributes'].find { |a| a['key'] == attribute } }
 end
 
+Then('all span bool attribute {string} is true') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('boolValue') } }.compact
+  selected_attributes.map { |a| Maze::check.true a['value']['boolValue'] }
+end
+
 Then('a span bool attribute {string} is true') do |attribute|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
-  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'] == attribute }['value']['boolValue'] }
-  Maze.check.includes selected_attributes, true
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('boolValue') } }.compact
+  selected_attributes = selected_attributes.map { |a| a['value']['boolValue'] == true }
+  Maze.check.false(selected_attributes.empty?)
+end
+
+Then('all span bool attribute {string} is false') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('boolValue') } }.compact
+  selected_attributes.map { |a| Maze::check.false a['value']['boolValue'] }
 end
 
 Then('a span bool attribute {string} is false') do |attribute|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
-  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'] == attribute }['value']['boolValue'] }
-  Maze.check.includes selected_attributes, false
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('boolValue') } }.compact
+  selected_attributes = selected_attributes.map { |a| a['value']['boolValue'] == false }
+  Maze.check.false(selected_attributes.empty?)
+end
+
+Then('a span field {string} is greater than {int}') do |key, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_keys = spans.map { |span| span[key] and span[key].to_i > expected }
+  Maze.check.false(selected_keys.empty?)
+end
+
+Then('a span field {string} exists') do |key|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_keys = spans.map { |span| span[key] }
+  Maze.check.false(selected_keys.empty?)
+end
+
+Then('a span field {string} does not exist') do |key|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_keys = spans.map { |span| !span[key] }
+  Maze.check.false(selected_keys.empty?)
+end
+
+Then('a span bool attribute {string} does not exist') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_keys = spans.map { |span| !span['attributes'].find { |a| a['key'] == attribute } }
+  Maze.check.false(selected_keys.empty?)
+end
+
+Then('a span string attribute {string} matches the regex {string}') do |attribute, pattern|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('stringValue') } }.compact
+  attribute_values = selected_attributes.map { |a| a['value']['stringValue'] }
+  attribute_values.map { |v| Maze.check.match pattern, v }
+end
+
+Then('a span integer attribute {string} is greater than {int}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') } }.compact
+  attribute_values = selected_attributes.map { |a| a['value']['intValue'].to_i > expected }
+  Maze.check.false(attribute_values.empty?)
 end


### PR DESCRIPTION
## Goal

Network requests were being started and stopped at the end of a network request, which doesn't work well for nested spans because you can end up with the wrong parent.

This PR swizzles `NSURLSessionTask`'s `resume` method, establishing parentage at that point, and then ends the span once the metrics are collected.


## Testing

New e2e tests to check parentage.
