### PR TITLE
[PLAT-10056] Don't convert double values to strings when encoding JSON

### DIFF
--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -194,7 +194,7 @@ OtlpTraceEncoding::encode(NSDictionary *attributes) noexcept {
                     case kCFNumberFloatType:
                     case kCFNumberDoubleType:
                     case kCFNumberCGFloatType:
-                        [result addObject:@{@"key": key, @"value": @{@"doubleValue": [value stringValue]}}];
+                        [result addObject:@{@"key": key, @"value": @{@"doubleValue": value}}];
                         break;
                         
                     default: break;

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -48,8 +48,8 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
 }
 
 - (void)testEncodeDoubleValue {
-    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @1.23}), (@[@{@"key": @"key", @"value": @{@"doubleValue": @"1.23"}}]));
-    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @1.f}), (@[@{@"key": @"key", @"value": @{@"doubleValue": @"1"}}]));
+    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @1.23}), (@[@{@"key": @"key", @"value": @{@"doubleValue": @1.23}}]));
+    XCTAssertEqualObjects(OtlpTraceEncoding::encode(@{@"key": @1.f}), (@[@{@"key": @"key", @"value": @{@"doubleValue": @1.0}}]));
 }
 
 - (void)testEncodeInt32Value {


### PR DESCRIPTION
## Goal

Double values should not be converted to strings when encoding JSON (only integers).
