### PR TITLE
Centralize and fix attribute names

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */; };
 		CBE0872829F806C2007455F2 /* NSURLSessionTask+Instrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE0872629F806C2007455F2 /* NSURLSessionTask+Instrumentation.h */; };
 		CBE0872929F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBE0872729F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm */; };
+		CBE0873229FA984C007455F2 /* BugsnagPerformanceViewType.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBE0873029FA984C007455F2 /* BugsnagPerformanceViewType.mm */; };
+		CBE0873329FA984C007455F2 /* BugsnagPerformanceViewType+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE0873129FA984C007455F2 /* BugsnagPerformanceViewType+Private.h */; };
 		CBE8EA16294B528100702950 /* BugsnagPerformanceImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */; };
 		CBE8EA17294B528100702950 /* BugsnagPerformanceImpl.mm in Sources */ = {isa = PBXBuildFile; fileRef = CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */; };
 		CBE8EA1A294B5AB800702950 /* Worker.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE8EA18294B5AB800702950 /* Worker.h */; };
@@ -243,6 +245,8 @@
 		CBE0872129F6C6A3007455F2 /* Startable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Startable.h; sourceTree = "<group>"; };
 		CBE0872629F806C2007455F2 /* NSURLSessionTask+Instrumentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSessionTask+Instrumentation.h"; sourceTree = "<group>"; };
 		CBE0872729F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSURLSessionTask+Instrumentation.mm"; sourceTree = "<group>"; };
+		CBE0873029FA984C007455F2 /* BugsnagPerformanceViewType.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceViewType.mm; sourceTree = "<group>"; };
+		CBE0873129FA984C007455F2 /* BugsnagPerformanceViewType+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceViewType+Private.h"; sourceTree = "<group>"; };
 		CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceImpl.h; sourceTree = "<group>"; };
 		CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceImpl.mm; sourceTree = "<group>"; };
 		CBE8EA18294B5AB800702950 /* Worker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Worker.h; sourceTree = "<group>"; };
@@ -378,6 +382,8 @@
 				CB78819B29E587CE00A58906 /* BugsnagPerformanceLibrary.h */,
 				CB78819A29E587CE00A58906 /* BugsnagPerformanceLibrary.mm */,
 				0122C23229019770002D243C /* BugsnagPerformanceSpan+Private.h */,
+				CBE0873029FA984C007455F2 /* BugsnagPerformanceViewType.mm */,
+				CBE0873129FA984C007455F2 /* BugsnagPerformanceViewType+Private.h */,
 				CB78819F29E698BF00A58906 /* Configurable.h */,
 				CBEC51D42976BCAD009C0CE3 /* Filesystem.h */,
 				CBEC51D52976BCAD009C0CE3 /* Filesystem.m */,
@@ -577,6 +583,7 @@
 				CB747D24299F6E03003CA1B4 /* SpanContextStack.h in Headers */,
 				0122C25329019770002D243C /* Span.h in Headers */,
 				CB7FD934299D31D300499E13 /* BugsnagPerformanceSpanContext.h in Headers */,
+				CBE0873329FA984C007455F2 /* BugsnagPerformanceViewType+Private.h in Headers */,
 				CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */,
 				CBEC51C0296DB312009C0CE3 /* JSON.h in Headers */,
 				0122C24A29019770002D243C /* AppStartupInstrumentation.h in Headers */,
@@ -833,6 +840,7 @@
 				01A414D22913C238003152A4 /* Reachability.mm in Sources */,
 				CB34771F29068C350033759C /* BSGURLSessionPerformanceProxy.m in Sources */,
 				CB04969C2915194E0097E526 /* OtlpUploader.mm in Sources */,
+				CBE0873229FA984C007455F2 /* BugsnagPerformanceViewType.mm in Sources */,
 				CBE0872929F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm in Sources */,
 				CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */,
 			);

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -347,25 +347,28 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name, Bugsna
     return span;
 }
 
-BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType) noexcept {
+BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *className, BugsnagPerformanceViewType viewType) noexcept {
     SpanOptions options;
-    auto span = tracer_->startViewLoadSpan(viewType, name, options);
+    auto span = tracer_->startViewLoadSpan(viewType, className, options);
+    [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
     possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
-BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType, BugsnagPerformanceSpanOptions *optionsIn) noexcept {
+BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *className, BugsnagPerformanceViewType viewType, BugsnagPerformanceSpanOptions *optionsIn) noexcept {
     auto options = SpanOptions(optionsIn);
-    auto span = tracer_->startViewLoadSpan(viewType, name, options);
+    auto span = tracer_->startViewLoadSpan(viewType, className, options);
+    [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
     possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
 void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, BugsnagPerformanceSpanOptions *optionsIn) noexcept {
     auto options = SpanOptions(optionsIn);
-    auto span = tracer_->startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
-                                          [NSString stringWithUTF8String:object_getClassName(controller)],
-                                          options);
+    auto viewType = BugsnagPerformanceViewTypeUIKit;
+    auto className = [NSString stringWithUTF8String:object_getClassName(controller)];
+    auto span = tracer_->startViewLoadSpan(viewType, className, options);
+    [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
     possiblyMakeSpanCurrent(span, options);
 
     std::lock_guard<std::mutex> guard(viewControllersToSpansMutex_);

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceViewType+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceViewType+Private.h
@@ -1,0 +1,15 @@
+//
+//  BugsnagPerformanceViewType+Private.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 27.04.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceViewType.h>
+
+namespace bugsnag {
+
+NSString *getBugsnagPerformanceViewTypeName(BugsnagPerformanceViewType viewType) noexcept;
+
+}

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceViewType.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceViewType.mm
@@ -1,0 +1,17 @@
+//
+//  BugsnagPerformanceViewType.cpp
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 27.04.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagPerformanceViewType+Private.h"
+
+NSString *bugsnag::getBugsnagPerformanceViewTypeName(BugsnagPerformanceViewType viewType) noexcept {
+    switch (viewType) {
+        case BugsnagPerformanceViewTypeSwiftUI: return @"SwiftUI";
+        case BugsnagPerformanceViewTypeUIKit:   return @"UIKit";
+        default:                                return @"?";
+    }
+}

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -172,14 +172,7 @@ AppStartupInstrumentation::beginAppStartSpan() noexcept {
     SpanOptions options;
     options.startTime = didStartProcessAtTime_;
     appStartSpan_ = tracer_->startAppStartSpan(name, options);
-    NSMutableDictionary *attributes = @{
-        @"bugsnag.app_start.type": isColdLaunch_ ? @"cold" : @"warm",
-        @"bugsnag.span.category": @"app_start",
-    }.mutableCopy;
-    if (firstViewName_ != nullptr) {
-        attributes[@"bugsnag.app_start.first_view_name"] = firstViewName_;
-    }
-    [appStartSpan_ addAttributes:attributes];
+    [appStartSpan_ addAttributes:spanAttributesProvider_->appStartSpanAttributes(firstViewName_, isColdLaunch_)];
 }
 
 void
@@ -195,7 +188,7 @@ AppStartupInstrumentation::beginPreMainSpan() noexcept {
     SpanOptions options;
     options.startTime = didStartProcessAtTime_;
     preMainSpan_ = tracer_->startAppStartSpan(name, options);
-    [preMainSpan_ addAttributes:spanAttributesProvider_->appStartSpanAttributes(@"App launching - pre main()")];
+    [preMainSpan_ addAttributes:spanAttributesProvider_->appStartPhaseSpanAttributes(@"App launching - pre main()")];
 }
 
 void
@@ -211,7 +204,7 @@ AppStartupInstrumentation::beginPostMainSpan() noexcept {
     SpanOptions options;
     options.startTime = didCallMainFunctionAtTime_;
     postMainSpan_ = tracer_->startAppStartSpan(name, options);
-    [postMainSpan_ addAttributes:spanAttributesProvider_->appStartSpanAttributes(@"App launching - post main()")];
+    [postMainSpan_ addAttributes:spanAttributesProvider_->appStartPhaseSpanAttributes(@"App launching - post main()")];
 }
 
 void
@@ -227,7 +220,7 @@ AppStartupInstrumentation::beginUIInitSpan() noexcept {
     SpanOptions options;
     options.startTime = didBecomeActiveAtTime_;
     uiInitSpan_ = tracer_->startAppStartSpan(name, options);
-    [uiInitSpan_ addAttributes:spanAttributesProvider_->appStartSpanAttributes(@"UI init")];
+    [uiInitSpan_ addAttributes:spanAttributesProvider_->appStartPhaseSpanAttributes(@"UI init")];
 }
 
 #pragma mark -

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -74,12 +74,13 @@ ViewLoadInstrumentation::onLoadView(UIViewController *viewController) noexcept {
     if (objc_getAssociatedObject(viewController, &kAssociatedSpan)) {
         return;
     }
-    
+
+    auto viewType = BugsnagPerformanceViewTypeUIKit;
+    auto className = NSStringFromClass([viewController class]);
     SpanOptions options;
-    auto span = tracer_->startViewLoadSpan(BugsnagPerformanceViewTypeUIKit,
-                                           NSStringFromClass([viewController class]),
-                                           options);
-    
+    auto span = tracer_->startViewLoadSpan(viewType, className, options);
+    [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
+
     objc_setAssociatedObject(viewController, &kAssociatedSpan, span,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -14,6 +14,7 @@ public:
     ~SpanAttributesProvider() {};
     
     NSDictionary *networkSpanAttributes(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept;
-    NSDictionary *appStartSpanAttributes(NSString *phase) noexcept;
+    NSDictionary *appStartSpanAttributes(NSString *firstViewName, bool isColdLaunch) noexcept;
+    NSDictionary *appStartPhaseSpanAttributes(NSString *phase) noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 #import <Foundation/Foundation.h>
+#import "BugsnagPerformanceViewType+Private.h"
 
 namespace bugsnag {
 class SpanAttributesProvider {
@@ -16,5 +17,6 @@ public:
     NSDictionary *networkSpanAttributes(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept;
     NSDictionary *appStartSpanAttributes(NSString *firstViewName, bool isColdLaunch) noexcept;
     NSDictionary *appStartPhaseSpanAttributes(NSString *phase) noexcept;
+    NSDictionary *viewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -135,3 +135,13 @@ SpanAttributesProvider::appStartSpanAttributes(NSString *firstViewName, bool isC
     }
     return attributes;
 }
+
+
+NSDictionary *
+SpanAttributesProvider::viewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept {
+    return @{
+        @"bugsnag.span.category": @"view_load",
+        @"bugsnag.view.name": className,
+        @"bugsnag.view.type": getBugsnagPerformanceViewTypeName(viewType)
+    };
+}

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -117,11 +117,21 @@ SpanAttributesProvider::networkSpanAttributes(NSURLSessionTask *task,
 }
 
 NSDictionary *
-SpanAttributesProvider::appStartSpanAttributes(NSString *phase) noexcept {
+SpanAttributesProvider::appStartPhaseSpanAttributes(NSString *phase) noexcept {
     return @{
-        @"bugsnag.span.category": @"app_start",
+        @"bugsnag.span.category": @"app_start_phase",
         @"bugsnag.phase": phase,
     };
 }
 
-
+NSDictionary *
+SpanAttributesProvider::appStartSpanAttributes(NSString *firstViewName, bool isColdLaunch) noexcept {
+    NSMutableDictionary *attributes = @{
+        @"bugsnag.span.category": @"app_start",
+        @"bugsnag.app_start.type": isColdLaunch ? @"cold" : @"warm",
+    }.mutableCopy;
+    if (firstViewName != nullptr) {
+        attributes[@"bugsnag.app_start.first_view_name"] = firstViewName;
+    }
+    return attributes;
+}

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -102,12 +102,7 @@ BugsnagPerformanceSpan *
 Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
                           NSString *className,
                           SpanOptions options) noexcept {
-    NSString *type;
-    switch (viewType) {
-        case BugsnagPerformanceViewTypeSwiftUI: type = @"SwiftUI"; break;
-        case BugsnagPerformanceViewTypeUIKit:   type = @"UIKit"; break;
-        default:                                type = @"?"; break;
-    }
+    NSString *type = getBugsnagPerformanceViewTypeName(viewType);
     onViewLoadSpanStarted_(className);
     NSString *name = [NSString stringWithFormat:@"[ViewLoad/%@]/%@", type, className];
     if (options.firstClass == BSGFirstClassUnset) {
@@ -115,13 +110,7 @@ Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
             options.firstClass = BSGFirstClassNo;
         }
     }
-    auto span = startSpan(name, options, BSGFirstClassYes);
-    [span addAttributes:@{
-        @"bugsnag.span.category": @"view_load",
-        @"bugsnag.view.name": className,
-        @"bugsnag.view.type": type
-    }];
-    return span;
+    return startSpan(name, options, BSGFirstClassYes);
 }
 
 BugsnagPerformanceSpan *

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -19,7 +19,8 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.phase" equals "App launching - pre main()"
     * a span string attribute "bugsnag.phase" equals "App launching - post main()"
     * a span string attribute "bugsnag.phase" equals "UI init"
-    * every span string attribute "bugsnag.span.category" equals "app_start"
+    * a span string attribute "bugsnag.span.category" equals "app_start"
+    * a span string attribute "bugsnag.span.category" equals "app_start_phase"
     * every span bool attribute "bugsnag.span.first_class" does not exist
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"


### PR DESCRIPTION
## Goal

All span attribute names are now centralized in `SpanAttributesProvider`.

Fixed misnamed attribute name (was `app_start`, now `app_start_phase`).

## Testing

Updated tests to check for this.