### PR TITLE
[Plat-10076] Disable viewWillDisappear swizzling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changelog
 
 ## 0.2.0 (2023-04-24)
 
+This release adds nested span support.
+
 ### Breaking changes
 
 The following changes need attention when updating to this version of the library:

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -190,13 +190,14 @@ ViewLoadInstrumentation::instrument(Class cls) noexcept {
         onViewDidAppear(self);
     });
 
-    selector = @selector(viewWillDisappear:);
-    IMP viewWillDisappear __block = nullptr;
-    viewWillDisappear = ObjCSwizzle::replaceInstanceMethodOverride(cls, selector, ^(id self, BOOL animated){
-        Trace(@"%@   -[%s %s]", self, class_getName(cls), sel_getName(selector));
-        reinterpret_cast<void (*)(id, SEL, BOOL)>(viewDidAppear)(self, selector, animated);
-        onViewWillDisappear(self);
-    });
+// Temporarily disabled to stop crashes while we build a more complete solution
+//    selector = @selector(viewWillDisappear:);
+//    IMP viewWillDisappear __block = nullptr;
+//    viewWillDisappear = ObjCSwizzle::replaceInstanceMethodOverride(cls, selector, ^(id self, BOOL animated){
+//        Trace(@"%@   -[%s %s]", self, class_getName(cls), sel_getName(selector));
+//        reinterpret_cast<void (*)(id, SEL, BOOL)>(viewDidAppear)(self, selector, animated);
+//        onViewWillDisappear(self);
+//    });
 }
 
 

--- a/Tests/BugsnagPerformanceTests/ViewControllerSpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/ViewControllerSpanTests.mm
@@ -98,8 +98,9 @@ using namespace bugsnag;
     [controller loadView];
     [controller viewDidLoad];
     XCTAssertEqual(1U, perf->testing_getBatchCount());
-    [controller viewWillDisappear:controller];
-    XCTAssertEqual(2U, perf->testing_getBatchCount());
+// Temporarily disabled to stop crashes while we build a more complete solution
+//    [controller viewWillDisappear:controller];
+//    XCTAssertEqual(2U, perf->testing_getBatchCount());
 }
 
 @end


### PR DESCRIPTION
## Goal

Disable swizzling of `viewWillDisappear` for now until a better solution can be built.

The swizzle code could cause crashes in some multithreaded situations.
