### PR TITLE
[PLAT-9978] Use monotonic clock to counter time skew

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		CB0AD7682965734F002A3FB6 /* BugsnagPerformanceErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD7672965734F002A3FB6 /* BugsnagPerformanceErrors.m */; };
 		CB0AD76A296573FC002A3FB6 /* BugsnagPerformanceErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = CB0AD76929657381002A3FB6 /* BugsnagPerformanceErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB0AD76C296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76B296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm */; };
+		CB2B8A9B2A0924A50054FBBE /* SpanTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB2B8A9A2A0924A50054FBBE /* SpanTests.mm */; };
 		CB34771E29068C350033759C /* NSURLSession+Instrumentation.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB34771A29068C350033759C /* NSURLSession+Instrumentation.mm */; };
 		CB34771F29068C350033759C /* BSGURLSessionPerformanceProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */; };
 		CB34772029068C350033759C /* BSGURLSessionPerformanceProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */; };
@@ -221,6 +222,7 @@
 		CB0AD7672965734F002A3FB6 /* BugsnagPerformanceErrors.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagPerformanceErrors.m; sourceTree = "<group>"; };
 		CB0AD76929657381002A3FB6 /* BugsnagPerformanceErrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceErrors.h; sourceTree = "<group>"; };
 		CB0AD76B296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceConfigurationTests.mm; sourceTree = "<group>"; };
+		CB2B8A9A2A0924A50054FBBE /* SpanTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SpanTests.mm; sourceTree = "<group>"; };
 		CB34771A29068C350033759C /* NSURLSession+Instrumentation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSURLSession+Instrumentation.mm"; sourceTree = "<group>"; };
 		CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGURLSessionPerformanceProxy.m; sourceTree = "<group>"; };
 		CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGURLSessionPerformanceProxy.h; sourceTree = "<group>"; };
@@ -500,6 +502,7 @@
 				01A58C10290931A5006E4DF7 /* SamplerTests.mm */,
 				CB747D26299F934E003CA1B4 /* SpanContextStackTests.mm */,
 				CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */,
+				CB2B8A9A2A0924A50054FBBE /* SpanTests.mm */,
 				CB747D20299E5458003CA1B4 /* TimeTests.mm */,
 				CB7FD928299BA5AD00499E13 /* ViewControllerSpanTests.mm */,
 				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
@@ -799,6 +802,7 @@
 				CB0AD75B295F27DD002A3FB6 /* WorkerTests.mm in Sources */,
 				CBEC51C3296EC0AC009C0CE3 /* JSONTests.mm in Sources */,
 				01A414C52912B93F003152A4 /* ResourceAttributesTests.mm in Sources */,
+				CB2B8A9B2A0924A50054FBBE /* SpanTests.mm in Sources */,
 				CBEC51CE296EEF52009C0CE3 /* PersistenceTests.mm in Sources */,
 				CBEC51D92976D54B009C0CE3 /* FilesystemTests.m in Sources */,
 				CB0AD75D29641B59002A3FB6 /* BatchTests.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #import "SpanData.h"
+#import "Utils.h"
 
 #import <memory>
 
@@ -23,9 +24,21 @@ typedef void (^OnSpanEnd)(std::shared_ptr<SpanData>);
  */
 class Span {
 public:
-    Span(std::shared_ptr<SpanData> data, OnSpanEnd onEnd) noexcept
-    : data_(data)
+    Span(NSString *name,
+         TraceId traceId,
+         SpanId spanId,
+         SpanId parentId,
+         CFAbsoluteTime startTime,
+         BSGFirstClass firstClass,
+         OnSpanEnd onEnd) noexcept
+    : data_(std::make_shared<SpanData>(name,
+                                       traceId,
+                                       spanId,
+                                       parentId,
+                                       currentTimeIfUnset(startTime),
+                                       firstClass))
     , onEnd_(onEnd)
+    , startClock_(currentMonotonicClockNsecIfUnset(startTime))
     {};
     
     Span(const Span&) = delete;
@@ -60,7 +73,16 @@ public:
             return;
         }
 
-        data_->endTime = time;
+        // If our start and end times were both "unset", then it's on us to counter any
+        // clock skew using the monotonic clock.
+        if (isMonotonicClockValid(startClock_)) {
+            auto endClock = currentMonotonicClockNsecIfUnset(time);
+            if (isMonotonicClockValid(endClock)) {
+                time = data_->startTime + ((double)(endClock - startClock_)) / NSEC_PER_SEC;
+            }
+        }
+
+        data_->endTime = currentTimeIfUnset(time);
         onEnd_(data_);
     }
 
@@ -71,6 +93,21 @@ private:
     std::shared_ptr<SpanData> data_;
     OnSpanEnd onEnd_{nil};
     std::atomic<bool> isEnded_{false};
+    uint64_t startClock_{MONOTONIC_CLOCK_INVALID};
+
+    static const uint64_t MONOTONIC_CLOCK_INVALID = 0;
+
+    static bool isMonotonicClockValid(uint64_t clock) {
+        return clock != MONOTONIC_CLOCK_INVALID;
+    }
+
+    static uint64_t currentMonotonicClockNsecIfUnset(CFAbsoluteTime time) {
+        return isCFAbsoluteTimeValid(time) ? MONOTONIC_CLOCK_INVALID : clock_gettime_nsec_np(CLOCK_MONOTONIC);
+    }
+
+    static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
+        return isCFAbsoluteTimeValid(time) ? time : CFAbsoluteTimeGetCurrent();
+    }
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -25,7 +25,7 @@ public:
     
     SpanOptions(BugsnagPerformanceSpanOptions *options)
     : SpanOptions(options.parentContext,
-                  options.startTime == nil ? CFAbsoluteTimeGetCurrent() : dateToAbsoluteTime(options.startTime),
+                  dateToAbsoluteTime(options.startTime),
                   options.makeCurrentContext,
                   options.firstClass)
     {}
@@ -33,13 +33,13 @@ public:
     SpanOptions()
     // These defaults must match the defaults in BugsnagPerformanceSpanOptions.m
     : SpanOptions(nil,
-                  CFAbsoluteTimeGetCurrent(),
+                  CFABSOLUTETIME_INVALID,
                   true,
                   BSGFirstClassUnset)
     {}
     
     id<BugsnagPerformanceSpanContext> parentContext{nil};
-    CFAbsoluteTime startTime{0};
+    CFAbsoluteTime startTime{CFABSOLUTETIME_INVALID};
     bool makeContextCurrent{false};
     BSGFirstClass firstClass{BSGFirstClassUnset};
 };

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -60,12 +60,12 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
         firstClass = defaultFirstClass;
     }
     auto spanId = IdGenerator::generateSpanId();
-    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:std::make_unique<Span>(std::make_shared<SpanData>(name,
+    auto span = [[BugsnagPerformanceSpan alloc] initWithSpan:std::make_unique<Span>(name,
                                                               traceId,
                                                               spanId,
                                                               parentSpanId,
                                                               options.startTime,
-                                                              firstClass),
+                                                              firstClass,
                                        ^void(std::shared_ptr<SpanData> spanData) {
         blockThis->tryAddSpanToBatch(spanData);
     })];

--- a/Sources/BugsnagPerformance/Private/Utils.h
+++ b/Sources/BugsnagPerformance/Private/Utils.h
@@ -47,6 +47,16 @@
 #endif
 
 namespace bugsnag {
+
+// Use NaN to signal an invalid/unset CFAbsoluteTime.
+// WARNING: Do not compare to this value! (NAN == NAN) is always FALSE for ieee754 float.
+// Use isCFAbsoluteTimeValid() instead.
+static const CFAbsoluteTime CFABSOLUTETIME_INVALID = NAN;
+
+static inline bool isCFAbsoluteTimeValid(CFAbsoluteTime time) {
+    return !isnan(time);
+}
+
 template<typename T>
 static inline T *BSGDynamicCast(__unsafe_unretained id obj) {
     if ([obj isKindOfClass:[T class]]) {
@@ -60,7 +70,7 @@ static inline T *BSGDynamicCast(__unsafe_unretained id obj) {
  * CFAbsoluteTime is a double containing the number of seconds since (00:00:00 1 January 2001).
  */
 static inline CFAbsoluteTime dateToAbsoluteTime(NSDate *date) {
-    return date.timeIntervalSinceReferenceDate;
+    return date ? date.timeIntervalSinceReferenceDate : CFABSOLUTETIME_INVALID;
 }
 
 /**

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -25,7 +25,7 @@ using namespace bugsnag;
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 - (void)end {
-    _span->end(CFAbsoluteTimeGetCurrent());
+    _span->end(CFABSOLUTETIME_INVALID);
 }
 
 - (void)endWithEndTime:(NSDate *)endTime {

--- a/Tests/BugsnagPerformanceTests/SpanContextStackTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanContextStackTests.mm
@@ -30,8 +30,7 @@ static std::atomic<int> counter;
 
 static BugsnagPerformanceSpan *newSpan() {
     TraceId tid = {.value = 1};
-    auto data = std::make_unique<SpanData>(@"test", tid, 1, 0, 0, BSGFirstClassUnset);
-    auto span = std::make_unique<Span>(std::move(data), ^(std::shared_ptr<SpanData>) {});
+    auto span = std::make_unique<Span>(@"test", tid, 1, 0, 0, BSGFirstClassUnset, ^(std::shared_ptr<SpanData>) {});
     return [[BugsnagPerformanceSpan alloc] initWithSpan:std::move(span)];
 }
 

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -45,7 +45,7 @@ using namespace bugsnag;
     BugsnagPerformanceSpanOptions *objcOptions = [BugsnagPerformanceSpanOptions new];
     SpanOptions cOptions(objcOptions);
     XCTAssertNil(cOptions.parentContext);
-    XCTAssertTrue(abs(cOptions.startTime - CFAbsoluteTimeGetCurrent()) < 1);
+    XCTAssertTrue(isnan(cOptions.startTime));
     XCTAssertTrue(cOptions.makeContextCurrent);
     XCTAssertEqual(cOptions.firstClass, BSGFirstClassUnset);
 }

--- a/Tests/BugsnagPerformanceTests/SpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanTests.mm
@@ -1,0 +1,143 @@
+//
+//  SpanTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 08.05.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "Span.h"
+#import "SpanData.h"
+
+using namespace bugsnag;
+
+@interface SpanTests : XCTestCase
+
+@end
+
+@implementation SpanTests
+
+static std::shared_ptr<Span> spanWithStartTime(CFAbsoluteTime startTime, OnSpanEnd onEnd) {
+    TraceId tid = {.value = 1};
+    return std::make_shared<Span>(@"test", tid, 1, 0, startTime, BSGFirstClassUnset, onEnd);
+}
+
+- (void)testStartEndUnset {
+    CFAbsoluteTime startTime = CFABSOLUTETIME_INVALID;
+    CFAbsoluteTime endTime = startTime;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqualWithAccuracy(spanData->endTime, CFAbsoluteTimeGetCurrent(), 0.001);
+}
+
+- (void)testStartNearPastEndUnset {
+    CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent() - 0.0005;
+    CFAbsoluteTime endTime = CFABSOLUTETIME_INVALID;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqualWithAccuracy(spanData->endTime, CFAbsoluteTimeGetCurrent(), 0.001);
+}
+
+- (void)testStartUnsetEndNearPast {
+    CFAbsoluteTime startTime = CFABSOLUTETIME_INVALID;
+    CFAbsoluteTime endTime = CFAbsoluteTimeGetCurrent() - 0.0005;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqualWithAccuracy(spanData->endTime, endTime, 0.001);
+}
+
+- (void)testStartUnsetEndNearFuture {
+    CFAbsoluteTime startTime = CFABSOLUTETIME_INVALID;
+    CFAbsoluteTime endTime = CFAbsoluteTimeGetCurrent() + 0.0005;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqualWithAccuracy(spanData->endTime, endTime, 0.001);
+}
+
+- (void)testStartNearPastEndNearFuture {
+    CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent() - 0.0005;
+    CFAbsoluteTime endTime = CFAbsoluteTimeGetCurrent() + 0.0005;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqualWithAccuracy(spanData->endTime, endTime, 0.001);
+}
+
+- (void)testStartFarPastEndUnset {
+    CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent() - 1.0;
+    CFAbsoluteTime endTime = CFABSOLUTETIME_INVALID;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqual(spanData->endTime, CFAbsoluteTimeGetCurrent());
+}
+
+- (void)testStartFarPastEndNearPast {
+    CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent() - 1.0;
+    CFAbsoluteTime endTime = CFAbsoluteTimeGetCurrent() - 0.0005;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqual(spanData->endTime, endTime);
+}
+
+- (void)testStartFarPastEndNearFuture {
+    CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent() - 1.0;
+    CFAbsoluteTime endTime = CFAbsoluteTimeGetCurrent() + 0.0005;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqual(spanData->endTime, endTime);
+}
+
+- (void)testStartNowEndFarFuture {
+    CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
+    CFAbsoluteTime endTime = CFAbsoluteTimeGetCurrent() + 1.0;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqual(spanData->endTime, endTime);
+}
+
+- (void)testStartFarPastEndFarFuture {
+    CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent() - 1.0;
+    CFAbsoluteTime endTime = CFAbsoluteTimeGetCurrent() + 1.0;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqual(spanData->endTime, endTime);
+}
+
+- (void)testStartNearPastEndFarFuture {
+    CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent() - 0.0001;
+    CFAbsoluteTime endTime = CFAbsoluteTimeGetCurrent() + 1.0;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqual(spanData->endTime, endTime);
+}
+
+- (void)testStartNearFutureEndFarFuture {
+    CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent() + 0.0001;
+    CFAbsoluteTime endTime = CFAbsoluteTimeGetCurrent() + 1.0;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqual(spanData->endTime, endTime);
+}
+
+- (void)testStartEndDistantPast {
+    CFAbsoluteTime startTime = 0;
+    CFAbsoluteTime endTime = 0;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    span->end(endTime);
+    XCTAssertEqual(spanData->endTime, endTime);
+}
+
+@end


### PR DESCRIPTION
## Goal

Events like time zone changes, daylight savings and NTP updates can cause the wall clock to skew, giving shortened spans or even spans with a start time before the end time. We want to counter this where we can.

## Design

When the span start time was the current time, and the end time is the current time, use monotonic clock info to adjust the end time in case any clock skew occurred.

## Testing

Added unit tests to make sure the time calculation is accurate.
