### PR TITLE
[PLAT-10066] Rename makeContextCurrent to makeCurrentContext

### DIFF
--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -26,7 +26,7 @@ public:
     SpanOptions(BugsnagPerformanceSpanOptions *options)
     : SpanOptions(options.parentContext,
                   options.startTime == nil ? CFAbsoluteTimeGetCurrent() : dateToAbsoluteTime(options.startTime),
-                  options.makeContextCurrent,
+                  options.makeCurrentContext,
                   options.firstClass)
     {}
     

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -35,7 +35,7 @@
     if ((self = [super init])) {
         _startTime = startTime;
         _parentContext = parentContext;
-        _makeContextCurrent = makeContextCurrent;
+        _makeCurrentContext = makeContextCurrent;
         _firstClass = firstClass;
     }
     return self;
@@ -45,7 +45,7 @@
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     return [BugsnagPerformanceSpanOptions optionsWithStartTime:_startTime
                                                  parentContext:_parentContext
-                                            makeContextCurrent:_makeContextCurrent
+                                            makeContextCurrent:_makeCurrentContext
                                                     firstClass:_firstClass];
 }
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -25,7 +25,7 @@ OBJC_EXPORT
 @property(nonatomic,readwrite,strong) id<BugsnagPerformanceSpanContext> parentContext;
 
 // If true, the span will be added to the current context stack.
-@property(nonatomic,readwrite) BOOL makeContextCurrent;
+@property(nonatomic,readwrite) BOOL makeCurrentContext;
 
 // If true, this span will be considered "first class" on the dashboard.
 @property(nonatomic,readwrite) BSGFirstClass firstClass;

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -37,7 +37,7 @@ using namespace bugsnag;
     BugsnagPerformanceSpanOptions *objcOptions = [BugsnagPerformanceSpanOptions new];
     XCTAssertNil(objcOptions.parentContext);
     XCTAssertNil(objcOptions.startTime);
-    XCTAssertTrue(objcOptions.makeContextCurrent);
+    XCTAssertTrue(objcOptions.makeCurrentContext);
     XCTAssertEqual(objcOptions.firstClass, BSGFirstClassUnset);
 }
 
@@ -55,7 +55,7 @@ using namespace bugsnag;
     BugsnagPerformanceSpanOptions *objcOptions = [BugsnagPerformanceSpanOptions new];
     objcOptions.startTime = [NSDate dateWithTimeIntervalSinceReferenceDate:1.0];
     objcOptions.parentContext = context;
-    objcOptions.makeContextCurrent = true;
+    objcOptions.makeCurrentContext = true;
     objcOptions.firstClass = BSGFirstClassNo;
 
     SpanOptions cOptions(objcOptions);


### PR DESCRIPTION
## Goal

Span option `makeContextCurrent` should be named `makeCurrentContext`
