### PR TITLE
[PLAT-10051] Don't capture file:// URLRequests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Don't capture file:// URLRequests
+  [138](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/138)
+
 ## 0.3.1 (2023-05-10)
 
 ### Bug fixes

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
@@ -104,6 +104,9 @@ NetworkInstrumentation::NetworkInstrumentation(std::shared_ptr<Tracer> tracer,
     if (!isEnabled_) {
         return;
     }
+    if ([task.currentRequest.URL.scheme isEqualToString:@"file"]) {
+        return;
+    }
     SpanOptions options;
     auto span = tracer_->startNetworkSpan(task.originalRequest.HTTPMethod, options);
     objc_setAssociatedObject(task, associatedNetworkSpanKey, span,

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -124,3 +124,18 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.Fixture"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
+  Scenario: Automatically start a network span that is a file:// scheme
+    Given I run "AutoInstrumentFileURLRequestScenario" and discard the initial p-value request
+    And I wait for 2 seconds
+    And I wait for 1 span
+    # We should only see the request to http://bs-local.com:9339/command, not the file:// request
+    Then the trace "Content-Type" header equals "application/json"
+    * a span field "parentSpanId" exists
+    * a span field "parentSpanId" is greater than 0
+    * a span field "parentSpanId" does not exist
+    * a span field "name" equals "[HTTP/GET]"
+    * a span string attribute "http.url" matches the regex "http://.*:9339/command"
+    * a span string attribute "http.method" equals "GET"
+    * a span integer attribute "http.status_code" is greater than 0
+    * a span integer attribute "http.response_content_length" is greater than 0

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
+		CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */; };
 		CB3477182901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */; };
 		CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */; };
 		CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */; };
@@ -63,6 +64,7 @@
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
 		CB211D0629EEB615008F748D /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "BugsnagPerformanceConfiguration+Private.h"; path = "../../../../Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
+		CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentFileURLRequestScenario.swift; sourceTree = "<group>"; };
 		CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkWithParentScenario.swift; sourceTree = "<group>"; };
 		CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundForegroundScenario.swift; sourceTree = "<group>"; };
 		CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualUIViewLoadScenario.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
+				CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */,
 				CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
 				CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */,
@@ -273,6 +276,7 @@
 				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,
 				967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */,
 				CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */,
+				CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,
 				01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */,
 				CBC90CE029CDD02800280884 /* FirstClassYesScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/AutoInstrumentFileURLRequestScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentFileURLRequestScenario.swift
@@ -1,0 +1,23 @@
+//
+//  AutoInstrumentFileURLRequestScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 11.05.23.
+//
+
+import Foundation
+
+class AutoInstrumentFileURLRequestScenario: Scenario {
+
+    override func configure() {
+        super.configure()
+        config.autoInstrumentNetworkRequests = true
+    }
+
+    override func run() {
+        // Force the automatic spans to be sent in a separate trace that we will discard
+        waitForCurrentBatch()
+        let url = URL(string: "file:///x")!
+        URLSession.shared.dataTask(with: url).resume()
+    }
+}


### PR DESCRIPTION
## Goal

We don't want to capture URLRequests that were actually for local files. We only want to capture network requests.

## Design

Check the URL scheme and ignore any that are `file`.

## Testing

Added extra e2e test to verify this.
