### PR TITLE
[PLAT-10063] Don't send network spans for failed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The following changes need attention when updating to this version of the librar
 
 ### Bug fixes
 
+* Don't send network spans for failed requests
+  [140](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/140)
+
 * Don't capture file:// URLRequests
   [138](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/138)
 

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -22,20 +22,11 @@ class ViewController: UIViewController {
         }
     }
 
-    func query(string: String) {
+    @IBAction func DoNetworkRequest(_ sender: Any) {
         let url = URL(string: "https://bugsnag.com")!
-        let semaphore = DispatchSemaphore(value: 0)
-
         let task = URLSession.shared.dataTask(with: url) {(data, response, error) in
-            semaphore.signal()
         }
         task.resume()
-        semaphore.wait()
-        Thread.sleep(forTimeInterval: 1)
-    }
-
-    @IBAction func DoNetworkRequest(_ sender: Any) {
-        query(string: "x")
     }
 
     @IBAction func DoManualSpan(_ sender: Any) {

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
@@ -72,6 +72,12 @@ API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0)) {
         return;
     }
 
+    auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
+
+    if (task.error != nil || task.response == nil || httpResponse.statusCode == 0) {
+        return;
+    }
+
     if (self.baseEndpointStr.length > 0 && [task.originalRequest.URL.absoluteString hasPrefix:self.baseEndpointStr]) {
         return;
     }

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -139,3 +139,8 @@ Feature: Automatic instrumentation spans
     * a span string attribute "http.method" equals "GET"
     * a span integer attribute "http.status_code" is greater than 0
     * a span integer attribute "http.response_content_length" is greater than 0
+
+  Scenario: Don't send an auto network span that failed to send
+    Given I run "AutoInstrumentNetworkBadAddressScenario" and discard the initial p-value request
+    # Only the initial command request should be captured.
+    Then I wait for 1 span

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
 		CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */; };
+		CB2B8A9F2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2B8A9E2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift */; };
 		CB3477182901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */; };
 		CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */; };
 		CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */; };
@@ -65,6 +66,7 @@
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
 		CB211D0629EEB615008F748D /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "BugsnagPerformanceConfiguration+Private.h"; path = "../../../../Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
 		CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentFileURLRequestScenario.swift; sourceTree = "<group>"; };
+		CB2B8A9E2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkBadAddressScenario.swift; sourceTree = "<group>"; };
 		CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkWithParentScenario.swift; sourceTree = "<group>"; };
 		CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundForegroundScenario.swift; sourceTree = "<group>"; };
 		CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualUIViewLoadScenario.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 			children = (
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
 				CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */,
+				CB2B8A9E2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift */,
 				CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
 				CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */,
@@ -276,6 +279,7 @@
 				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,
 				967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */,
 				CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */,
+				CB2B8A9F2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift in Sources */,
 				CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,
 				01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkBadAddressScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkBadAddressScenario.swift
@@ -1,0 +1,33 @@
+//
+//  AutoInstrumentNetworkBadAddressScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 12.05.23.
+//
+
+import Foundation
+
+class AutoInstrumentNetworkBadAddressScenario: Scenario {
+
+    lazy var baseURL: URL = {
+        var components = URLComponents(string: Scenario.mazeRunnerURL)!
+        components.port = 9876 // Use the wrong port
+        return components.url!
+    }()
+
+    override func configure() {
+        super.configure()
+        config.autoInstrumentNetworkRequests = true
+    }
+
+    func query(string: String) {
+        let url = URL(string: string, relativeTo: baseURL)!
+        URLSession.shared.dataTask(with: url).resume()
+    }
+
+    override func run() {
+        // Force the automatic spans to be sent in a separate trace that we will discard
+        waitForCurrentBatch()
+        query(string: "/reflect/?status=200")
+    }
+}


### PR DESCRIPTION
## Goal

If a network request fails (meaning it didn't even get a response from the server), don't record a span for it.

## Testing

Added e2e test