### PR TITLE
[PLAT-10154] Protect span attributes with a mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The following changes need attention when updating to this version of the librar
 
 ### Bug fixes
 
+* Protect against multithreaded span attributes access
+  [146](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/146)
+
 * Don't send network spans for failed requests
   [140](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/140)
 

--- a/Sources/BugsnagPerformance/Private/SpanData.h
+++ b/Sources/BugsnagPerformance/Private/SpanData.h
@@ -12,6 +12,7 @@
 
 #import "IdGenerator.h"
 #import "SpanKind.h"
+#import <mutex>
 
 namespace bugsnag {
 /**
@@ -44,5 +45,8 @@ public:
     CFAbsoluteTime startTime{0};
     CFAbsoluteTime endTime{0};
     BSGFirstClass firstClass{BSGFirstClassUnset};
+
+private:
+    std::mutex mutex_;
 };
 }

--- a/Sources/BugsnagPerformance/Private/SpanData.mm
+++ b/Sources/BugsnagPerformance/Private/SpanData.mm
@@ -31,11 +31,13 @@ SpanData::SpanData(NSString *name,
 
 void
 SpanData::addAttributes(NSDictionary *dictionary) noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
     [this->attributes addEntriesFromDictionary:dictionary];
 }
 
 bool
 SpanData::hasAttribute(NSString *attributeName, id value) noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
     for (id key in attributes) {
         if ([key isEqualToString:attributeName]) {
             return [attributes[key] isEqual:value];

--- a/Tests/BugsnagPerformanceTests/SpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanTests.mm
@@ -140,4 +140,18 @@ static std::shared_ptr<Span> spanWithStartTime(CFAbsoluteTime startTime, OnSpanE
     XCTAssertEqual(spanData->endTime, endTime);
 }
 
+- (void)testMultithreadedAttributesAccess {
+    auto span = spanWithStartTime(0, ^(std::shared_ptr<SpanData>) {});
+
+    [NSThread detachNewThreadWithBlock:^{
+        for (int i = 0; i < 10000000; i++) {
+            span->addAttributes(@{@"a": @(i)});
+        }
+    }];
+
+    for(int i = 0; i < 1000000; i++) {
+        span->hasAttribute(@"a", @1);
+    }
+}
+
 @end


### PR DESCRIPTION
## Goal

It's still technically possible in the early stages of span generation to access the span's attributes in a multithreaded way. Protect against this with a mutex.

## Testing

Added unit test for this.
