### PR TITLE
Remove C++ code from public headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The following changes need attention when updating to this version of the librar
 
 ### Bug fixes
 
+* Removed C++ code from public headers
+  [147](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/147)
+
 * Don't send network spans for failed requests
   [140](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/140)
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
@@ -17,10 +17,8 @@ typedef union {
         uint64_t hi;
     };
 } TraceId;
-static_assert(sizeof(TraceId) == 16, "Compiler issue: TraceId was not 16 bytes long");
 
 typedef uint64_t SpanId;
-static_assert(sizeof(SpanId) == 8, "Compiler issue: SpanId was not 8 bytes long");
 
 
 // https://opentelemetry.io/docs/reference/specification/trace/api/#spancontext


### PR DESCRIPTION
## Goal

`static_assert` is a C++ operation, which shouldn't be in public headers (they need to work with `.m` files).

## Design

These asserts aren't actually needed since the sizes are already guaranteed by the C and CLANG specs.

## Changeset

Removed the static asserts

## Testing

None needed.
