### PR TITLE
Add support for invoking functions on the current scenario

### DIFF
--- a/features/fixtures/ios/Fixture/Fixture.swift
+++ b/features/fixtures/ios/Fixture/Fixture.swift
@@ -7,59 +7,98 @@
 
 import Foundation
 
-func fetchAndExecuteCommand() {
-    NSLog("[Fixture] Preparing to load scenario from \(Scenario.mazeRunnerURL)/command")
-    let url = URL(string: "\(Scenario.mazeRunnerURL)/command")!
-    
-    var request = URLRequest(url: url)
-    request.setValue("application/json", forHTTPHeaderField: "Accept")
-    NSLog("[Fixture] Sending command request \(request.httpMethod!) \(request) \(request.allHTTPHeaderFields!)")
-    
-    URLSession.shared.dataTask(with: request) { data, response, connectionError in
-        if let response = response {
-            if let ur = response as? HTTPURLResponse {
-                NSLog("[Fixture] Server responded: \(ur.statusCode)")
-            } else {
-                NSLog("[Fixture] Server responded: \(response)")
+class Fixture: NSObject {
+    var scenario: Scenario? = nil
+
+    func fetchAndExecuteCommand() {
+        let url = URL(string: "\(Scenario.mazeRunnerURL)/command")!
+
+        var request = URLRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        NSLog("[Fixture] Sending command request to \(Scenario.mazeRunnerURL)/command: \(request.httpMethod!) \(request) \(request.allHTTPHeaderFields!)")
+
+        URLSession.shared.dataTask(with: request) { data, response, connectionError in
+            if let response = response {
+                if let ur = response as? HTTPURLResponse {
+                    NSLog("[Fixture] Server responded: \(ur.statusCode)")
+                } else {
+                    NSLog("[Fixture] Server responded: \(response)")
+                }
+            } else if let error = connectionError {
+                NSLog("[Fixture] Server responded with error: \(error)")
             }
-        } else if let error = connectionError {
-            NSLog("[Fixture] Server responded with error: \(error)")
-        }
-        
-        guard let data = data else { return }
-        NSLog("[Fixture] Server response data: \(String(data: data, encoding: .utf8)!)")
-        
-        let command: Command
-        do {
-            command = try JSONDecoder().decode(Command.self, from: data)
-        } catch {
-            NSLog("[Fixture] JSON decode error: \(error)")
-            return
-        }
-        
-        NSLog("[Fixture] Response decoded. Dispatching command \(command.scenario) on main thread")
-        DispatchQueue.main.async {
-            run(command: command)
-        }
-    }.resume()
-}
 
-func run(command: Command) {
-    NSLog("[Fixture] Running command: \(command.scenario)")
-    let scenarioClass: AnyClass = NSClassFromString("Fixture.\(command.scenario)")!
-    NSLog("[Fixture] Loaded scenario class: \(scenarioClass)")
-    let scenario = (scenarioClass as! NSObject.Type).init() as! Scenario
-    NSLog("[Fixture] Configuring scenario \(scenario)")
-    scenario.configure()
-    NSLog("[Fixture] Clearing persistent data")
-    scenario.clearPersistentData()
-    NSLog("[Fixture] Starting bugsnag")
-    scenario.startBugsnag()
-    NSLog("[Fixture] Running scenario \(scenarioClass)")
-    scenario.run()
-    NSLog("[Fixture] Scenario \(scenarioClass) complete")
-}
+            guard let data = data else { return }
+            NSLog("[Fixture] Server response data: \(String(data: data, encoding: .utf8)!)")
 
-struct Command: Decodable {
-    let scenario: String
+            let command: Command
+            do {
+                command = try JSONDecoder().decode(Command.self, from: data)
+            } catch {
+                NSLog("[Fixture] JSON decode error: \(error)")
+                return
+            }
+
+            NSLog("[Fixture] Response decoded. Dispatching command \(command.action) on main thread")
+            DispatchQueue.main.async {
+                self.runCommand(command: command)
+            }
+        }.resume()
+    }
+
+    private func runCommand(command: Command) {
+        NSLog("[Fixture] Running command [\(command.action)] with args \(command.args)")
+
+        switch command.action {
+        case "run_scenario":
+            runScenario(scenarioName: command.args[0])
+            break
+        case "invoke_method":
+            invokeMethod(methodName: command.args[0], args: Array(command.args[1...]))
+            break;
+        default:
+            assertionFailure("\(command.action): Unknown command")
+        }
+    }
+
+    private func runScenario(scenarioName: String) {
+        NSLog("[Fixture] Running scenario \(scenarioName)")
+        let scenarioClass: AnyClass = NSClassFromString("Fixture.\(scenarioName)")!
+        NSLog("[Fixture] Loaded scenario class: \(scenarioClass)")
+        scenario = (scenarioClass as! NSObject.Type).init() as! Scenario?
+        NSLog("[Fixture] Configuring scenario \(scenarioName)")
+        scenario!.configure()
+        NSLog("[Fixture] Clearing persistent data")
+        scenario!.clearPersistentData()
+        NSLog("[Fixture] Starting bugsnag")
+        scenario!.startBugsnag()
+        NSLog("[Fixture] Running scenario \(scenarioClass)")
+        scenario!.run()
+        NSLog("[Fixture] Scenario \(scenarioClass) complete")
+    }
+
+    private func invokeMethod(methodName: String, args: Array<String>) {
+        NSLog("[Fixture] Invoking: \(methodName) with args \(args) on \(String(describing: scenario!.self))")
+
+        let sel = NSSelectorFromString(methodName)
+        if (!scenario!.responds(to: sel)) {
+            fatalError("\(String(describing: scenario!.self)) does not respond to \(methodName). Did you set the @objcMembers annotation on \(String(describing: scenario!.self))?")
+        }
+
+        switch args.count {
+        case 0:
+            scenario!.perform(sel)
+        case 1:
+            // Note: Parameter must accept a string
+            scenario!.perform(sel, with: args[0])
+        default:
+            fatalError("invoking \(methodName) with args \(args): Fixture currently only supports up to 1 argument")
+        }
+    }
+
+    private struct Command: Decodable {
+        let action: String
+        let args: Array<String>
+    }
+
 }

--- a/features/fixtures/ios/Fixture/ViewController.swift
+++ b/features/fixtures/ios/Fixture/ViewController.swift
@@ -8,8 +8,9 @@
 import UIKit
 
 class ViewController: UIViewController {
+    var fixture: Fixture = Fixture()
     
     @IBAction func fetchCommand(_ sender: UIButton) {
-        fetchAndExecuteCommand()
+        fixture.fetchAndExecuteCommand()
     }
 }

--- a/features/fixtures/ios/Scenarios/AutoInstrumentAppStartsScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentAppStartsScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class AutoInstrumentAppStartsScenario: Scenario {
     
     override func configure() {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentFileURLRequestScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentFileURLRequestScenario.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@objcMembers
 class AutoInstrumentFileURLRequestScenario: Scenario {
 
     override func configure() {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkBadAddressScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkBadAddressScenario.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@objcMembers
 class AutoInstrumentNetworkBadAddressScenario: Scenario {
 
     lazy var baseURL: URL = {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkNoParentScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkNoParentScenario.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@objcMembers
 class AutoInstrumentNetworkNoParentScenario: Scenario {
 
     lazy var baseURL: URL = {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkWithParentScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkWithParentScenario.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@objcMembers
 class AutoInstrumentNetworkWithParentScenario: Scenario {
 
     lazy var baseURL: URL = {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentSubViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentSubViewLoadScenario.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+@objcMembers
 class AutoInstrumentSubViewLoadScenario: Scenario {
     
     override func configure() {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentViewLoadScenario.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+@objcMembers
 class AutoInstrumentViewLoadScenario: Scenario {
     
     override func configure() {

--- a/features/fixtures/ios/Scenarios/BackgroundForegroundScenario.swift
+++ b/features/fixtures/ios/Scenarios/BackgroundForegroundScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class BackgroundForegroundScenario: Scenario {
     var backgroundTask: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier.invalid
 

--- a/features/fixtures/ios/Scenarios/BatchingScenario.swift
+++ b/features/fixtures/ios/Scenarios/BatchingScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class BatchingScenario: Scenario {
 
     override func configure() {

--- a/features/fixtures/ios/Scenarios/BatchingWithTimeoutScenario.swift
+++ b/features/fixtures/ios/Scenarios/BatchingWithTimeoutScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class BatchingWithTimeoutScenario: Scenario {
 
     override func configure() {

--- a/features/fixtures/ios/Scenarios/FirstClassNoScenario.swift
+++ b/features/fixtures/ios/Scenarios/FirstClassNoScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class FirstClassNoScenario: Scenario {
 
     override func run() {

--- a/features/fixtures/ios/Scenarios/FirstClassYesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FirstClassYesScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class FirstClassYesScenario: Scenario {
 
     override func run() {

--- a/features/fixtures/ios/Scenarios/InitialPScenario.swift
+++ b/features/fixtures/ios/Scenarios/InitialPScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class InitialPScenario: Scenario {
 
     override func configure() {

--- a/features/fixtures/ios/Scenarios/ManualNetworkSpanScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualNetworkSpanScenario.swift
@@ -25,6 +25,7 @@ extension MyNetworkDelegate : URLSessionDataDelegate {
     }
 }
 
+@objcMembers
 class ManualNetworkSpanScenario: Scenario {
 
     lazy var baseURL: URL = {

--- a/features/fixtures/ios/Scenarios/ManualSpanBeforeStartScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualSpanBeforeStartScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class ManualSpanBeforeStartScenario: Scenario {
     
     override func startBugsnag() {

--- a/features/fixtures/ios/Scenarios/ManualSpanScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualSpanScenario.swift
@@ -8,6 +8,7 @@
 import Bugsnag
 import BugsnagPerformance
 
+@objcMembers
 class ManualSpanScenario: Scenario {
     
     override func startBugsnag() {

--- a/features/fixtures/ios/Scenarios/ManualUIViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualUIViewLoadScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class ManualUIViewLoadScenario: Scenario {
 
     override func run() {

--- a/features/fixtures/ios/Scenarios/ManualViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualViewLoadScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class ManualViewLoadScenario: Scenario {
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/ParentSpanScenario.swift
+++ b/features/fixtures/ios/Scenarios/ParentSpanScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class ParentSpanScenario: Scenario {
 
     override func configure() {

--- a/features/fixtures/ios/Scenarios/ProbabilityExpiryScenario.swift
+++ b/features/fixtures/ios/Scenarios/ProbabilityExpiryScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class ProbabilityExpiryScenario: Scenario {
     override func configure() {
         super.configure()

--- a/features/fixtures/ios/Scenarios/ReleaseStageNotEnabledScenario.swift
+++ b/features/fixtures/ios/Scenarios/ReleaseStageNotEnabledScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class ReleaseStageNotEnabledScenario: Scenario {
     
     override func configure() {

--- a/features/fixtures/ios/Scenarios/RetryScenario.swift
+++ b/features/fixtures/ios/Scenarios/RetryScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class RetryScenario: Scenario {
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/SamplingProbabilityZeroScenario.swift
+++ b/features/fixtures/ios/Scenarios/SamplingProbabilityZeroScenario.swift
@@ -7,6 +7,7 @@
 
 import BugsnagPerformance
 
+@objcMembers
 class SamplingProbabilityZeroScenario: Scenario {
     
     override func configure() {

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -1,7 +1,26 @@
 # frozen_string_literal: true
 
 When('I run {string}') do |scenario_name|
-  Maze::Server.commands.add({ scenario: scenario_name })
+  Maze::Server.commands.add({ action: "run_scenario", args: [scenario_name] })
+  Maze.driver.click_element :execute_command
+  # Ensure fixture has read the command
+  count = 100
+  sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
+  raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
+end
+
+When('I invoke {string}') do |method_name|
+  Maze::Server.commands.add({ action: "invoke_method", args: [method_name] })
+  Maze.driver.click_element :execute_command
+  # Ensure fixture has read the command
+  count = 100
+  sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
+  raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
+end
+
+When('I invoke {string} with parameter {string}') do |method_name, arg1|
+  # Note: The method will usually be of the form "xyzWithParam:"
+  Maze::Server.commands.add({ action: "invoke_method", args: [method_name, arg1] })
   Maze.driver.click_element :execute_command
   # Ensure fixture has read the command
   count = 100


### PR DESCRIPTION
## Goal

With this PR, maze runner can now invoke arbitrary functions on the scenario:

```
  Scenario: My scenario
    Given I run "MyScenario"
    And I wait for 1 span
    ...
    And I invoke "sendMoreSpans"
    And I wait for 3 spans
    ...
```

## Testing

Tested manually. Updated e2e tests will come in a future PR.
