### PR TITLE
Remove Bugsnag-Span-Sampling header check on AutoInstrumentViewLoadScenario

### DIFF
--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -30,7 +30,6 @@ Feature: Automatic instrumentation spans
     Given I run "AutoInstrumentViewLoadScenario"
     And I wait for 2 spans
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoad/UIKit]/Fixture.ViewController"
     * a span field "name" equals "[ViewLoad/UIKit]/Fixture.AutoInstrumentViewLoadScenario_ViewController"


### PR DESCRIPTION
## Goal

We can't guarantee that the automatic load view spans will always be in the same trace, so this test can't check `Bugsnag-Span-Sampling` without becoming flaky.
