### PR TITLE
Use callbacks to make some e2e tests more robust

### DIFF
--- a/features/fixtures/ios/Scenarios/InitialPScenario.swift
+++ b/features/fixtures/ios/Scenarios/InitialPScenario.swift
@@ -18,7 +18,9 @@ class InitialPScenario: Scenario {
         // Wait to receive an initial P value response.
         waitForCurrentBatch()
         BugsnagPerformance.startSpan(name: "First").end()
-        waitForCurrentBatch()
+    }
+
+    func step2() {
         BugsnagPerformance.startSpan(name: "Second").end()
     }
 }

--- a/features/fixtures/ios/Scenarios/RetryScenario.swift
+++ b/features/fixtures/ios/Scenarios/RetryScenario.swift
@@ -12,7 +12,9 @@ class RetryScenario: Scenario {
     
     override func run() {
         BugsnagPerformance.startSpan(name: "WillRetry").end()
-        waitForCurrentBatch()
+    }
+
+    func step2() {
         BugsnagPerformance.startSpan(name: "Success").end()
     }
 }

--- a/features/initial-p-value.feature
+++ b/features/initial-p-value.feature
@@ -7,6 +7,8 @@ Feature: Initial P values
     * the sampling request "Bugsnag-Span-Sampling" header equals "1:0"
     * the sampling request "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the sampling request payload field "resourceSpans" is an array with 0 elements
+    Then I invoke "step2"
+    And I should receive no traces
 
   Scenario: Initial P value of 1
     Given I set the sampling probability for the next traces to "1"
@@ -16,12 +18,21 @@ Feature: Initial P values
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1:0"
     * the sampling request "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
 
-    Then I wait for 2 spans
+    Then I wait for 1 span
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-
-    * a span field "name" equals "First"
-    * a span field "name" equals "Second"
+    * every span field "name" equals "First"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    Then I discard the oldest trace
+    And I invoke "step2"
+    And I wait for 1 span
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "Second"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -5,9 +5,13 @@ Feature: Manual creation of spans
   Scenario: Retry a manual span
     Given I set the HTTP status code for the next requests to "200,500,200,200"
     And I run "RetryScenario"
-    And I wait for 3 spans
+    And I wait for 1 span
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "WillRetry"
+    Then I discard the oldest trace
+    And I invoke "step2"
+    And I wait for 2 spans
     * a span field "name" equals "WillRetry"
     * a span field "name" equals "Success"
     * every span bool attribute "bugsnag.span.first_class" is true


### PR DESCRIPTION
## Goal

Some of the e2e tests were relying on delays, which can sometimes flake. Instead, use callbacks for better synchronization between mazerunner and the scenarios.
