### PR TITLE
Add subseconds to iso8601 dates even on ios 11

### DIFF
--- a/Sources/BugsnagPerformance/Private/OtlpUploader.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpUploader.mm
@@ -31,13 +31,23 @@ void OtlpUploader::upload(OtlpPackage &package, UploadResultCallback callback) n
     auto urlRequest = [NSMutableURLRequest requestWithURL:(NSURL *)endpoint_];
     [urlRequest setValue:apiKey_ forHTTPHeaderField:@"Bugsnag-Api-Key"];
 
+    NSDate *now = [NSDate new];
+    NSString *suffix = @"";
     NSISO8601DateFormatOptions options = NSISO8601DateFormatWithInternetDateTime;
     if (@available(iOS 11.2, *)) {
         options |= NSISO8601DateFormatWithFractionalSeconds;
+    } else {
+        NSDateComponents *components = [NSCalendar.currentCalendar components:(NSCalendarUnitNanosecond) fromDate:now];
+        NSInteger msec = components.nanosecond / 1000000;
+        suffix = [NSString stringWithFormat:@".%03ldZ", (long)msec];
     }
-    NSString *timestamp = [NSISO8601DateFormatter stringFromDate:[NSDate new]
+    NSString *timestamp = [NSISO8601DateFormatter stringFromDate:now
                                                         timeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]
                                                    formatOptions:options];
+    if (suffix.length > 0) {
+        timestamp = [NSString stringWithFormat:@"%@%@", [timestamp substringToIndex:timestamp.length-1], suffix];
+    }
+
     [urlRequest setValue:timestamp forHTTPHeaderField:@"Bugsnag-Sent-At"];
     package.fillURLRequest(urlRequest);
 


### PR DESCRIPTION
## Goal

iOS 11.2 and below don't support subseconds in the ISO 8601 date formatter.

This PR compensates for that.

## Testing

Manually tested on an ios 11.0 device to ensure the e2e tests still pass.