### PR TITLE
[Plat-10168] device-id improvements

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -80,6 +80,9 @@
 		CB34772129068C350033759C /* NSURLSession+Instrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */; };
 		CB572EAA29BB783200FD7A2A /* AppStateTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = CB572EA829BB783200FD7A2A /* AppStateTracker.h */; };
 		CB572EAB29BB783200FD7A2A /* AppStateTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = CB572EA929BB783200FD7A2A /* AppStateTracker.m */; };
+		CB68FAB92A3C27B9005B2CDB /* PersistentDeviceID.h in Headers */ = {isa = PBXBuildFile; fileRef = CB68FAB72A3C27B9005B2CDB /* PersistentDeviceID.h */; };
+		CB68FABA2A3C27B9005B2CDB /* PersistentDeviceID.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB68FAB82A3C27B9005B2CDB /* PersistentDeviceID.mm */; };
+		CB68FABC2A3C4208005B2CDB /* PersistentDeviceIDTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB68FABB2A3C4208005B2CDB /* PersistentDeviceIDTest.mm */; };
 		CB747D1F299E4984003CA1B4 /* SpanOptionsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */; };
 		CB747D21299E5458003CA1B4 /* TimeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB747D20299E5458003CA1B4 /* TimeTests.mm */; };
 		CB78819C29E587CE00A58906 /* BugsnagPerformanceLibrary.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB78819A29E587CE00A58906 /* BugsnagPerformanceLibrary.mm */; };
@@ -256,6 +259,9 @@
 		CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSession+Instrumentation.h"; sourceTree = "<group>"; };
 		CB572EA829BB783200FD7A2A /* AppStateTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppStateTracker.h; sourceTree = "<group>"; };
 		CB572EA929BB783200FD7A2A /* AppStateTracker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppStateTracker.m; sourceTree = "<group>"; };
+		CB68FAB72A3C27B9005B2CDB /* PersistentDeviceID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PersistentDeviceID.h; sourceTree = "<group>"; };
+		CB68FAB82A3C27B9005B2CDB /* PersistentDeviceID.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PersistentDeviceID.mm; sourceTree = "<group>"; };
+		CB68FABB2A3C4208005B2CDB /* PersistentDeviceIDTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PersistentDeviceIDTest.mm; sourceTree = "<group>"; };
 		CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SpanOptionsTests.mm; sourceTree = "<group>"; };
 		CB747D20299E5458003CA1B4 /* TimeTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TimeTests.mm; sourceTree = "<group>"; };
 		CB78819A29E587CE00A58906 /* BugsnagPerformanceLibrary.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceLibrary.mm; sourceTree = "<group>"; };
@@ -432,6 +438,8 @@
 				CB04969A2915194E0097E526 /* OtlpUploader.mm */,
 				CBEC51B6296D8386009C0CE3 /* Persistence.h */,
 				CBEC51B7296D8386009C0CE3 /* Persistence.mm */,
+				CB68FAB72A3C27B9005B2CDB /* PersistentDeviceID.h */,
+				CB68FAB82A3C27B9005B2CDB /* PersistentDeviceID.mm */,
 				CBEC51BA296D9EED009C0CE3 /* PersistentState.h */,
 				CBEC51BB296D9EED009C0CE3 /* PersistentState.mm */,
 				CB78819F29E698BF00A58906 /* PhasedStartup.h */,
@@ -444,6 +452,7 @@
 				01A58C0C29092D25006E4DF7 /* Sampler.h */,
 				01A58C0D29092D25006E4DF7 /* Sampler.mm */,
 				0122C23529019770002D243C /* Span.h */,
+				96D55C822A1EBA35006D1F29 /* SpanActivityState.h */,
 				01A414CB2913C0F0003152A4 /* SpanAttributes.h */,
 				01A414CC2913C0F0003152A4 /* SpanAttributes.mm */,
 				96D4160D29F276FE00AEE435 /* SpanAttributesProvider.h */,
@@ -452,6 +461,8 @@
 				0122C22129019770002D243C /* SpanData.mm */,
 				0122C22329019770002D243C /* SpanKind.h */,
 				CB7FD935299D330500499E13 /* SpanOptions.h */,
+				96D55C7D2A1EA5A8006D1F29 /* SpanStackingHandler.h */,
+				96D55C7F2A1EA5C6006D1F29 /* SpanStackingHandler.mm */,
 				CBEBE59129F2783C00BF0B4F /* Swizzle.h */,
 				CBEBE59029F2783C00BF0B4F /* Swizzle.mm */,
 				CBC90C4429C84DEB00280884 /* Targets.h */,
@@ -462,9 +473,6 @@
 				015836C3291264E0002F54C8 /* Version.h */,
 				CBE8EA18294B5AB800702950 /* Worker.h */,
 				CBE8EA19294B5AB800702950 /* Worker.mm */,
-				96D55C7D2A1EA5A8006D1F29 /* SpanStackingHandler.h */,
-				96D55C7F2A1EA5C6006D1F29 /* SpanStackingHandler.mm */,
-				96D55C822A1EBA35006D1F29 /* SpanActivityState.h */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -517,17 +525,18 @@
 				CBEC51C2296EC0AC009C0CE3 /* JSONTests.mm */,
 				CBEC51DE29782471009C0CE3 /* OtlpPackageTests.mm */,
 				0122C26029019C05002D243C /* OtlpTraceEncodingTests.mm */,
+				CB68FABB2A3C4208005B2CDB /* PersistentDeviceIDTest.mm */,
 				CBEC51CD296EEF52009C0CE3 /* PersistenceTests.mm */,
 				CBEC51C4296ED8BA009C0CE3 /* PersistentStateTests.mm */,
 				01A414C42912B93F003152A4 /* ResourceAttributesTests.mm */,
 				CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */,
 				01A58C10290931A5006E4DF7 /* SamplerTests.mm */,
 				CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */,
+				96D55C872A1EE26A006D1F29 /* SpanStackingHandlerTests.mm */,
 				CB2B8A9A2A0924A50054FBBE /* SpanTests.mm */,
 				CB747D20299E5458003CA1B4 /* TimeTests.mm */,
 				CB7FD928299BA5AD00499E13 /* ViewControllerSpanTests.mm */,
 				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
-				96D55C872A1EE26A006D1F29 /* SpanStackingHandlerTests.mm */,
 			);
 			path = BugsnagPerformanceTests;
 			sourceTree = "<group>";
@@ -611,6 +620,7 @@
 				0122C23929019770002D243C /* BugsnagPerformanceViewType.h in Headers */,
 				0122C23A29019770002D243C /* BugsnagPerformanceConfiguration.h in Headers */,
 				CBA22C962A0137230066A2C1 /* EarlyConfiguration.h in Headers */,
+				CB68FAB92A3C27B9005B2CDB /* PersistentDeviceID.h in Headers */,
 				CBF7C5E1297A8E9100D47719 /* Gzip.h in Headers */,
 				0122C25329019770002D243C /* Span.h in Headers */,
 				96D55C832A1EBA35006D1F29 /* SpanActivityState.h in Headers */,
@@ -830,6 +840,7 @@
 				96D55C882A1EE26A006D1F29 /* SpanStackingHandlerTests.mm in Sources */,
 				CBEC51D92976D54B009C0CE3 /* FilesystemTests.m in Sources */,
 				CB0AD75D29641B59002A3FB6 /* BatchTests.mm in Sources */,
+				CB68FABC2A3C4208005B2CDB /* PersistentDeviceIDTest.mm in Sources */,
 				CB747D21299E5458003CA1B4 /* TimeTests.mm in Sources */,
 				0122C27129019CEF002D243C /* OtlpTraceEncodingTests.mm in Sources */,
 				962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */,
@@ -868,6 +879,7 @@
 				CBEBE59B29F671A800BF0B4F /* Instrumentation.mm in Sources */,
 				0122C24029019770002D243C /* SpanData.mm in Sources */,
 				96D4160C29F276E400AEE435 /* SpanAttributesProvider.mm in Sources */,
+				CB68FABA2A3C27B9005B2CDB /* PersistentDeviceID.mm in Sources */,
 				CBF7C5E2297A8E9100D47719 /* Gzip.m in Sources */,
 				0122C24829019770002D243C /* NetworkInstrumentation.mm in Sources */,
 				0122C24D29019770002D243C /* ViewLoadInstrumentation.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -23,6 +23,7 @@
 #import "AppStateTracker.h"
 #import "PhasedStartup.h"
 #import "Instrumentation/Instrumentation.h"
+#import "ResourceAttributes.h"
 
 #import <mutex>
 
@@ -75,7 +76,7 @@ private:
     std::shared_ptr<PersistentState> persistentState_;
     std::shared_ptr<OtlpUploader> uploader_;
     std::unique_ptr<RetryQueue> retryQueue_;
-    NSDictionary *resourceAttributes_{nil};
+    std::shared_ptr<ResourceAttributes> resourceAttributes_;
     std::atomic<bool> shouldPersistState_{false};
     std::mutex viewControllersToSpansMutex_;
     NSMapTable<UIViewController *, BugsnagPerformanceSpan *> *viewControllersToSpans_;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -66,6 +66,7 @@ public:
 
 private:
     std::shared_ptr<Persistence> persistence_;
+    std::shared_ptr<PersistentState> persistentState_;
     std::atomic<bool> isStarted_{false};
     std::shared_ptr<SpanStackingHandler> spanStackingHandler_;
     std::shared_ptr<Batch> batch_;
@@ -73,11 +74,10 @@ private:
     std::shared_ptr<Tracer> tracer_;
     Worker *worker_{nil};
     BugsnagPerformanceConfiguration *configuration_;
-    std::shared_ptr<PersistentState> persistentState_;
     std::shared_ptr<OtlpUploader> uploader_;
     std::unique_ptr<RetryQueue> retryQueue_;
+    std::shared_ptr<PersistentDeviceID> deviceID_;
     std::shared_ptr<ResourceAttributes> resourceAttributes_;
-    std::atomic<bool> shouldPersistState_{false};
     std::mutex viewControllersToSpansMutex_;
     NSMapTable<UIViewController *, BugsnagPerformanceSpan *> *viewControllersToSpans_;
     CFAbsoluteTime probabilityExpiry_{0};
@@ -97,13 +97,11 @@ private:
     bool sendCurrentBatchTask() noexcept;
     bool sendRetriesTask() noexcept;
     bool sendPValueRequestTask() noexcept;
-    bool maybePersistStateTask() noexcept;
 
     // Event reactions
     void onBatchFull() noexcept;
     void onConnectivityChanged(Reachability::Connectivity connectivity) noexcept;
     void onProbabilityChanged(double newProbability) noexcept;
-    void onPersistentStateChanged() noexcept;
     void onFilesystemError() noexcept;
     void onWorkInterval() noexcept;
     void onAppEnteredForeground() noexcept;

--- a/Sources/BugsnagPerformance/Private/Persistence.h
+++ b/Sources/BugsnagPerformance/Private/Persistence.h
@@ -15,15 +15,22 @@ namespace bugsnag {
 class Persistence {
 public:
     Persistence() = delete;
-    Persistence(NSString *topLevelDir) noexcept
-    : topLevelDir_(topLevelDir)
-    {}
+    Persistence(NSString *topLevelDir) noexcept;
 
     void start() noexcept;
-    NSError *clear(void) noexcept;
-    NSString *topLevelDirectory(void) noexcept;
+
+    // Clear all "performance" data. "shared" data is unaffected.
+    NSError *clearPerformanceData(void) noexcept;
+
+    // "performance" dir is for regular bugsnag-performance persistent data, and is versioned.
+    NSString *bugsnagPerformanceDir(void) noexcept;
+
+    // "shared" dir is shared between bugsnag and bugsnag-persistence. It is *not* versioned!
+    NSString *bugsnagSharedDir(void) noexcept;
+
 private:
-    NSString *topLevelDir_{nil};
+    NSString *bugsnagSharedDir_{nil};
+    NSString *bugsnagPerformanceDir_{nil};
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/Persistence.mm
+++ b/Sources/BugsnagPerformance/Private/Persistence.mm
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 
-#define PERSISTENCE_VERSION @"v1"
+#define BUGSNAG_PERFORMANCE_PERSISTENCE_VERSION @"v1"
 
 #import "Persistence.h"
 #import "Filesystem.h"
@@ -14,17 +14,40 @@
 
 using namespace bugsnag;
 
+static NSString *bugsnagPerformancePath(NSString *topLevelDir) {
+    // Namespace it to the bundle identifier because all MacOS non-sandboxed apps share the same cache dir.
+    return [topLevelDir stringByAppendingFormat:@"/bugsnag-performance-%@", [[NSBundle mainBundle] bundleIdentifier]];
+}
+
+static NSString *bugsnagSharedPath(NSString *topLevelDir) {
+    return [topLevelDir stringByAppendingFormat:@"/bugsnag-shared-%@", [[NSBundle mainBundle] bundleIdentifier]];
+}
+
+Persistence::Persistence(NSString *topLevelDir) noexcept
+: bugsnagSharedDir_(bugsnagSharedPath(topLevelDir))
+, bugsnagPerformanceDir_(bugsnagPerformancePath(topLevelDir))
+{}
+
 void Persistence::start() noexcept {
     NSError *error = nil;
-    if ((error = [Filesystem ensurePathExists:topLevelDir_]) != nil) {
-        BSGLogError(@"error while initializing persistence: %@", error);
+    if ((error = [Filesystem ensurePathExists:bugsnagPerformanceDir_]) != nil) {
+        BSGLogError(@"error while initializing bugsnag performance persistence dir: %@", error);
+    }
+    if ((error = [Filesystem ensurePathExists:bugsnagSharedDir_]) != nil) {
+        BSGLogError(@"error while initializing bugsnag shared persistence dir: %@", error);
     }
 }
 
-NSString *Persistence::topLevelDirectory(void) noexcept {
-    return [topLevelDir_ stringByAppendingPathComponent:PERSISTENCE_VERSION];
+NSString *Persistence::bugsnagSharedDir(void) noexcept {
+    return bugsnagSharedDir_;
 }
 
-NSError *Persistence::clear(void) noexcept {
-    return [Filesystem rebuildPath:topLevelDir_];
+NSString *Persistence::bugsnagPerformanceDir(void) noexcept {
+    return [bugsnagPerformanceDir_ stringByAppendingPathComponent:BUGSNAG_PERFORMANCE_PERSISTENCE_VERSION];
+}
+
+NSError *Persistence::clearPerformanceData(void) noexcept {
+    return [Filesystem rebuildPath:bugsnagPerformanceDir_];
+
+    // Note: We don't clear bugsnagSharedDir_ because it's shared with the bugsnag notifier.
 }

--- a/Sources/BugsnagPerformance/Private/PersistentDeviceID.h
+++ b/Sources/BugsnagPerformance/Private/PersistentDeviceID.h
@@ -1,0 +1,41 @@
+//
+//  PersistentDeviceID.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 16.06.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import "PhasedStartup.h"
+#import "Persistence.h"
+#import <memory>
+
+NS_ASSUME_NONNULL_BEGIN
+namespace bugsnag {
+class PersistentDeviceID: public PhasedStartup {
+public:
+    PersistentDeviceID() = delete;
+    PersistentDeviceID(std::shared_ptr<Persistence> persistence) noexcept
+    : persistence_(persistence)
+    {}
+
+    void earlyConfigure(BSGEarlyConfiguration *) noexcept {}
+    void earlySetup() noexcept {}
+    void configure(BugsnagPerformanceConfiguration *) noexcept {};
+    void start() noexcept;
+
+    NSString *current() noexcept { return cachedDeviceID_; };
+
+private:
+    std::shared_ptr<Persistence> persistence_;
+    NSString *cachedDeviceID_{@""};
+    NSString *persistenceDir_{nil};
+
+    NSString *getFilePath();
+    NSError *load();
+    NSError *save();
+};
+}
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/PersistentDeviceID.mm
+++ b/Sources/BugsnagPerformance/Private/PersistentDeviceID.mm
@@ -1,0 +1,177 @@
+//
+//  PersistentDeviceID.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 16.06.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "PersistentDeviceID.h"
+#import "Version.h"
+#import "JSON.h"
+#import "Filesystem.h"
+
+#import <CommonCrypto/CommonDigest.h>
+#import <sys/sysctl.h>
+
+using namespace bugsnag;
+
+// Used to compute deviceId; mimics +[BSG_KSSystemInfo CPUArchForCPUType:subType:]
+static NSString *cpuArch() noexcept {
+    cpu_type_t cpuType = 0;
+    auto size = sizeof cpuType;
+    if (sysctlbyname("hw.cputype", &cpuType, &size, NULL, 0) != 0) {
+        return nil;
+    }
+
+    cpu_subtype_t subType = 0;
+    size = sizeof subType;
+    if (sysctlbyname("hw.cpusubtype", &subType, &size, NULL, 0) != 0) {
+        return nil;
+    }
+
+    switch (cpuType) {
+        case CPU_TYPE_ARM: {
+            switch (subType) {
+                case CPU_SUBTYPE_ARM_V6:
+                    return @"armv6";
+                case CPU_SUBTYPE_ARM_V7:
+                    return @"armv7";
+                case CPU_SUBTYPE_ARM_V7F:
+                    return @"armv7f";
+                case CPU_SUBTYPE_ARM_V7K:
+                    return @"armv7k";
+#ifdef CPU_SUBTYPE_ARM_V7S
+                case CPU_SUBTYPE_ARM_V7S:
+                    return @"armv7s";
+#endif
+                case CPU_SUBTYPE_ARM_V8:
+                    return @"armv8";
+            }
+            break;
+        }
+        case CPU_TYPE_ARM64: {
+            switch (subType) {
+                case CPU_SUBTYPE_ARM64E:
+                    return @"arm64e";
+                default:
+                    return @"arm64";
+            }
+        }
+        case CPU_TYPE_ARM64_32: {
+            // Ignore arm64_32_v8 subtype
+            return @"arm64_32";
+        }
+        case CPU_TYPE_X86:
+            return @"x86";
+        case CPU_TYPE_X86_64:
+            return @"x86_64";
+    }
+
+    return nil;
+}
+
+static NSString *sysctlString(const char *name) noexcept {
+    char value[32];
+    auto size = sizeof value;
+    if (sysctlbyname(name, value, &size, NULL, 0) == 0) {
+        value[sizeof value - 1] = '\0';
+        return [NSString stringWithCString:value encoding:NSUTF8StringEncoding];
+    } else {
+        return nil;
+    }
+}
+
+static NSData * _Nonnull dataForString(NSString *str) noexcept {
+    if (str == nil) {
+        return [NSData data];
+    }
+    return (NSData * _Nonnull)[str dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+static bool isAllZeroes(NSData *data) {
+    const uint8_t *bytes = (const uint8_t*)data.bytes;
+    for (NSUInteger i = 0; i < data.length; i++) {
+        if (bytes[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static NSString *newDeviceAndAppHash() {
+    NSMutableData *data = nil;
+
+#if __has_include(<UIKit/UIDevice.h>)
+    data = [NSMutableData dataWithLength:16];
+    [[UIDevice currentDevice].identifierForVendor getUUIDBytes:(uint8_t*)data.mutableBytes];
+#else
+    data = [NSMutableData dataWithLength:6];
+    bsg_kssysctl_getMacAddress(BSGKeyDefaultMacName, [data mutableBytes]);
+#endif
+
+    if (isAllZeroes(data)) {
+        // If we failed to get an initial identifier via Apple APIs, generate a random one.
+        data = [NSMutableData dataWithLength:16];
+        [[NSUUID UUID] getUUIDBytes:(uint8_t *)data.mutableBytes];
+    }
+
+    // Append some device-specific data.
+    [data appendData:dataForString(sysctlString("hw.machine"))];
+    [data appendData:dataForString(sysctlString("hw.model"))];
+    [data appendData:dataForString(cpuArch())];
+
+    // Append the bundle ID.
+    [data appendData:dataForString(NSBundle.mainBundle.bundleIdentifier)];
+
+    // SHA the whole thing.
+    uint8_t sha[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1([data bytes], (CC_LONG)[data length], sha);
+
+    NSMutableString *hash = [NSMutableString string];
+    for (size_t i = 0; i < sizeof(sha); i++) {
+        [hash appendFormat:@"%02x", sha[i]];
+    }
+
+    return hash;
+}
+
+static NSString *getString(NSDictionary* dict, NSString *key) {
+    NSString *value = dict[key];
+    return [value isKindOfClass:[NSString class]] ? value : nil;
+}
+
+NSString *PersistentDeviceID::getFilePath() {
+    return [persistenceDir_ stringByAppendingPathComponent:@"device-id.json"];
+}
+
+NSError *PersistentDeviceID::load() {
+    NSError *error = nil;
+    NSDictionary *dict = JSON::fileToDictionary(getFilePath(), &error);
+    if (error != nil) {
+        return error;
+    }
+
+    cachedDeviceID_ = getString(dict, @"deviceID");
+    return nil;
+}
+
+NSError *PersistentDeviceID::save() {
+    NSError *error = [Filesystem ensurePathExists:persistenceDir_];
+    if (error != nil) {
+        return error;
+    }
+
+    return JSON::dictionaryToFile(getFilePath(), @{
+        @"deviceID": cachedDeviceID_
+    });
+}
+
+void PersistentDeviceID::start() noexcept {
+    persistenceDir_ = persistence_->bugsnagSharedDir();
+    load();
+    if (cachedDeviceID_.length == 0) {
+        cachedDeviceID_ = newDeviceAndAppHash();
+        save();
+    }
+}

--- a/Sources/BugsnagPerformance/Private/ResourceAttributes.h
+++ b/Sources/BugsnagPerformance/Private/ResourceAttributes.h
@@ -8,21 +8,24 @@
 
 #pragma once
 
-#import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
+#import "PhasedStartup.h"
+
 NS_ASSUME_NONNULL_BEGIN
 namespace bugsnag {
-class ResourceAttributes {
+class ResourceAttributes: public PhasedStartup {
 public:
-    ResourceAttributes(BugsnagPerformanceConfiguration *configuration) noexcept
-    : releaseStage_(configuration.releaseStage)
-    , configuration_(configuration)
-    {}
-    
-    NSDictionary *get() noexcept;
+    void earlyConfigure(BSGEarlyConfiguration *) noexcept {}
+    void earlySetup() noexcept {}
+    void configure(BugsnagPerformanceConfiguration *configuration) noexcept;
+    void start() noexcept;
+
+    NSDictionary *get() noexcept { return cachedAttributes_; };
     
 private:
-    BugsnagPerformanceConfiguration * configuration_;
     NSString *releaseStage_{nil};
+    NSString *bundleVersion_{nil};
+    NSString *serviceVersion_{nil};
+    NSDictionary *cachedAttributes_{nil};
 };
 }
 NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/ResourceAttributes.h
+++ b/Sources/BugsnagPerformance/Private/ResourceAttributes.h
@@ -9,11 +9,17 @@
 #pragma once
 
 #import "PhasedStartup.h"
+#import "PersistentDeviceID.h"
+#import <memory>
 
 NS_ASSUME_NONNULL_BEGIN
 namespace bugsnag {
 class ResourceAttributes: public PhasedStartup {
 public:
+    ResourceAttributes(std::shared_ptr<PersistentDeviceID> deviceID) noexcept
+    : deviceID_(deviceID)
+    {}
+
     void earlyConfigure(BSGEarlyConfiguration *) noexcept {}
     void earlySetup() noexcept {}
     void configure(BugsnagPerformanceConfiguration *configuration) noexcept;
@@ -22,6 +28,7 @@ public:
     NSDictionary *get() noexcept { return cachedAttributes_; };
     
 private:
+    std::shared_ptr<PersistentDeviceID> deviceID_;
     NSString *releaseStage_{nil};
     NSString *bundleVersion_{nil};
     NSString *serviceVersion_{nil};

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -7,7 +7,6 @@
 
 #import "Tracer.h"
 
-#import "ResourceAttributes.h"
 #import "SpanAttributes.h"
 #import "Utils.h"
 #import "BugsnagPerformanceSpan+Private.h"

--- a/Tests/BugsnagPerformanceTests/PersistentDeviceIDTest.mm
+++ b/Tests/BugsnagPerformanceTests/PersistentDeviceIDTest.mm
@@ -1,0 +1,55 @@
+//
+//  PersistentDeviceIDTest.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 16.06.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "FileBasedTest.h"
+#import "PersistentDeviceID.h"
+#import <memory.h>
+
+using namespace bugsnag;
+
+@interface PersistentDeviceIDTest : FileBasedTest
+
+@end
+
+@implementation PersistentDeviceIDTest
+
+- (std::shared_ptr<PersistentDeviceID>)newDeviceID {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
+    auto persistence = std::make_shared<Persistence>(self.filePath);
+    auto deviceID = std::make_shared<PersistentDeviceID>(persistence);
+    deviceID->earlyConfigure([BSGEarlyConfiguration new]);
+    deviceID->earlySetup();
+    deviceID->configure(config);
+    deviceID->start();
+    return deviceID;
+}
+
+- (void)testGeneratesID {
+    auto deviceID = [self newDeviceID]->current();
+    XCTAssertEqual(deviceID.length, (NSUInteger)40);
+}
+
+- (void)testGeneratesSameID {
+    auto expectedId = [self newDeviceID]->current();
+
+    auto fm = [NSFileManager defaultManager];
+    NSError *error = nil;
+    [fm removeItemAtPath:self.filePath error:&error];
+    XCTAssertNil(error);
+
+    auto actualId = [self newDeviceID]->current();
+    XCTAssertEqualObjects(expectedId, actualId);
+}
+
+- (void)testIDDoesNotChange {
+    auto expectedId = [self newDeviceID]->current();
+    auto actualId = [self newDeviceID]->current();
+    XCTAssertEqualObjects(expectedId, actualId);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/PersistentStateTests.mm
+++ b/Tests/BugsnagPerformanceTests/PersistentStateTests.mm
@@ -18,40 +18,64 @@ using namespace bugsnag;
 
 @implementation PersistentStateTests
 
+- (std::shared_ptr<PersistentState>)persistentStateWithConfig:(BugsnagPerformanceConfiguration *)config {
+    auto persistence = std::make_shared<Persistence>(self.filePath);
+    auto persistentState = std::make_shared<PersistentState>(persistence);
+    persistentState->earlyConfigure([BSGEarlyConfiguration new]);
+    persistentState->earlySetup();
+    persistentState->configure(config);
+    persistence->start();
+    // Don't start persistentState yet...
+    return persistentState;
+}
+
 - (void)testPersistentState {
+    NSString *expectedPath = [self.filePath stringByAppendingPathComponent:
+                                  [NSString stringWithFormat:@"bugsnag-performance-%@/v1/persistent-state.json",
+                                   NSBundle.mainBundle.bundleIdentifier]];
+
     auto fm = [NSFileManager defaultManager];
-    __block int callbackCallCount = false;
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
 
-    auto state = PersistentState(self.filePath, ^{
-        callbackCallCount++;
-    });
+    XCTAssertFalse([fm fileExistsAtPath:expectedPath]);
 
-    XCTAssertEqual(0, state.probability());
-    XCTAssertFalse([fm fileExistsAtPath:self.filePath]);
-    XCTAssertEqual(0, callbackCallCount);
+    auto state = [self persistentStateWithConfig:config];
 
-    state.setProbability(0.5);
-    XCTAssertEqual(0.5, state.probability());
-    XCTAssertFalse([fm fileExistsAtPath:self.filePath]);
-    XCTAssertEqual(1, callbackCallCount);
+    // Default BugsnagPerformanceConfiguration probability is 1
+    XCTAssertEqual(1, state->probability());
 
-    state.setProbability(0.6);
-    XCTAssertEqual(0.6, state.probability());
-    XCTAssertFalse([fm fileExistsAtPath:self.filePath]);
-    XCTAssertEqual(2, callbackCallCount);
+    // File gets created on start()
+    XCTAssertFalse([fm fileExistsAtPath:expectedPath]);
+    state->start();
+    XCTAssertTrue([fm fileExistsAtPath:expectedPath]);
+    XCTAssertEqual(1, state->probability());
 
-    state.persist();
-    XCTAssertTrue([fm fileExistsAtPath:self.filePath]);
+    config.samplingProbability = 0.1;
+    state = [self persistentStateWithConfig:config];
+    // pre-start probability uses config
+    XCTAssertEqual(0.1, state->probability());
+    // start() loads persisted data, which overrides config probability
+    state->start();
+    XCTAssertEqual(1, state->probability());
 
-    callbackCallCount = 0;
-    state = PersistentState(self.filePath, ^{
-        callbackCallCount++;
-    });
-    XCTAssertEqual(0, state.probability());
-    XCTAssertNil(state.load());
-    XCTAssertEqual(0.6, state.probability());
-    XCTAssertTrue([fm fileExistsAtPath:self.filePath]);
-    XCTAssertEqual(0, callbackCallCount);
+    // Corrupt or missing file reverts to the config probability
+    [fm removeItemAtPath:expectedPath error:nil];
+    config.samplingProbability = 0.1;
+    state = [self persistentStateWithConfig:config];
+    state->start();
+    XCTAssertEqual(0.1, state->probability());
+
+    // Multiple changes are properly reflected
+    state->setProbability(0.5);
+    XCTAssertEqual(0.5, state->probability());
+    state->setProbability(0.6);
+    XCTAssertEqual(0.6, state->probability());
+
+    // ... even after reload
+    config.samplingProbability = 0.1;
+    state = [self persistentStateWithConfig:config];
+    state->start();
+    XCTAssertEqual(0.6, state->probability());
 }
 
 @end

--- a/Tests/BugsnagPerformanceTests/ResourceAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/ResourceAttributesTests.mm
@@ -6,14 +6,15 @@
 //  Copyright © 2022 Bugsnag. All rights reserved.
 //
 
-#import <XCTest/XCTest.h>
+#import "FileBasedTest.h"
 
 #import "../../Sources/BugsnagPerformance/Private/ResourceAttributes.h"
+#import "../../Sources/BugsnagPerformance/Private/PersistentState.h"
 #import <memory>
 
 using namespace bugsnag;
 
-@interface ResourceAttributesTests : XCTestCase
+@interface ResourceAttributesTests : FileBasedTest
 
 @property(nonatomic,readwrite,strong) BugsnagPerformanceConfiguration *config;
 
@@ -22,6 +23,7 @@ using namespace bugsnag;
 @implementation ResourceAttributesTests
 
 - (void)setUp {
+    [super setUp];
     NSError *error = nil;
     self.config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
     XCTAssertNil(error);
@@ -33,10 +35,18 @@ using namespace bugsnag;
 }
 
 - (std::shared_ptr<ResourceAttributes>) resourceAttributesWithConfig:(BugsnagPerformanceConfiguration *)config {
-    auto attributes = std::make_shared<ResourceAttributes>();
+    auto persistence = std::make_shared<Persistence>(self.filePath);
+    auto deviceID = std::make_shared<PersistentDeviceID>(persistence);
+    auto attributes = std::make_shared<ResourceAttributes>(deviceID);
+
+    deviceID->earlyConfigure([BSGEarlyConfiguration new]);
     attributes->earlyConfigure([BSGEarlyConfiguration new]);
+    deviceID->earlySetup();
     attributes->earlySetup();
+    deviceID->configure(config);
     attributes->configure(config);
+    persistence->start();
+    deviceID->start();
     attributes->start();
     return attributes;
 }


### PR DESCRIPTION
## Goal

This PR makes the device ID generation reliable and repeatable.

## Design

We use the same algorithm as bugsnag-cocoa, but also account for the Apple APIs failing, in which case we seed from a random UUID.

The generated device ID is persisted across launches. Device ID persistence goes into a separate "bugsnag-shared" directory off the top cache dir so that the same algorithm can later be implemented in bugsnag-cocoa.

Note: Clearing persistence does *not* clear the "bugsnag-shared" directory.

## Changeset

Some classes needed to be converted over to `PhasedStartup`.

## Testing

Added tests to ensure the stability and robustness of the algorithm.
