### PR TITLE
Remove public access to the samplingProbability config option

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 		CBA22C942A0137230066A2C1 /* EarlyConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EarlyConfiguration.h; sourceTree = "<group>"; };
 		CBA22C952A0137230066A2C1 /* EarlyConfiguration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EarlyConfiguration.mm; sourceTree = "<group>"; };
 		CBA22C982A03EA300066A2C1 /* NetworkCommon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkCommon.h; sourceTree = "<group>"; };
+		CBA686CB2A41AE2700C7BD39 /* BugsnagPerformanceTestsApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceTestsApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCUtils.h; sourceTree = "<group>"; };
 		CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCUtils.mm; sourceTree = "<group>"; };
 		CBC90C4429C84DEB00280884 /* Targets.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Targets.h; sourceTree = "<group>"; };
@@ -565,11 +566,12 @@
 			isa = PBXGroup;
 			children = (
 				96D415F229E6ADC500AEE435 /* AppDelegate.swift */,
-				96D415F629E6ADC500AEE435 /* ViewController.swift */,
-				96D415F829E6ADC500AEE435 /* Main.storyboard */,
 				96D415FB29E6ADC600AEE435 /* Assets.xcassets */,
-				96D415FD29E6ADC600AEE435 /* LaunchScreen.storyboard */,
+				CBA686CB2A41AE2700C7BD39 /* BugsnagPerformanceTestsApp-Bridging-Header.h */,
 				96D4160029E6ADC600AEE435 /* Info.plist */,
+				96D415FD29E6ADC600AEE435 /* LaunchScreen.storyboard */,
+				96D415F829E6ADC500AEE435 /* Main.storyboard */,
+				96D415F629E6ADC500AEE435 /* ViewController.swift */,
 			);
 			path = BugsnagPerformanceTestsApp;
 			sourceTree = "<group>";
@@ -761,6 +763,7 @@
 					96D415EF29E6ADC500AEE435 = {
 						CreatedOnToolsVersion = 14.2;
 						DevelopmentTeam = 7W9PZ27Y5F;
+						LastSwiftMigration = 1420;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -975,6 +978,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "BugsnagPerformanceTestsApp/BugsnagPerformanceTestsApp-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -996,6 +1000,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "BugsnagPerformanceTestsApp/BugsnagPerformanceTestsApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BugsnagPerformanceTestsApp.app/BugsnagPerformanceTestsApp";
@@ -1255,6 +1260,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "BugsnagPerformanceTestsApp/BugsnagPerformanceTestsApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BugsnagPerformanceTestsApp.app/BugsnagPerformanceTestsApp";
@@ -1274,6 +1280,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "BugsnagPerformanceTestsApp/BugsnagPerformanceTestsApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BugsnagPerformanceTestsApp.app/BugsnagPerformanceTestsApp";
@@ -1287,6 +1294,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7W9PZ27Y5F;
@@ -1304,6 +1312,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "BugsnagPerformanceTestsApp/BugsnagPerformanceTestsApp-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1315,6 +1325,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7W9PZ27Y5F;
@@ -1332,6 +1343,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "BugsnagPerformanceTestsApp/BugsnagPerformanceTestsApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;

--- a/BugsnagPerformanceTestsApp/BugsnagPerformanceTestsApp-Bridging-Header.h
+++ b/BugsnagPerformanceTestsApp/BugsnagPerformanceTestsApp-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "BugsnagPerformanceConfiguration+Private.h"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+## TBD
+
+### Breaking changes
+
+The following changes need attention when updating to this version of the library:
+
+* RRemove public access to the samplingProbability config option because it gets too confusing when mixed with server-side P values.
+  [174](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/174)
+
 ## 0.6.0 (2023-06-15)
 
 ### Breaking changes

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,readwrite) CFTimeInterval probabilityValueExpiresAfterSeconds;
 @property(nonatomic,readwrite) CFTimeInterval probabilityRequestsPauseForSeconds;
 
+@property (nonatomic) double initialSamplingProbability;
+
 /**
  * Delay between sending the initial P value request and doing the first cycle of work
  * (to ensure that the initial P value request span is the first one received during an e2e test)

--- a/Sources/BugsnagPerformance/Private/PersistentState.h
+++ b/Sources/BugsnagPerformance/Private/PersistentState.h
@@ -26,7 +26,7 @@ public:
 
     void earlyConfigure(BSGEarlyConfiguration *) noexcept {}
     void earlySetup() noexcept {}
-    void configure(BugsnagPerformanceConfiguration *config) noexcept;
+    void configure(BugsnagPerformanceConfiguration *) noexcept;
     void start() noexcept;
 
     void setProbability(double probability) noexcept;
@@ -37,7 +37,7 @@ private:
     std::shared_ptr<Persistence> persistence_;
     NSString *jsonFilePath_{nil};
     NSString *persistentStateDir_{nil};
-    double probability_{0};
+    double probability_{1.0};
 
     NSError *persist() noexcept;
 };

--- a/Sources/BugsnagPerformance/Private/PersistentState.mm
+++ b/Sources/BugsnagPerformance/Private/PersistentState.mm
@@ -9,6 +9,7 @@
 #import "PersistentState.h"
 #import "JSON.h"
 #import "Filesystem.h"
+#import "BugsnagPerformanceConfiguration+Private.h"
 
 using namespace bugsnag;
 
@@ -37,7 +38,7 @@ NSError *PersistentState::persist() noexcept {
 }
 
 void PersistentState::configure(BugsnagPerformanceConfiguration *config) noexcept {
-    probability_ = config.samplingProbability;
+    probability_ = config.internal.initialSamplingProbability;
 };
 
 void PersistentState::start() noexcept {

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -29,7 +29,6 @@ static NSString *defaultEndpoint = @"https://otlp.bugsnag.com/v1/traces";
 #else
         _releaseStage = @"production";
 #endif
-        _samplingProbability = 1.0;
     }
     return self;
 }
@@ -107,6 +106,8 @@ static NSString *defaultEndpoint = @"https://otlp.bugsnag.com/v1/traces";
 
         _probabilityValueExpiresAfterSeconds = 24 * 3600;
         _probabilityRequestsPauseForSeconds = 30;
+
+        _initialSamplingProbability = 1.0;
     }
     return self;
 }

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -34,8 +34,6 @@ OBJC_EXPORT
 
 @property (nonatomic) BOOL autoInstrumentNetworkRequests;
 
-@property (nonatomic) double samplingProbability;
-
 /**
  *  The version of the application
  */

--- a/Tests/BugsnagPerformanceTests/PersistentStateTests.mm
+++ b/Tests/BugsnagPerformanceTests/PersistentStateTests.mm
@@ -9,6 +9,7 @@
 #import "FileBasedTest.h"
 
 #import "PersistentState.h"
+#import "BugsnagPerformanceConfiguration+Private.h"
 
 using namespace bugsnag;
 
@@ -50,7 +51,7 @@ using namespace bugsnag;
     XCTAssertTrue([fm fileExistsAtPath:expectedPath]);
     XCTAssertEqual(1, state->probability());
 
-    config.samplingProbability = 0.1;
+    config.internal.initialSamplingProbability = 0.1;
     state = [self persistentStateWithConfig:config];
     // pre-start probability uses config
     XCTAssertEqual(0.1, state->probability());
@@ -60,7 +61,7 @@ using namespace bugsnag;
 
     // Corrupt or missing file reverts to the config probability
     [fm removeItemAtPath:expectedPath error:nil];
-    config.samplingProbability = 0.1;
+    config.internal.initialSamplingProbability = 0.1;
     state = [self persistentStateWithConfig:config];
     state->start();
     XCTAssertEqual(0.1, state->probability());
@@ -72,7 +73,7 @@ using namespace bugsnag;
     XCTAssertEqual(0.6, state->probability());
 
     // ... even after reload
-    config.samplingProbability = 0.1;
+    config.internal.initialSamplingProbability = 0.1;
     state = [self persistentStateWithConfig:config];
     state->start();
     XCTAssertEqual(0.6, state->probability());

--- a/Tests/BugsnagPerformanceTestsSwift/PerformanceMicrobenchmarkTests.swift
+++ b/Tests/BugsnagPerformanceTestsSwift/PerformanceMicrobenchmarkTests.swift
@@ -21,7 +21,7 @@ final class PerformanceMicrobenchmarkTests: XCTestCase {
 
     @available(iOS 13.0, *)
     func testCreateAndEndSpansWithSampling() throws {
-        config.samplingProbability = 1
+        config.internal.initialSamplingProbability = 1
         BugsnagPerformance.start(configuration: config)
         self.measure {
             for _ in 0..<numberOfTestSpans {
@@ -33,7 +33,7 @@ final class PerformanceMicrobenchmarkTests: XCTestCase {
     
     @available(iOS 13.0, *)
     func testCreateAndEndSpansWithoutSampling() throws {
-        config.samplingProbability = 0
+        config.internal.initialSamplingProbability = 0
         BugsnagPerformance.start(configuration: config)
         self.measure {
             for _ in 0..<numberOfTestSpans {
@@ -45,7 +45,7 @@ final class PerformanceMicrobenchmarkTests: XCTestCase {
     
     @available(iOS 13.0, *)
     func testCreateAndEndViewSpansWithSampling() throws {
-        config.samplingProbability = 1
+        config.internal.initialSamplingProbability = 1
         BugsnagPerformance.start(configuration: config)
         self.measure {
             for _ in 0..<numberOfTestSpans {
@@ -57,7 +57,7 @@ final class PerformanceMicrobenchmarkTests: XCTestCase {
     
     @available(iOS 13.0, *)
     func testCreateAndEndViewSpansWithoutSampling() throws {
-        config.samplingProbability = 0
+        config.internal.initialSamplingProbability = 0
         BugsnagPerformance.start(configuration: config)
         self.measure {
             for _ in 0..<numberOfTestSpans {
@@ -69,7 +69,7 @@ final class PerformanceMicrobenchmarkTests: XCTestCase {
     
     @available(iOS 13.0, *)
     func testCreateBatchAndEndSpansWithSampling() throws {
-        config.samplingProbability = 1
+        config.internal.initialSamplingProbability = 1
         BugsnagPerformance.start(configuration: config)
         self.measure {
             var spans: [BugsnagPerformanceSpan] = []
@@ -82,7 +82,7 @@ final class PerformanceMicrobenchmarkTests: XCTestCase {
     
     @available(iOS 13.0, *)
     func testCreateBatchAndEndSpansWithoutSampling() throws {
-        config.samplingProbability = 0
+        config.internal.initialSamplingProbability = 0
         BugsnagPerformance.start(configuration: config)
         self.measure {
             var spans: [BugsnagPerformanceSpan] = []

--- a/features/fixtures/ios/Scenarios/SamplingProbabilityZeroScenario.swift
+++ b/features/fixtures/ios/Scenarios/SamplingProbabilityZeroScenario.swift
@@ -15,7 +15,7 @@ class SamplingProbabilityZeroScenario: Scenario {
         config.autoInstrumentAppStarts = true
         config.autoInstrumentNetworkRequests = true
         config.autoInstrumentViewControllers = true
-        config.samplingProbability = 0
+        config.internal.initialSamplingProbability = 0
     }
     
     override func startBugsnag() {

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -29,7 +29,6 @@ class Scenario: NSObject {
         config.autoInstrumentAppStarts = false
         config.autoInstrumentNetworkRequests = false
         config.autoInstrumentViewControllers = false
-        config.samplingProbability = 1
         config.endpoint = URL(string:"\(Scenario.mazeRunnerURL)/traces")!
     }
     


### PR DESCRIPTION
## Goal

Remove public access to the `samplingProbability` config option because it gets too confusing when mixed with server-side P values.
