### PR TITLE
[PLAT-10310] Ensure that network spans don't become parents

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -399,6 +399,7 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
     auto interval = metrics.taskInterval;
     auto name = task.originalRequest.HTTPMethod;
     SpanOptions options;
+    options.makeCurrentContext = false;
     options.startTime = dateToAbsoluteTime(interval.startDate);
     auto span = tracer_->startNetworkSpan(name, options);
     [span addAttributes:spanAttributesProvider_->networkSpanAttributes(task, metrics)];

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
@@ -114,6 +114,7 @@ NetworkInstrumentation::NetworkInstrumentation(std::shared_ptr<Tracer> tracer,
         return;
     }
     SpanOptions options;
+    options.makeCurrentContext = false;
     auto span = tracer_->startNetworkSpan(task.originalRequest.HTTPMethod, options);
     objc_setAssociatedObject(task, associatedNetworkSpanKey, span,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -268,6 +268,27 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
 
+  Scenario: Auto-capture multiple network spans
+    Given I run "AutoInstrumentNetworkMultiple"
+    And I wait for 10 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "parentSpanId" does not exist
+    * a span field "name" equals "[HTTP/GET]"
+    * a span string attribute "http.flavor" exists
+    * a span string attribute "http.method" equals "GET"
+    * a span integer attribute "http.status_code" is greater than 0
+    * a span integer attribute "http.response_content_length" is greater than 0
+    * a span string attribute "net.host.connection.type" equals "wifi"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.PerformanceFixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
   Scenario: Automatically start a network span that is a file:// scheme
     Given I run "AutoInstrumentFileURLRequestScenario"
     And I wait for 2 seconds

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		CBE43A9929A8EFA3000B4205 /* ProbabilityExpiryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */; };
 		CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
+		CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
 /* End PBXBuildFile section */
 
@@ -85,6 +86,7 @@
 		CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProbabilityExpiryScenario.swift; sourceTree = "<group>"; };
 		CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSpanScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
+		CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkMultiple.swift; sourceTree = "<group>"; };
 		CBF62108291A4F47004BEE0B /* RetryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -158,6 +160,7 @@
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
 				CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */,
 				CB2B8A9E2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift */,
+				CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */,
 				CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
 				CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */,
@@ -270,6 +273,7 @@
 				CBE0872B29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift in Sources */,
 				0185C47228F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
+				CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */,
 				01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */,
 				CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */,
 				9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkMultiple.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkMultiple.swift
@@ -1,0 +1,46 @@
+//
+//  AutoInstrumentNetworkMultiple.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 23.06.23.
+//
+
+import Foundation
+
+@objcMembers
+class AutoInstrumentNetworkMultiple: Scenario {
+
+    lazy var baseURL: URL = {
+        var components = URLComponents(string: Scenario.mazeRunnerURL)!
+        components.port = 9340 // `/reflect` listens on a different port :-((
+        return components.url!
+    }()
+
+    override func configure() {
+        super.configure()
+        config.autoInstrumentNetworkRequests = true
+    }
+
+    func query(url: String) {
+        let url = URL(string: "https://google.com")!
+        let task = URLSession.shared.dataTask(with: url) {(data, response, error) in
+        }
+        task.resume()
+
+    }
+
+    override func run() {
+        // Force the automatic spans to be sent in a separate trace that we will discard
+        waitForCurrentBatch()
+        query(url: "https://google.com")
+        query(url: "https://facebook.com")
+        query(url: "https://amazon.com")
+        query(url: "https://bing.com")
+        query(url: "https://reuters.com")
+        query(url: "https://sap.com")
+        query(url: "https://redhat.com")
+        query(url: "https://ubuntu.com")
+        query(url: "https://kubernetes.io")
+        query(url: "https://bugsnag.com")
+    }
+}


### PR DESCRIPTION
## Goal

Network spans must have their `makeCurrentContext` explicitly set to false because the default is true, and we don't want network spans to become parents of other spans.

## Testing

Added e2e test