### PR TITLE
Update persistent device id code to match bugsnag-cocoa

### DIFF
--- a/Sources/BugsnagPerformance/Private/PersistentDeviceID.h
+++ b/Sources/BugsnagPerformance/Private/PersistentDeviceID.h
@@ -26,11 +26,15 @@ public:
     void configure(BugsnagPerformanceConfiguration *) noexcept {};
     void start() noexcept;
 
-    NSString *current() noexcept { return cachedDeviceID_; };
+    NSString *external() noexcept { return externalDeviceID_; };
+
+    // Not used by bugsnag-cocoa-performance
+    NSString *unittest_internal() noexcept { return internalDeviceID_; };
 
 private:
     std::shared_ptr<Persistence> persistence_;
-    NSString *cachedDeviceID_{@""};
+    NSString *externalDeviceID_{@""};
+    NSString *internalDeviceID_{@""};
     NSString *persistenceDir_{nil};
 
     NSString *getFilePath();

--- a/Sources/BugsnagPerformance/Private/ResourceAttributes.mm
+++ b/Sources/BugsnagPerformance/Private/ResourceAttributes.mm
@@ -77,7 +77,7 @@ void ResourceAttributes::start() noexcept {
         @"deployment.environment": releaseStage_ ?: [NSNull null],
 
         // https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/device/
-        @"device.id": deviceID_->current(),
+        @"device.id": deviceID_->external(),
         @"device.manufacturer": @"Apple",
         @"device.model.identifier": deviceModelIdentifier() ?: [NSNull null],
 

--- a/Tests/BugsnagPerformanceTests/PersistentDeviceIDTest.mm
+++ b/Tests/BugsnagPerformanceTests/PersistentDeviceIDTest.mm
@@ -29,27 +29,55 @@ using namespace bugsnag;
     return deviceID;
 }
 
+- (void)testSavePath {
+    // Force file creation if it hasn't happened already.
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
+    auto cachesPath = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+    auto persistence = std::make_shared<Persistence>(cachesPath);
+    auto deviceID = std::make_shared<PersistentDeviceID>(persistence);
+    deviceID->earlyConfigure([BSGEarlyConfiguration new]);
+    deviceID->earlySetup();
+    deviceID->configure(config);
+    deviceID->start();
+
+    // Save path must be <caches-dir>/bugsnag-shared-<bundle-id>/device-id.json
+    NSString *topLevelDir = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+    NSString *dirPath = [topLevelDir stringByAppendingFormat:@"/bugsnag-shared-%@", [[NSBundle mainBundle] bundleIdentifier]];
+    NSString *filePath = [dirPath stringByAppendingPathComponent:@"device-id.json"];
+
+    NSFileManager *fm = [NSFileManager defaultManager];
+    XCTAssertTrue([fm fileExistsAtPath:filePath]);
+}
+
 - (void)testGeneratesID {
-    auto deviceID = [self newDeviceID]->current();
-    XCTAssertEqual(deviceID.length, (NSUInteger)40);
+    auto deviceID = [self newDeviceID];
+    XCTAssertEqual(deviceID->external().length, (NSUInteger)40);
+    XCTAssertEqual(deviceID->unittest_internal().length, (NSUInteger)40);
+}
+
+- (void)testExternalAndInternalAreDifferent {
+    auto deviceID = [self newDeviceID];
+    XCTAssertNotEqualObjects(deviceID->external(), deviceID->unittest_internal());
 }
 
 - (void)testGeneratesSameID {
-    auto expectedId = [self newDeviceID]->current();
+    auto expected = [self newDeviceID];
 
     auto fm = [NSFileManager defaultManager];
     NSError *error = nil;
     [fm removeItemAtPath:self.filePath error:&error];
     XCTAssertNil(error);
 
-    auto actualId = [self newDeviceID]->current();
-    XCTAssertEqualObjects(expectedId, actualId);
+    auto actual = [self newDeviceID];
+    XCTAssertEqualObjects(expected->external(), actual->external());
+    XCTAssertEqualObjects(expected->unittest_internal(), actual->unittest_internal());
 }
 
 - (void)testIDDoesNotChange {
-    auto expectedId = [self newDeviceID]->current();
-    auto actualId = [self newDeviceID]->current();
-    XCTAssertEqualObjects(expectedId, actualId);
+    auto expected = [self newDeviceID];
+    auto actual = [self newDeviceID];
+    XCTAssertEqualObjects(expected->external(), actual->external());
+    XCTAssertEqualObjects(expected->unittest_internal(), actual->unittest_internal());
 }
 
 @end


### PR DESCRIPTION
## Goal

Make the persistent device ID code match https://github.com/bugsnag/bugsnag-cocoa/pull/1568 as closely as possible.

Both codebases must produce exactly the same ID values, in the same JSON structure, written to the same file location.

Furthermore, both codebases must preserve any existing "external" device ID to handle the upgrade path from the already released code that doesn't contain an "internal" device ID.
