### PR TITLE
[PLAT-10570] Removed duplicate ViewLoadPhase spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Removed duplicate ViewLoadPhase spans
+  [182](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/182)
+
 ## 0.7.0 (2023-06-26)
 
 ### Breaking changes

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -28,8 +28,7 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentViewLoadScenario
     Given I run "AutoInstrumentViewLoadScenario"
-    And I wait for 20 spans
-    And I wait for 10 seconds
+    And I wait for 18 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoad/UIKit]/Fixture.ViewController"
@@ -67,8 +66,7 @@ Feature: Automatic instrumentation spans
   Scenario: AutoInstrumentSubViewLoadScenario
     Given I run "AutoInstrumentSubViewLoadScenario"
     And I wait for 2 seconds
-    And I wait for 20 spans
-    And I wait for 10 seconds
+    And I wait for 27 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoad/UIKit]/Fixture.ViewController"
@@ -117,8 +115,7 @@ Feature: Automatic instrumentation spans
   Scenario: AutoInstrumentTabViewLoadScenario
     Given I run "AutoInstrumentTabViewLoadScenario"
     And I wait for 2 seconds
-    And I wait for 5 spans
-    And I wait for 10 seconds
+    And I wait for 18 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoad/UIKit]/Fixture.ViewController"
@@ -166,8 +163,7 @@ Feature: Automatic instrumentation spans
   Scenario: AutoInstrumentNavigationViewLoadScenario
     Given I run "AutoInstrumentNavigationViewLoadScenario"
     And I wait for 2 seconds
-    And I wait for 5 spans
-    And I wait for 10 seconds
+    And I wait for 18 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoad/UIKit]/Fixture.ViewController"

--- a/features/fixtures/ios/Scenarios/AutoInstrumentSubViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentSubViewLoadScenario.swift
@@ -25,6 +25,7 @@ class AutoInstrumentSubViewLoadScenario_ViewController: UIViewController {
     let subVC = AutoInstrumentSubViewLoadScenario_SubViewController()
 
     override func viewDidLoad() {
+        super.viewDidLoad()
         add(childViewController:AutoInstrumentSubViewLoadScenario_SubViewController(), to:view)
     }
 }
@@ -37,6 +38,10 @@ class AutoInstrumentSubViewLoadScenario_SubViewController: UIViewController {
         label.textAlignment = .center
         label.text = String(describing: type(of: self))
         view = label
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
     }
 }
 


### PR DESCRIPTION
Made sure that each ViewLoadPhase is reported only once. This allows us to avoid duplicates in case of ViewControllers that override a particular phase and call super.