### PR TITLE
Cover all attribute mutation cases with a mutex to avoid future problems

### DIFF
--- a/Sources/BugsnagPerformance/Private/SpanData.mm
+++ b/Sources/BugsnagPerformance/Private/SpanData.mm
@@ -49,6 +49,7 @@ SpanData::hasAttribute(NSString *attributeName, id value) noexcept {
 void
 SpanData::updateSamplingProbability(double value) noexcept {
     if (samplingProbability > value) {
+        std::lock_guard<std::mutex> guard(mutex_);
         samplingProbability = value;
         attributes[@"bugsnag.sampling.p"] = @(value);
     }


### PR DESCRIPTION
## Goal

Just to be 1000% sure, cover all span attribute mutation cases with a mutex lock, even if the code won't run multithreaded at this time. This ensures that any future code changes won't accidentally trigger a regression.
