### PR TITLE
[PLAT-10185] Throw out failed payloads that are oversized

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       selenium-webdriver (~> 4.2, < 4.6)
     bugsnag (6.25.2)
       concurrent-ruby (~> 1.0)
-    bugsnag-maze-runner (8.0.0)
+    bugsnag-maze-runner (8.1.4)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -82,7 +82,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     multi_test (0.1.2)
-    nokogiri (1.15.2-x86_64-darwin)
+    nokogiri (1.15.3-arm64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -116,9 +116,7 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
-  x86_64-darwin-19
-  x86_64-darwin-20
-  x86_64-darwin-21
+  arm64-darwin-22
 
 DEPENDENCIES
   bugsnag-maze-runner (~> 8.0)

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) double initialSamplingProbability;
 
+@property (nonatomic) uint64_t maxPackageContentLength;
+
 /**
  * Delay between sending the initial P value request and doing the first cycle of work
  * (to ensure that the initial P value request span is the first one received during an e2e test)

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -90,6 +90,7 @@ private:
     CFTimeInterval probabilityRequestsPauseForSeconds_{0};
     std::shared_ptr<SpanAttributesProvider> spanAttributesProvider_;
     std::shared_ptr<Instrumentation> instrumentation_;
+    uint64_t maxPackageContentLength_{1000000};
 
     // Tasks
     NSArray<Task> *buildInitialTasks() noexcept;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -78,6 +78,7 @@ void BugsnagPerformanceImpl::configure(BugsnagPerformanceConfiguration *config) 
     performWorkInterval_ = config.internal.performWorkInterval;
     probabilityValueExpiresAfterSeconds_ = config.internal.probabilityValueExpiresAfterSeconds;
     probabilityRequestsPauseForSeconds_ = config.internal.probabilityRequestsPauseForSeconds;
+    maxPackageContentLength_ = config.internal.maxPackageContentLength;
 
     configuration_ = config;
     persistentState_->configure(config);
@@ -306,7 +307,7 @@ void BugsnagPerformanceImpl::uploadPackage(std::unique_ptr<OtlpPackage> package,
                 }
                 break;
             case UploadResult::FAILED_CAN_RETRY:
-                if (!isRetry) {
+                if (!isRetry && blockPackage->uncompressedContentLength() <= maxPackageContentLength_) {
                     blockThis->retryQueue_->add(*blockPackage);
                 }
                 break;

--- a/Sources/BugsnagPerformance/Private/OtlpPackage.h
+++ b/Sources/BugsnagPerformance/Private/OtlpPackage.h
@@ -35,6 +35,7 @@ public:
 
     const dispatch_time_t timestamp{0};
 
+    uint64_t uncompressedContentLength();
 
 private:
     friend bool operator==(const OtlpPackage &lhs, const OtlpPackage &rhs);

--- a/Sources/BugsnagPerformance/Private/OtlpPackage.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpPackage.mm
@@ -88,3 +88,8 @@ NSData *OtlpPackage::serialize() noexcept {
     [data appendData:(NSData * _Nonnull)payload_];
     return data;
 }
+
+uint64_t OtlpPackage::uncompressedContentLength() {
+    NSString *strValue = headers_[@"Bugsnag-Uncompressed-Content-Length"];
+    return (uint64_t)strValue.longLongValue;
+}

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -281,6 +281,7 @@ std::unique_ptr<OtlpPackage> OtlpTraceEncoding::buildUploadPackage(const std::ve
     auto headers = @{
         @"Content-Type": @"application/json",
         @"Bugsnag-Integrity": integrityDigestForData(payload),
+        @"Bugsnag-Uncompressed-Content-Length": [NSString stringWithFormat:@"%ld", payload.length],
         @"Bugsnag-Span-Sampling": pValueHistogramForSpans(spans),
     };
 

--- a/Sources/BugsnagPerformance/Private/OtlpUploader.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpUploader.mm
@@ -67,7 +67,8 @@ void OtlpUploader::upload(OtlpPackage &package, UploadResultCallback callback) n
 
 UploadResult OtlpUploader::getUploadResult(NSURLResponse *response) const {
     if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-        return UploadResult::FAILED_CANNOT_RETRY;
+        // Failed to connect. We may be able to connect later.
+        return UploadResult::FAILED_CAN_RETRY;
     }
 
     auto httpResponse = (NSHTTPURLResponse *_Nonnull)response;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -144,6 +144,8 @@ static NSString *defaultEndpoint = @"https://otlp.bugsnag.com/v1/traces";
         _probabilityRequestsPauseForSeconds = 30;
 
         _initialSamplingProbability = 1.0;
+
+        _maxPackageContentLength = 1000000;
     }
     return self;
 }

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */; };
 		CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */; };
 		CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */; };
+		CBEC89452A4ED0590088A3CE /* MaxPayloadSizeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
 /* End PBXBuildFile section */
 
@@ -87,6 +88,7 @@
 		CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSpanScenario.swift; sourceTree = "<group>"; };
 		CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanScenario.swift; sourceTree = "<group>"; };
 		CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkMultiple.swift; sourceTree = "<group>"; };
+		CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxPayloadSizeScenario.swift; sourceTree = "<group>"; };
 		CBF62108291A4F47004BEE0B /* RetryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -159,11 +161,13 @@
 			children = (
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
 				CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */,
+				9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */,
 				CB2B8A9E2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift */,
 				CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */,
 				CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
 				CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */,
+				9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */,
 				0185C47128F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift */,
 				CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */,
 				CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */,
@@ -178,14 +182,13 @@
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
 				CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */,
 				01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */,
+				CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */,
 				CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */,
 				CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */,
 				967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */,
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
-				9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */,
-				9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -290,6 +293,7 @@
 				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,
 				967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */,
 				9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */,
+				CBEC89452A4ED0590088A3CE /* MaxPayloadSizeScenario.swift in Sources */,
 				CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */,
 				CB2B8A9F2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift in Sources */,
 				CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/MaxPayloadSizeScenario.swift
+++ b/features/fixtures/ios/Scenarios/MaxPayloadSizeScenario.swift
@@ -1,0 +1,23 @@
+//
+//  MaxPayloadSizeScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 30.06.23.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class MaxPayloadSizeScenario: Scenario {
+
+    override func configure() {
+        super.configure()
+        config.internal.maxPackageContentLength = 10
+        config.internal.autoTriggerExportOnBatchSize = 1
+        config.internal.performWorkInterval = 1
+    }
+
+    override func run() {
+        BugsnagPerformance.startSpan(name: "MaxPayloadSizeScenario").end()
+    }
+}

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -206,3 +206,35 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" is false
+
+  Scenario: Trace exceeds the max package size
+    Given I set the HTTP status code for the next requests to 402,402,402
+    And I run "MaxPayloadSizeScenario"
+    And I wait for exactly 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * the trace "Bugsnag-Uncompressed-Content-Length" header matches the regex "^[0-9]+$"
+    * every span field "name" equals "MaxPayloadSizeScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.app.in_foreground" is true
+    * every span string attribute "net.host.connection.type" equals "wifi"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" equals "30"
+    * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "staging"
+    * the trace payload field "resourceSpans.0.resource" string attribute "device.id" exists
+    * the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" equals "Apple"
+    * the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists
+    * the trace payload field "resourceSpans.0.resource" string attribute "host.arch" matches the regex "arm64|amd64"
+    * the trace payload field "resourceSpans.0.resource" string attribute "os.name" equals "iOS"
+    * the trace payload field "resourceSpans.0.resource" string attribute "os.type" equals "darwin"
+    * the trace payload field "resourceSpans.0.resource" string attribute "os.version" exists
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.PerformanceFixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "10.0"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"


### PR DESCRIPTION
## Goal

If a failed request contained an (uncompressed) payload size over the limit, don't retry; just throw it out.

## Testing

Added e2e test.
