### PR TITLE
Don't implicitly trust the monotonic clock when calculating span end times

### DIFF
--- a/Tests/BugsnagPerformanceTests/SpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanTests.mm
@@ -32,6 +32,16 @@ static std::shared_ptr<Span> spanWithStartTime(CFAbsoluteTime startTime, OnSpanE
     XCTAssertEqualWithAccuracy(spanData->endTime, CFAbsoluteTimeGetCurrent(), 0.001);
 }
 
+- (void)testStartEndUnset2 {
+    CFAbsoluteTime startTime = CFABSOLUTETIME_INVALID;
+    CFAbsoluteTime endTime = startTime;
+    __block std::shared_ptr<SpanData> spanData = nullptr;
+    auto span = spanWithStartTime(startTime, ^(std::shared_ptr<SpanData> data) {spanData = data;});
+    sleep(1);
+    span->end(endTime);
+    XCTAssertEqualWithAccuracy(spanData->endTime, CFAbsoluteTimeGetCurrent(), 0.001);
+}
+
 - (void)testStartNearPastEndUnset {
     CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent() - 0.0005;
     CFAbsoluteTime endTime = CFABSOLUTETIME_INVALID;


### PR DESCRIPTION
## Goal

We're getting occasional broken end times that are theorised to be caused by skews in the monotonic clock. This PR adds code to validate any time values calculated using the monotonic clock to ensure they're not too far out from the regular clock-based end time.

## Testing

Added more unit tests.