### PR TITLE
Perform end time calculation using signed ints to prevent unsigned overflow

### DIFF
--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -78,7 +78,8 @@ public:
         if (isMonotonicClockValid(startClock_)) {
             auto endClock = currentMonotonicClockNsecIfUnset(time);
             if (isMonotonicClockValid(endClock)) {
-                time = data_->startTime + ((double)(endClock - startClock_)) / NSEC_PER_SEC;
+                // Calculate using signed int so that an end time < start time doesn't overflow.
+                time = data_->startTime + ((double)((int64_t)endClock - (int64_t)startClock_)) / NSEC_PER_SEC;
             }
         }
 


### PR DESCRIPTION
## Goal

We've been experiencing an overflow in very rare cases when calculating end time using the system monotonic clock. To better understand what's going on, do a signed subtraction instead so that we can measure the magnitude of the effect going forward.
