### PR TITLE
[PLAT-10621] Allow users to control network spans via callback mechanism

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		01A58C0F29092D25006E4DF7 /* Sampler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 01A58C0D29092D25006E4DF7 /* Sampler.mm */; };
 		01A58C11290931A5006E4DF7 /* SamplerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 01A58C10290931A5006E4DF7 /* SamplerTests.mm */; };
 		01EAF980291AAF19007AC627 /* Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 01EAF97F291AAF19007AC627 /* Utils.h */; };
+		0921F02B2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0921F02C2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */; };
 		8A80DA8B2966CE940035BDA9 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		8A80DA912966CEB30035BDA9 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A80DA80296588840035BDA9 /* ConfigurationTests.swift */; };
 		962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F80F129DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift */; };
@@ -224,6 +226,8 @@
 		01A58C10290931A5006E4DF7 /* SamplerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SamplerTests.mm; sourceTree = "<group>"; };
 		01EAF97F291AAF19007AC627 /* Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
 		01EF4A3E29067786003CC5A5 /* BugsnagPerformance.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BugsnagPerformance.xcconfig; sourceTree = "<group>"; };
+		0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceNetworkRequestInfo.h; sourceTree = "<group>"; };
+		0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagPerformanceNetworkRequestInfo.m; sourceTree = "<group>"; };
 		72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformance.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A80DA80296588840035BDA9 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		8A80DA872966CE940035BDA9 /* BugsnagPerformance-SwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagPerformance-SwiftTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -386,6 +390,7 @@
 				0122C21A29019770002D243C /* BugsnagPerformance.h */,
 				0122C21929019770002D243C /* BugsnagPerformanceConfiguration.h */,
 				CB0AD76929657381002A3FB6 /* BugsnagPerformanceErrors.h */,
+				0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */,
 				0122C21729019770002D243C /* BugsnagPerformanceSpan.h */,
 				CB7FD92F299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h */,
 				0122C21829019770002D243C /* BugsnagPerformanceViewType.h */,
@@ -399,6 +404,7 @@
 				0122C21D29019770002D243C /* BugsnagPerformance.mm */,
 				0122C21C29019770002D243C /* BugsnagPerformanceConfiguration.mm */,
 				CB0AD7672965734F002A3FB6 /* BugsnagPerformanceErrors.m */,
+				0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */,
 				0122C21E29019770002D243C /* BugsnagPerformanceSpan.mm */,
 				CB7FD931299D2F7700499E13 /* BugsnagPerformanceSpanOptions.m */,
 			);
@@ -629,6 +635,7 @@
 				CBE0873329FA984C007455F2 /* BugsnagPerformanceViewType+Private.h in Headers */,
 				CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */,
 				CBEC51C0296DB312009C0CE3 /* JSON.h in Headers */,
+				0921F02B2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h in Headers */,
 				0122C24A29019770002D243C /* AppStartupInstrumentation.h in Headers */,
 				CB04969B2915194E0097E526 /* OtlpUploader.h in Headers */,
 				0122C25029019770002D243C /* BugsnagPerformanceSpan+Private.h in Headers */,
@@ -894,6 +901,7 @@
 				CBE0873229FA984C007455F2 /* BugsnagPerformanceViewType.mm in Sources */,
 				CBE0872929F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm in Sources */,
 				CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */,
+				0921F02C2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Network spans can now be controlled via user callbacks.
+  [189](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/189)
+
+
 ## 1.0.0 (2023-07-17)
 
 ### Bug fixes

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -402,7 +402,7 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
     SpanOptions options;
     options.makeCurrentContext = false;
     options.startTime = dateToAbsoluteTime(interval.startDate);
-    auto span = tracer_->startNetworkSpan(name, options);
+    auto span = tracer_->startNetworkSpan(task.originalRequest.URL, name, options);
     [span addAttributes:spanAttributesProvider_->networkSpanAttributes(task, metrics)];
     [span endWithEndTime:interval.endDate];
 }

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -21,9 +21,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSpan:(std::unique_ptr<bugsnag::Span>)span NS_DESIGNATED_INITIALIZER;
 
+- (void)addAttribute:(NSString *)attributeName withValue:(id)value;
+
 - (void)addAttributes:(NSDictionary *)attributes;
 
 - (BOOL)hasAttribute:(NSString *)attributeName withValue:(id)value;
+
+- (id)getAttribute:(NSString *)attributeName;
 
 - (void)endWithAbsoluteTime:(CFAbsoluteTime)endTime;
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
@@ -115,7 +115,7 @@ NetworkInstrumentation::NetworkInstrumentation(std::shared_ptr<Tracer> tracer,
     }
     SpanOptions options;
     options.makeCurrentContext = false;
-    auto span = tracer_->startNetworkSpan(task.originalRequest.HTTPMethod, options);
+    auto span = tracer_->startNetworkSpan(task.originalRequest.URL, task.originalRequest.HTTPMethod, options);
     objc_setAssociatedObject(task, associatedNetworkSpanKey, span,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     if (isEarlySpansPhase_) {

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -42,7 +42,11 @@ public:
     {};
     
     Span(const Span&) = delete;
-    
+
+    void addAttribute(NSString *attributeName, id value) noexcept {
+        data_->addAttribute(attributeName, value);
+    }
+
     void addAttributes(NSDictionary *attributes) noexcept {
         // This doesn't have to be thread safe because this method is never called
         // after the span is started.
@@ -58,6 +62,10 @@ public:
             return data->hasAttribute(attributeName, value);
         }
         return false;
+    }
+
+    id getAttribute(NSString *attributeName) noexcept {
+        return data_->attributes[attributeName];
     }
 
     bool isEnded(void) {

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -113,7 +113,6 @@ SpanAttributesProvider::networkSpanAttributes(NSURLSessionTask *task,
     attributes[@"http.flavor"] = getHTTPFlavour(metrics);
     attributes[@"http.method"] = task.originalRequest.HTTPMethod;
     attributes[@"http.status_code"] = httpResponse ? @(httpResponse.statusCode) : @0;
-    attributes[@"http.url"] = task.originalRequest.URL.absoluteString;
     attributes[@"net.host.connection.type"] = getConnectionType(task, metrics);
     attributes[@"net.host.connection.subtype"] = getConnectionSubtype(attributes[@"net.host.connection.type"]);
     addNonZero(attributes, @"http.request_content_length", @(task.countOfBytesSent));

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -24,9 +24,8 @@ static NSString * const connectionTypeCell = @"cell";
 SpanAttributesProvider::SpanAttributesProvider() noexcept {};
 
 static NSString *getHTTPFlavour(NSURLSessionTaskMetrics *metrics) {
-    auto transactionMetrics = metrics.transactionMetrics;
-    if (transactionMetrics.count > 0) {
-        NSString *protocolName = transactionMetrics[0].networkProtocolName;
+    for (NSURLSessionTaskTransactionMetrics *transactionMetrics in metrics.transactionMetrics) {
+        NSString *protocolName = transactionMetrics.networkProtocolName;
         if ([protocolName isEqualToString:@"http/1.1"]) {
             return @"1.1";
         }

--- a/Sources/BugsnagPerformance/Private/SpanData.h
+++ b/Sources/BugsnagPerformance/Private/SpanData.h
@@ -28,7 +28,9 @@ public:
              BSGFirstClass firstClass) noexcept;
     
     SpanData(const SpanData&) = delete;
-    
+
+    void addAttribute(NSString *attributeName, id value) noexcept;
+
     void addAttributes(NSDictionary *attributes) noexcept;
 
     bool hasAttribute(NSString *attributeName, id value) noexcept;

--- a/Sources/BugsnagPerformance/Private/SpanData.mm
+++ b/Sources/BugsnagPerformance/Private/SpanData.mm
@@ -30,6 +30,12 @@ SpanData::SpanData(NSString *name,
 }
 
 void
+SpanData::addAttribute(NSString *attributeName, id value) noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    this->attributes[attributeName] = value;
+}
+
+void
 SpanData::addAttributes(NSDictionary *dictionary) noexcept {
     std::lock_guard<std::mutex> guard(mutex_);
     [this->attributes addEntriesFromDictionary:dictionary];

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -50,7 +50,7 @@ public:
                                               NSString *className,
                                               SpanOptions options) noexcept;
 
-    BugsnagPerformanceSpan *startNetworkSpan(NSString *httpMethod, SpanOptions options) noexcept;
+    BugsnagPerformanceSpan *startNetworkSpan(NSURL *url, NSString *httpMethod, SpanOptions options) noexcept;
     
     BugsnagPerformanceSpan *startViewLoadPhaseSpan(NSString *name, SpanOptions options) noexcept;
 
@@ -59,16 +59,21 @@ public:
 private:
     std::shared_ptr<Sampler> sampler_;
     std::shared_ptr<SpanStackingHandler> spanStackingHandler_;
-    
+
+    std::atomic<bool> isEarlySpansPhase_{true};
+    std::mutex earlySpansMutex_;
+    NSMutableArray<BugsnagPerformanceSpan *> *earlyNetworkSpans_;
+
     std::shared_ptr<Batch> batch_;
     void (^onSpanStarted_)(){nil};
     void (^onViewLoadSpanStarted_)(NSString *className){
         ^(NSString *) {}
     };
+    BugsnagPerformanceNetworkRequestCallback networkRequestCallback_;
 
-    BugsnagPerformanceConfiguration *configuration;
-    
     BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
     void tryAddSpanToBatch(std::shared_ptr<SpanData> spanData);
+    void markEarlyNetworkSpan(BugsnagPerformanceSpan *span) noexcept;
+    void endEarlySpansPhase() noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceNetworkRequestInfo.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceNetworkRequestInfo.m
@@ -1,0 +1,13 @@
+//
+//  BugsnagPerformanceNetworkRequestInfo.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 19.07.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceNetworkRequestInfo.h>
+
+@implementation BugsnagPerformanceNetworkRequestInfo
+
+@end

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -58,12 +58,20 @@ using namespace bugsnag;
     return !_span->isEnded();
 }
 
+- (void)addAttribute:(NSString *)attributeName withValue:(id)value {
+    _span->addAttribute(attributeName, value);
+}
+
 - (void)addAttributes:(NSDictionary *)attributes {
     _span->addAttributes(attributes);
 }
 
 - (BOOL)hasAttribute:(NSString *)attributeName withValue:(id)value {
     return _span->hasAttribute(attributeName, value);
+}
+
+- (id)getAttribute:(NSString *)attributeName {
+    return _span->getAttribute(attributeName);
 }
 
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -10,6 +10,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
+#import <BugsnagPerformance/BugsnagPerformanceNetworkRequestInfo.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -6,6 +6,7 @@
 //
 
 #import <BugsnagPerformance/BugsnagPerformanceErrors.h>
+#import <BugsnagPerformance/BugsnagPerformanceNetworkRequestInfo.h>
 
 #import <UIKit/UIKit.h>
 
@@ -60,6 +61,11 @@ OBJC_EXPORT
  *  Release stages which are allowed to notify Bugsnag
  */
 @property (copy, nullable, nonatomic) NSSet<NSString *> *enabledReleaseStages;
+
+/**
+ * Callback used to control how network request spans are created.
+ */
+@property(nullable, nonatomic) BugsnagPerformanceNetworkRequestCallback networkRequestCallback;
 
 @end
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceNetworkRequestInfo.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceNetworkRequestInfo.h
@@ -1,0 +1,29 @@
+//
+//  BugsnagPerformanceNetworkRequestInfo.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 19.07.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * This class is used in network request callbacks to modify network span behaviour on a per-request basis.
+ */
+@interface BugsnagPerformanceNetworkRequestInfo : NSObject
+
+/**
+ * When passed into the callback, this contains the URL of the network request.
+ * On return, specifies the URL to report in the network request span.
+ * If null on return, no network request span will be created.
+ */
+@property(readwrite,nonatomic,nullable) NSURL *url;
+
+@end
+
+typedef BugsnagPerformanceNetworkRequestInfo * _Nonnull (^BugsnagPerformanceNetworkRequestCallback)(BugsnagPerformanceNetworkRequestInfo * _Nonnull info);
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */; };
 		01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC428E1AF9600D1F239 /* Scenario.swift */; };
 		01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC628E1D5A400D1F239 /* Fixture.swift */; };
+		0921F02E2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */; };
+		09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */; };
 		9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */; };
 		9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */; };
 		967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */; };
@@ -65,6 +67,8 @@
 		01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanScenario.swift; sourceTree = "<group>"; };
 		01FE4DC428E1AF9600D1F239 /* Scenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scenario.swift; sourceTree = "<group>"; };
 		01FE4DC628E1D5A400D1F239 /* Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
+		0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkCallbackScenario.swift; sourceTree = "<group>"; };
+		09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkCallbackScenario.swift; sourceTree = "<group>"; };
 		9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentTabViewLoadScenario.swift; sourceTree = "<group>"; };
 		9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNavigationViewLoadScenario.swift; sourceTree = "<group>"; };
 		967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseStageNotEnabledScenario.swift; sourceTree = "<group>"; };
@@ -163,6 +167,7 @@
 				CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */,
 				9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */,
 				CB2B8A9E2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift */,
+				0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */,
 				CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */,
 				CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
@@ -177,6 +182,7 @@
 				CBC90C4129C466BD00280884 /* ForceUBSan.h */,
 				CBC90C4229C466BD00280884 /* ForceUBSan.m */,
 				CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */,
+				09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */,
 				CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
@@ -290,6 +296,7 @@
 				CB3477182901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift in Sources */,
 				CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */,
 				01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */,
+				09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */,
 				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,
 				967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */,
 				9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */,
@@ -303,6 +310,7 @@
 				CBC90CDE29CDCFF700280884 /* FirstClassNoScenario.swift in Sources */,
 				CBC90C4329C466BD00280884 /* ForceUBSan.m in Sources */,
 				CBC90CE429D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift in Sources */,
+				0921F02E2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift in Sources */,
 				01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */,
 				CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */,
 			);

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkCallbackScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkCallbackScenario.swift
@@ -1,0 +1,59 @@
+//
+//  AutoInstrumentNetworkCallbackScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 20.07.23.
+//
+
+import Foundation
+
+@objcMembers
+class AutoInstrumentNetworkCallbackScenario: Scenario {
+
+    lazy var baseURL: URL = {
+        var components = URLComponents(string: Scenario.mazeRunnerURL)!
+        components.port = 9340 // `/reflect` listens on a different port :-((
+        return components.url!
+    }()
+
+    override func configure() {
+        super.configure()
+        config.autoInstrumentNetworkRequests = true
+        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+
+            let testUrl = info.url
+            if (testUrl == nil) {
+                return info
+            }
+
+            let url = testUrl!
+            let urlString = url.absoluteString
+
+            if (urlString.starts(with:"http://bs-local.com")) {
+                info.url = nil
+            }
+            else if url.absoluteString == "https://google.com" {
+                info.url = nil
+            } else if url.lastPathComponent == "changeme" {
+                info.url = URL(string:"changed", relativeTo:url.deletingLastPathComponent())
+            }
+
+            return info
+        }
+    }
+
+    func query(url: URL) {
+        let task = URLSession.shared.dataTask(with: url) {(data, response, error) in
+        }
+        task.resume()
+
+    }
+
+    override func run() {
+        // Force the automatic spans to be sent in a separate trace that we will discard
+        waitForCurrentBatch()
+        query(url: URL(string: "https://bugsnag.com")!)
+        query(url: URL(string: "https://bugsnag.com/changeme")!)
+        query(url: URL(string: "https://google.com")!)
+    }
+}

--- a/features/fixtures/ios/Scenarios/ManualNetworkCallbackScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualNetworkCallbackScenario.swift
@@ -1,0 +1,72 @@
+//
+//  ManualNetworkCallbackScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 24.07.23.
+//
+
+import Foundation
+
+@objcMembers
+class ManualNetworkCallbackScenario: Scenario {
+
+    public var urlSession: URLSession?
+
+    private override init() {
+        super.init()
+        self.urlSession = URLSession(configuration: URLSessionConfiguration.default, delegate: self, delegateQueue: OperationQueue.main)
+    }
+
+    lazy var baseURL: URL = {
+        var components = URLComponents(string: Scenario.mazeRunnerURL)!
+        components.port = 9340 // `/reflect` listens on a different port :-((
+        return components.url!
+    }()
+
+    override func configure() {
+        super.configure()
+        config.autoInstrumentNetworkRequests = false
+        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+
+            let testUrl = info.url
+            if (testUrl == nil) {
+                return info
+            }
+
+            let url = testUrl!
+            let urlString = url.absoluteString
+
+            if (urlString.starts(with:"http://bs-local.com")) {
+                info.url = nil
+            }
+            else if url.absoluteString == "https://google.com" {
+                info.url = nil
+            } else if url.lastPathComponent == "changeme" {
+                info.url = URL(string:"changed", relativeTo:url.deletingLastPathComponent())
+            }
+
+            return info
+        }
+    }
+
+    func query(url: URL) {
+        let task = self.urlSession!.dataTask(with: url) {(data, response, error) in
+        }
+        task.resume()
+
+    }
+
+    override func run() {
+        // Force the automatic spans to be sent in a separate trace that we will discard
+        waitForCurrentBatch()
+        query(url: URL(string: "https://bugsnag.com")!)
+        query(url: URL(string: "https://bugsnag.com/changeme")!)
+        query(url: URL(string: "https://google.com")!)
+    }
+}
+
+extension ManualNetworkCallbackScenario : URLSessionDataDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        BugsnagPerformance.reportNetworkRequestSpan(task: task, metrics: metrics)
+    }
+}

--- a/features/network.feature
+++ b/features/network.feature
@@ -1,0 +1,29 @@
+Feature: Automatic instrumentation spans
+
+  Scenario: AutoInstrumentNetworkCallbackScenario
+    Given I run "AutoInstrumentNetworkCallbackScenario"
+    And I wait for exactly 2 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "[HTTP/GET]"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "http.url" equals "https://bugsnag.com"
+    * a span string attribute "http.url" equals "https://bugsnag.com/changed"
+
+  Scenario: ManualNetworkCallbackScenario
+    Given I run "ManualNetworkCallbackScenario"
+    And I wait for exactly 2 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "[HTTP/GET]"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "http.url" equals "https://bugsnag.com"
+    * a span string attribute "http.url" equals "https://bugsnag.com/changed"


### PR DESCRIPTION
## Goal

Allow more user control over network spans.

## Design

Configuration now allows the user to set a callback that will be called on every network span, allowing the reported URL to be changed, or even causing the entire span to be dropped and not reported.

## Testing

Added new e2e tests.
