### PR TITLE
Capture unit test logs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,9 +31,17 @@ steps:
       - label: "iOS 15 Unit Tests"
         commands:
           - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=15.0
+        plugins:
+          artifacts#v1.5.0:
+            upload:
+              - "logs/*"
       - label: "iOS 11 Unit Tests"
         commands:
           - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=11.4
+        plugins:
+          artifacts#v1.5.0:
+            upload:
+              - "logs/*"
         agents:
           queue: macos-11
 

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,8 @@ iOSInjectionProject/
 # Bugsnag
 appium_server.log
 maze_output
+BugsnagTests-*.xcresult
+logs/*
 
 # Other
 .DS_Store


### PR DESCRIPTION
## Goal

Capture unit test logs.

## Design

Note that logs are only copied into place by the script when tests fail, so successful builds will not have any build artifacts attached.

## Testing

Tested by forcing a unit test failure in a temporary commit - the artifacts were attached to the Buildkite step as expected.