### PR TITLE
[PLAT-10958] Fix some subtle swizzling bugs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       selenium-webdriver (~> 4.2, < 4.6)
     bugsnag (6.26.0)
       concurrent-ruby (~> 1.0)
-    bugsnag-maze-runner (8.4.0)
+    bugsnag-maze-runner (8.4.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -70,7 +70,7 @@ GEM
     faye-websocket (0.11.3)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.15.5)
+    ffi (1.16.3)
     hana (1.3.7)
     json_schemer (0.2.25)
       ecma-re-validator (~> 0.3)
@@ -78,9 +78,9 @@ GEM
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
       uri_template (~> 0.7)
-    mime-types (3.5.0)
+    mime-types (3.5.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0808)
+    mime-types-data (3.2023.1003)
     multi_test (0.1.2)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
@@ -92,7 +92,7 @@ GEM
     racc (1.7.1)
     rack (2.2.8)
     rake (12.3.3)
-    regexp_parser (2.8.1)
+    regexp_parser (2.8.2)
     rexml (3.2.6)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)
@@ -112,13 +112,14 @@ GEM
     unf_ext (0.0.8.2)
     uri_template (0.7.0)
     webrick (1.7.0)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -57,7 +57,7 @@ public:
 
     void onSpanStarted() noexcept;
 
-    void setOnViewLoadSpanStarted(void (^onViewLoadSpanStarted)(NSString *className)) noexcept {
+    void setOnViewLoadSpanStarted(std::function<void(NSString *)> onViewLoadSpanStarted) noexcept {
         tracer_->setOnViewLoadSpanStarted(onViewLoadSpanStarted);
     }
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
@@ -52,8 +52,9 @@ BugsnagPerformanceLibrary::BugsnagPerformanceLibrary()
 , reachability_(std::make_shared<Reachability>())
 , bugsnagPerformanceImpl_(std::make_shared<BugsnagPerformanceImpl>(reachability_, appStateTracker_))
 {
-    bugsnagPerformanceImpl_->setOnViewLoadSpanStarted(^(NSString *className) {
-        bugsnagPerformanceImpl_->didStartViewLoadSpan(className);
+    auto impl = bugsnagPerformanceImpl_;
+    bugsnagPerformanceImpl_->setOnViewLoadSpanStarted([=](NSString *className) {
+        impl->didStartViewLoadSpan(className);
     });
 }
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSessionTask+Instrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSessionTask+Instrumentation.mm
@@ -41,16 +41,15 @@ static NSArray<Class> *getURLSessionTaskClassesWithResumeMethod() {
 
 static void replace_NSURLSessionTask_resume(Class cls, BSGSessionTaskResumeCallback onResume) {
     __weak BSGSessionTaskResumeCallback weakOnResume = onResume;
-    SEL selector = @selector(resume);
-    typedef void (*IMPPrototype)(id, SEL);
-    __block IMPPrototype originalIMP = (IMPPrototype)ObjCSwizzle::replaceInstanceMethodOverride(cls,
-                                                                                            selector,
-                                                                                            ^(id self) {
+    __block SEL selector = @selector(resume);
+    __block IMP resume = ObjCSwizzle::replaceInstanceMethodOverride(cls, selector, ^(id self) {
         BSGSessionTaskResumeCallback localOnResume = weakOnResume;
         if (localOnResume != nil) {
             localOnResume(self);
         }
-        originalIMP(self, selector);
+        if (resume) {
+            reinterpret_cast<void (*)(id, SEL)>(resume)(self, selector);
+        }
     });
 }
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -35,7 +35,14 @@ private:
     static bool isViewControllerSubclass(Class subclass) noexcept;
     
     void instrument(Class cls) noexcept;
-    
+    void instrumentLoadView(Class cls) noexcept;
+    void instrumentViewDidLoad(Class cls) noexcept;
+    void instrumentViewWillAppear(Class cls) noexcept;
+    void instrumentViewDidAppear(Class cls) noexcept;
+    void instrumentViewWillDisappear(Class cls) noexcept;
+    void instrumentViewWillLayoutSubviews(Class cls) noexcept;
+    void instrumentViewDidLayoutSubviews(Class cls) noexcept;
+
     void onLoadView(UIViewController *viewController) noexcept;
     void onViewDidAppear(UIViewController *viewController) noexcept;
     void onViewWillDisappear(UIViewController *viewController) noexcept;

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -38,7 +38,7 @@ public:
     void configure(BugsnagPerformanceConfiguration *configuration) noexcept;
     void start() noexcept;
 
-    void setOnViewLoadSpanStarted(void (^onViewLoadSpanStarted)(NSString *className)) noexcept {
+    void setOnViewLoadSpanStarted(std::function<void(NSString *)> onViewLoadSpanStarted) noexcept {
         onViewLoadSpanStarted_ = onViewLoadSpanStarted;
     }
 
@@ -66,9 +66,7 @@ private:
 
     std::shared_ptr<Batch> batch_;
     void (^onSpanStarted_)(){nil};
-    void (^onViewLoadSpanStarted_)(NSString *className){
-        ^(NSString *) {}
-    };
+    std::function<void(NSString *)> onViewLoadSpanStarted_{};
     BugsnagPerformanceNetworkRequestCallback networkRequestCallback_;
 
     BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;


### PR DESCRIPTION
## Goal

There were some subtle issues with the existing swizzled methods that are fixed in this PR.

## Changeset

- BugsnagPerformanceLibrary's callback was changed to a C++ lambda so that we can use copy semantics since `bugsnagPerformanceImpl_` is a smart pointer that could invalidate when the stack went away.
- Harmonized all swizzled methods to use the same approach.
- Separated each view swizzle into a separate method to avoid accidental local variable bleeding.
- Check for nil before calling the original method implementation when swizzling.
- Mark all local variables used in swizzled methods `__block` (not strictly necessary in all cases, but safer all around)

## Testing

Tested manually on the example app, re-ran e2e tests.
