### PR TITLE
[PLAT-10845] Rename [AppStart/Cold] with [AppStart/iOSCold] and [AppStart/Warm] with [AppStart/iOSWarm]

### DIFF
--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -169,7 +169,7 @@ AppStartupInstrumentation::beginAppStartSpan() noexcept {
         return;
     }
 
-    auto name = isColdLaunch_ ? @"[AppStart/Cold]" : @"[AppStart/Warm]";
+    auto name = isColdLaunch_ ? @"[AppStart/iOSCold]" : @"[AppStart/iOSWarm]";
     SpanOptions options;
     options.startTime = didStartProcessAtTime_;
     appStartSpan_ = tracer_->startAppStartSpan(name, options);

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -6,7 +6,7 @@ Feature: Automatic instrumentation spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:4"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "[AppStart/Cold]"
+    * a span field "name" equals "[AppStart/iOSCold]"
     * a span field "name" equals "[AppStartPhase/App launching - pre main()]"
     * a span field "name" equals "[AppStartPhase/App launching - post main()]"
     * a span field "name" equals "[AppStartPhase/UI init]"


### PR DESCRIPTION
## Goal

Rename the cold/warm start spans so that they can be better differentiated when using native platforms with languages like RN.

## Testing

Updated e2e tests.
