### PR TITLE
[Plat-10875] Prewarm view spans

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		01EAF980291AAF19007AC627 /* Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 01EAF97F291AAF19007AC627 /* Utils.h */; };
 		0921F02B2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0921F02C2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */; };
+		09509B752ADFE9A900A358EC /* TracerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09509B742ADFE9A900A358EC /* TracerTests.mm */; };
 		8A80DA8B2966CE940035BDA9 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		8A80DA912966CEB30035BDA9 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A80DA80296588840035BDA9 /* ConfigurationTests.swift */; };
 		962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F80F129DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift */; };
@@ -227,6 +228,7 @@
 		01EF4A3E29067786003CC5A5 /* BugsnagPerformance.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BugsnagPerformance.xcconfig; sourceTree = "<group>"; };
 		0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceNetworkRequestInfo.h; sourceTree = "<group>"; };
 		0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagPerformanceNetworkRequestInfo.m; sourceTree = "<group>"; };
+		09509B742ADFE9A900A358EC /* TracerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TracerTests.mm; sourceTree = "<group>"; };
 		72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformance.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A80DA80296588840035BDA9 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		8A80DA872966CE940035BDA9 /* BugsnagPerformance-SwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagPerformance-SwiftTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -531,8 +533,8 @@
 				CBEC51C2296EC0AC009C0CE3 /* JSONTests.mm */,
 				CBEC51DE29782471009C0CE3 /* OtlpPackageTests.mm */,
 				0122C26029019C05002D243C /* OtlpTraceEncodingTests.mm */,
-				CB68FABB2A3C4208005B2CDB /* PersistentDeviceIDTest.mm */,
 				CBEC51CD296EEF52009C0CE3 /* PersistenceTests.mm */,
+				CB68FABB2A3C4208005B2CDB /* PersistentDeviceIDTest.mm */,
 				CBEC51C4296ED8BA009C0CE3 /* PersistentStateTests.mm */,
 				01A414C42912B93F003152A4 /* ResourceAttributesTests.mm */,
 				CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */,
@@ -541,6 +543,7 @@
 				96D55C872A1EE26A006D1F29 /* SpanStackingHandlerTests.mm */,
 				CB2B8A9A2A0924A50054FBBE /* SpanTests.mm */,
 				CB747D20299E5458003CA1B4 /* TimeTests.mm */,
+				09509B742ADFE9A900A358EC /* TracerTests.mm */,
 				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
 			);
 			path = BugsnagPerformanceTests;
@@ -851,6 +854,7 @@
 				CB68FABC2A3C4208005B2CDB /* PersistentDeviceIDTest.mm in Sources */,
 				CB747D21299E5458003CA1B4 /* TimeTests.mm in Sources */,
 				0122C27129019CEF002D243C /* OtlpTraceEncodingTests.mm in Sources */,
+				09509B752ADFE9A900A358EC /* TracerTests.mm in Sources */,
 				962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */,
 				CB747D1F299E4984003CA1B4 /* SpanOptionsTests.mm in Sources */,
 				CB0AD76C296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/EarlyConfiguration.h
+++ b/Sources/BugsnagPerformance/Private/EarlyConfiguration.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The early confguration happens duing the library early init phase (before main is called), and thus cannot be done
  * using a configuration object passed in by the user (because control hasn't been passed to user code yet).
- * Instead, we get the early configuration from the app's Info.plist file.
+ * Instead, we get the early configuration from the app's Info.plist file and environment variables.
  */
 @interface BSGEarlyConfiguration : NSObject
 
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly) BOOL enableSwizzling;
 @property(nonatomic, readonly) BOOL swizzleViewLoadPreMain;
+@property(nonatomic, readwrite) BOOL appWasLaunchedPreWarmed;
 
 @end
 

--- a/Sources/BugsnagPerformance/Private/EarlyConfiguration.mm
+++ b/Sources/BugsnagPerformance/Private/EarlyConfiguration.mm
@@ -18,6 +18,7 @@
         }
         id swizzleViewLoadPreMain = [dict valueForKeyPath:@"bugsnag.performance.swizzleViewLoadPreMain"];
         _swizzleViewLoadPreMain = swizzleViewLoadPreMain == nil || [swizzleViewLoadPreMain boolValue];
+        _appWasLaunchedPreWarmed = [NSProcessInfo.processInfo.environment[@"ActivePrewarm"] isEqualToString:@"1"];
     }
 
     return self;

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -72,6 +72,10 @@ public:
         return isEnded_;
     }
 
+    void abort() noexcept {
+        isEnded_ = true;
+    }
+
     void end(CFAbsoluteTime time) noexcept {
         bool expected = false;
         if (!isEnded_.compare_exchange_strong(expected, true)) {

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -30,6 +30,10 @@ using namespace bugsnag;
 // We want direct ivar access to avoid accessors copying unique_ptrs
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
+- (void)abort {
+    _span->abort();
+}
+
 - (void)end {
     _span->end(CFABSOLUTETIME_INVALID);
 }

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
@@ -28,6 +28,8 @@ OBJC_EXPORT
 
 - (instancetype)init NS_UNAVAILABLE;
 
+- (void)abort;
+
 - (void)end;
 
 - (void)endWithEndTime:(NSDate *)endTime NS_SWIFT_NAME(end(endTime:));

--- a/Tests/BugsnagPerformanceTests/TracerTests.mm
+++ b/Tests/BugsnagPerformanceTests/TracerTests.mm
@@ -1,0 +1,112 @@
+//
+//  TracerTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 18.10.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "Tracer.h"
+
+using namespace bugsnag;
+
+@interface TracerTests : XCTestCase
+
+@end
+
+static BugsnagPerformanceConfiguration *newConfig() {
+    return [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"11111111111111111111111111111111"];
+}
+
+@implementation TracerTests
+
+- (void)testPrewarmEndBefore {
+    auto earlyConfig = [BSGEarlyConfiguration new];
+    earlyConfig.appWasLaunchedPreWarmed = YES;
+    auto config = newConfig();
+    auto stackingHandler = std::make_shared<SpanStackingHandler>();
+    auto sampler = std::make_shared<Sampler>();
+    sampler->setProbability(1.0);
+    auto batch = std::make_shared<Batch>();
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, ^(){});
+    tracer->earlyConfigure(earlyConfig);
+    tracer->earlySetup();
+    tracer->configure(config);
+    tracer->start();
+
+    SpanOptions spanOptions;
+    auto span = tracer->startViewLoadSpan(BugsnagPerformanceViewTypeUIKit, @"myclass", spanOptions);
+    [span end];
+    tracer->onPrewarmPhaseEnded();
+    auto spans = batch->drain(true);
+    XCTAssertEqual(spans->size(), 1UL);
+}
+
+- (void)testPrewarmEndAfter {
+    auto earlyConfig = [BSGEarlyConfiguration new];
+    earlyConfig.appWasLaunchedPreWarmed = YES;
+    auto config = newConfig();
+    auto stackingHandler = std::make_shared<SpanStackingHandler>();
+    auto sampler = std::make_shared<Sampler>();
+    sampler->setProbability(1.0);
+    auto batch = std::make_shared<Batch>();
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, ^(){});
+    tracer->earlyConfigure(earlyConfig);
+    tracer->earlySetup();
+    tracer->configure(config);
+    tracer->start();
+
+    SpanOptions spanOptions;
+    auto span = tracer->startViewLoadSpan(BugsnagPerformanceViewTypeUIKit, @"myclass", spanOptions);
+    tracer->onPrewarmPhaseEnded();
+    [span end];
+    auto spans = batch->drain(true);
+    XCTAssertEqual(spans->size(), 0UL);
+}
+
+- (void)testNoPrewarmEndBefore {
+    auto earlyConfig = [BSGEarlyConfiguration new];
+    earlyConfig.appWasLaunchedPreWarmed = NO;
+    auto config = newConfig();
+    auto stackingHandler = std::make_shared<SpanStackingHandler>();
+    auto sampler = std::make_shared<Sampler>();
+    sampler->setProbability(1.0);
+    auto batch = std::make_shared<Batch>();
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, ^(){});
+    tracer->earlyConfigure(earlyConfig);
+    tracer->earlySetup();
+    tracer->configure(config);
+    tracer->start();
+
+    SpanOptions spanOptions;
+    auto span = tracer->startViewLoadSpan(BugsnagPerformanceViewTypeUIKit, @"myclass", spanOptions);
+    [span end];
+    tracer->onPrewarmPhaseEnded();
+    auto spans = batch->drain(true);
+    XCTAssertEqual(spans->size(), 1UL);
+}
+
+- (void)testNoPrewarmEndAfter {
+    auto earlyConfig = [BSGEarlyConfiguration new];
+    earlyConfig.appWasLaunchedPreWarmed = NO;
+    auto config = newConfig();
+    auto stackingHandler = std::make_shared<SpanStackingHandler>();
+    auto sampler = std::make_shared<Sampler>();
+    sampler->setProbability(1.0);
+    auto batch = std::make_shared<Batch>();
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, ^(){});
+    tracer->earlyConfigure(earlyConfig);
+    tracer->earlySetup();
+    tracer->configure(config);
+    tracer->start();
+
+    SpanOptions spanOptions;
+    auto span = tracer->startViewLoadSpan(BugsnagPerformanceViewTypeUIKit, @"myclass", spanOptions);
+    tracer->onPrewarmPhaseEnded();
+    [span end];
+    auto spans = batch->drain(true);
+    XCTAssertEqual(spans->size(), 1UL);
+}
+
+@end


### PR DESCRIPTION
## Goal

When view spans are started during the prewarm phase, throw them out because they'll end up with long durations that skew the dashboard stats.


## Testing

Added uni tests.
