### PR TITLE
Ensure span cancellation is done properly with concurrency protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ logs/*
 
 # Other
 .DS_Store
+features/fixtures/ios/Fixture/Info.plist

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -21,13 +21,6 @@ static NSString *getPersistenceDir() {
     return NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
 }
 
-void (^generateOnSpanStarted(BugsnagPerformanceImpl *impl))(void) {
-    __block auto blockImpl = impl;
-  return ^{
-      blockImpl->onSpanStarted();
-  };
-}
-
 BugsnagPerformanceImpl::BugsnagPerformanceImpl(std::shared_ptr<Reachability> reachability,
                                                AppStateTracker *appStateTracker) noexcept
 : persistence_(std::make_shared<Persistence>(getPersistenceDir()))
@@ -36,7 +29,7 @@ BugsnagPerformanceImpl::BugsnagPerformanceImpl(std::shared_ptr<Reachability> rea
 , reachability_(reachability)
 , batch_(std::make_shared<Batch>())
 , sampler_(std::make_shared<Sampler>())
-, tracer_(std::make_shared<Tracer>(spanStackingHandler_, sampler_, batch_, generateOnSpanStarted(this)))
+, tracer_(std::make_shared<Tracer>(spanStackingHandler_, sampler_, batch_, ^{this->onSpanStarted();}))
 , retryQueue_(std::make_unique<RetryQueue>([persistence_->bugsnagPerformanceDir() stringByAppendingPathComponent:@"retry-queue"]))
 , appStateTracker_(appStateTracker)
 , viewControllersToSpans_([NSMapTable mapTableWithKeyOptions:NSMapTableWeakMemory | NSMapTableObjectPointerPersonality

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
@@ -51,18 +51,17 @@ BugsnagPerformanceLibrary::BugsnagPerformanceLibrary()
 : appStateTracker_([[AppStateTracker alloc] init])
 , reachability_(std::make_shared<Reachability>())
 , bugsnagPerformanceImpl_(std::make_shared<BugsnagPerformanceImpl>(reachability_, appStateTracker_))
-{
-    auto impl = bugsnagPerformanceImpl_;
-    bugsnagPerformanceImpl_->setOnViewLoadSpanStarted([=](NSString *className) {
-        impl->didStartViewLoadSpan(className);
-    });
-}
+{}
 
 void BugsnagPerformanceLibrary::earlyConfigure(BSGEarlyConfiguration *config) noexcept {
     bugsnagPerformanceImpl_->earlyConfigure(config);
 }
 
 void BugsnagPerformanceLibrary::earlySetup() noexcept {
+    auto impl = bugsnagPerformanceImpl_;
+    bugsnagPerformanceImpl_->setOnViewLoadSpanStarted([=](NSString *className) {
+        impl->didStartViewLoadSpan(className);
+    });
     bugsnagPerformanceImpl_->earlySetup();
 }
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
@@ -23,7 +23,7 @@ public:
                               std::shared_ptr<SpanAttributesProvider> spanAttributesProvider) noexcept;
 
     void earlyConfigure(BSGEarlyConfiguration *) noexcept {}
-    void earlySetup() noexcept {}
+    void earlySetup() noexcept;
     void configure(BugsnagPerformanceConfiguration *config) noexcept;
     void start() noexcept {}
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -64,9 +64,10 @@ AppStartupInstrumentation::AppStartupInstrumentation(std::shared_ptr<Tracer> tra
 , tracer_(tracer)
 , spanAttributesProvider_(spanAttributesProvider)
 , didStartProcessAtTime_(getProcessStartTime())
-, didCallMainFunctionAtTime_(CFAbsoluteTimeGetCurrent())
 , isColdLaunch_(isColdLaunch())
-{
+{}
+
+void AppStartupInstrumentation::earlySetup() noexcept {
     if (!canInstallInstrumentation()) {
         disable();
     }
@@ -86,6 +87,7 @@ void AppStartupInstrumentation::willCallMainFunction() noexcept {
 
     beginAppStartSpan();
     beginPreMainSpan();
+    didCallMainFunctionAtTime_ = CFAbsoluteTimeGetCurrent();
     [preMainSpan_ endWithAbsoluteTime:didCallMainFunctionAtTime_];
     beginPostMainSpan();
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -111,7 +111,10 @@ ViewLoadInstrumentation::configure(BugsnagPerformanceConfiguration *config) noex
     }
 
     isEnabled_ &= config.autoInstrumentViewControllers;
-    callback_ = config.viewControllerInstrumentationCallback;
+    auto callback = config.viewControllerInstrumentationCallback;
+    if (callback != nullptr) {
+        callback_ = callback;
+    }
 
     endEarlySpanPhase();
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -65,12 +65,16 @@ private:
     NSMutableArray<BugsnagPerformanceSpan *> *earlyNetworkSpans_;
 
     std::shared_ptr<Batch> batch_;
-    void (^onSpanStarted_)(){nil};
-    std::function<void(NSString *)> onViewLoadSpanStarted_{};
-    BugsnagPerformanceNetworkRequestCallback networkRequestCallback_;
+    void (^onSpanStarted_)(){ ^(){} };
+    std::function<void(NSString *)> onViewLoadSpanStarted_{ [](NSString *){} };
+    BugsnagPerformanceNetworkRequestCallback networkRequestCallback_ {
+        ^BugsnagPerformanceNetworkRequestInfo * _Nonnull(BugsnagPerformanceNetworkRequestInfo * _Nonnull info) {
+            return info;
+        }
+    };
 
     BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
-    void tryAddSpanToBatch(std::shared_ptr<SpanData> spanData);
+    void trySampleAndAddSpanToBatch(std::shared_ptr<SpanData> spanData);
     void markEarlyNetworkSpan(BugsnagPerformanceSpan *span) noexcept;
     void endEarlySpansPhase() noexcept;
 };

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -24,7 +24,7 @@ class Scenario: NSObject {
     }
 
     func configure() {
-        NSLog("Scenario.configure()")
+        logDebug("Scenario.configure()")
 
         // Make sure the initial P value has time to be fully received before sending spans
         config.internal.initialRecurringWorkDelay = 0.5
@@ -39,20 +39,20 @@ class Scenario: NSObject {
     }
     
     func clearPersistentData() {
-        NSLog("Scenario.clearPersistentData()")
+        logDebug("Scenario.clearPersistentData()")
         UserDefaults.standard.removePersistentDomain(
             forName: Bundle.main.bundleIdentifier!)
     }
     
     func startBugsnag() {
-        NSLog("Scenario.startBugsnag()")
+        logDebug("Scenario.startBugsnag()")
         performAndReportDuration({
             BugsnagPerformance.start(configuration: config)
         }, measurement: "start")
     }
     
     func run() {
-        NSLog("Scenario.run() has not been overridden!")
+        logError("Scenario.run() has not been overridden!")
         fatalError("To be implemented by subclass")
     }
     
@@ -75,7 +75,7 @@ class Scenario: NSObject {
     }
 
     func waitForCurrentBatch() {
-        NSLog("Scenario.waitForCurrentBatch()")
+        logDebug("Scenario.waitForCurrentBatch()")
         // Wait long enough to allow the current batch to be packaged and sent
         Thread.sleep(forTimeInterval: 1.0)
     }

--- a/features/fixtures/ios/build.sh
+++ b/features/fixtures/ios/build.sh
@@ -44,4 +44,4 @@ xcodebuild -destination generic/platform=iOS -archivePath Fixture.xcarchive -exp
 
 mv ./output/Fixture.ipa ./output/$fixture_name.ipa
 
-rm ./Fixture/Info.plist
+#rm ./Fixture/Info.plist


### PR DESCRIPTION
## Goal

Using `networkRequestCallback_` null value as a flag affecting behaviour is too fragile and has led to multiple bugs. Refactor this section to just re-run the callback for the (max 10 or so) initial spans instead, which makes the concurrency checks far less complex / prone to holes.

As a result:
- `isEarlySpansPhase_` and dependent code will never suffer race conditions
- Spans will never end up partially initialized because they ran in between states where the network callback pointed to actual user code.
- The callbacks can never be null
