### PR TITLE
[PLAT-11205] Add view load phase API that can be called from Swift

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -51,6 +51,9 @@ public:
                                               BugsnagPerformanceViewType viewType,
                                               BugsnagPerformanceSpanOptions *options) noexcept;
 
+    BugsnagPerformanceSpan *startViewLoadPhaseSpan(NSString *className, NSString *phase,
+                                                   BugsnagPerformanceSpan *parentContext) noexcept;
+
     void startViewLoadSpan(UIViewController *controller, BugsnagPerformanceSpanOptions *options) noexcept;
 
     void endViewLoadSpan(UIViewController *controller, NSDate *endTime) noexcept;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -370,6 +370,13 @@ void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, Bug
     [viewControllersToSpans_ setObject:span forKey:controller];
 }
 
+BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadPhaseSpan(NSString *className, NSString *phase,
+                                                                       BugsnagPerformanceSpan *parentContext) noexcept {
+    auto span = tracer_->startViewLoadPhaseSpan(className, phase, parentContext);
+    [span addAttributes:spanAttributesProvider_->viewLoadPhaseSpanAttributes(className, phase)];
+    return span;
+}
+
 void BugsnagPerformanceImpl::endViewLoadSpan(UIViewController *controller, NSDate *endTime) noexcept {
     /* Although NSMapTable supports weak keys, zeroed keys are not actually removed
      * until certain internal operations occur (such as the map resizing itself).

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -302,10 +302,8 @@ ViewLoadInstrumentation::startViewLoadPhaseSpan(UIViewController *viewController
         return nullptr;
     }
     auto className = NSStringFromClass([viewController class]);
-    SpanOptions options;
-    BugsnagPerformanceSpan *viewLoadSpan = objc_getAssociatedObject(viewController, &kAssociatedViewLoadSpan);
-    options.parentContext = viewLoadSpan;
-    auto span = tracer_->startViewLoadPhaseSpan([NSString stringWithFormat:@"[ViewLoadPhase/%@]/%@", phase, className], options);
+    BugsnagPerformanceSpan *parentViewLoadSpan = objc_getAssociatedObject(viewController, &kAssociatedViewLoadSpan);
+    auto span = tracer_->startViewLoadPhaseSpan(className, phase, parentViewLoadSpan);
     [span addAttributes:spanAttributesProvider_->viewLoadPhaseSpanAttributes(className, phase)];
 
     if (isEarlySpanPhase_) {

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -52,7 +52,9 @@ public:
 
     BugsnagPerformanceSpan *startNetworkSpan(NSURL *url, NSString *httpMethod, SpanOptions options) noexcept;
 
-    BugsnagPerformanceSpan *startViewLoadPhaseSpan(NSString *name, SpanOptions options) noexcept;
+    BugsnagPerformanceSpan *startViewLoadPhaseSpan(NSString *className,
+                                                   NSString *phase,
+                                                   BugsnagPerformanceSpan *parentContext) noexcept;
 
     void cancelQueuedSpan(BugsnagPerformanceSpan *span) noexcept;
 

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -145,8 +145,12 @@ Tracer::startNetworkSpan(NSURL *url, NSString *httpMethod, SpanOptions options) 
 }
 
 BugsnagPerformanceSpan *
-Tracer::startViewLoadPhaseSpan(NSString *name,
-                        SpanOptions options) noexcept {
+Tracer::startViewLoadPhaseSpan(NSString *className,
+                               NSString *phase,
+                               BugsnagPerformanceSpan *parentContext) noexcept {
+    NSString *name = [NSString stringWithFormat:@"[ViewLoadPhase/%@]/%@", phase, className];
+    SpanOptions options;
+    options.parentContext = parentContext;
     auto span = startSpan(name, options, BSGFirstClassUnset);
     if (willDiscardPrewarmSpans_) {
         markPrewarmSpan(span);

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -42,6 +42,12 @@ using namespace bugsnag;
     return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startViewLoadSpan(name, viewType, options);
 }
 
++ (BugsnagPerformanceSpan *)startViewLoadPhaseSpanWithName:(NSString *)name
+                                                     phase:(NSString *)phase
+                                             parentContext:(BugsnagPerformanceSpan *)parentContext {
+    return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startViewLoadPhaseSpan(name, phase, parentContext);
+}
+
 + (void)startViewLoadSpanWithController:(UIViewController *)controller
                                 options:(BugsnagPerformanceSpanOptions *)options {
     BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startViewLoadSpan(controller, options);

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -50,6 +50,11 @@ OBJC_EXPORT
                               endTime:(NSDate *)endTime
   NS_SWIFT_NAME(endViewLoadSpan(controller:endTime:));
 
++ (BugsnagPerformanceSpan *)startViewLoadPhaseSpanWithName:(NSString *)name
+                                                     phase:(NSString *)phase
+                                             parentContext:(BugsnagPerformanceSpan *)parentContext
+  NS_SWIFT_NAME(startViewLoadPhaseSpan(name:phase:parentContext:));
+
 @end
 
 @interface BugsnagPerformance (/* Manual network spans */)

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -83,6 +83,23 @@ Feature: Manual creation of spans
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "view_load"
 
+  Scenario: Manually report a SwiftUI view load phase span
+    Given I run "ManualViewLoadPhaseScenario"
+    And I wait for 2 spans
+    * the trace "Bugsnag-Span-Sampling" header is present
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "[ViewLoad/SwiftUI]/ManualViewLoadPhaseScenario"
+    * a span field "name" equals "[ViewLoadPhase/SomePhase]/ManualViewLoadPhaseScenario"
+    * every span string attribute "bugsnag.view.name" equals "ManualViewLoadPhaseScenario"
+    * a span string attribute "bugsnag.view.type" equals "SwiftUI"
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * a span bool attribute "bugsnag.span.first_class" is false
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "bugsnag.span.category" equals "view_load"
+    * a span string attribute "bugsnag.span.category" equals "view_load_phase"
+
   Scenario: Manually report a UIViewController load span
     Given I run "ManualUIViewLoadScenario"
     And I wait for 1 span

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		09637A412B060E7C00F4F776 /* CommandReaderThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A402B060E7C00F4F776 /* CommandReaderThread.swift */; };
 		09637A432B0617FE00F4F776 /* MazeRunnerCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A422B0617FE00F4F776 /* MazeRunnerCommand.swift */; };
 		09637A452B0B883B00F4F776 /* FixtureConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A442B0B883B00F4F776 /* FixtureConfig.swift */; };
+		098808E02B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */; };
 		09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */; };
 		9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */; };
 		9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */; };
@@ -79,6 +80,7 @@
 		09637A402B060E7C00F4F776 /* CommandReaderThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandReaderThread.swift; sourceTree = "<group>"; };
 		09637A422B0617FE00F4F776 /* MazeRunnerCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MazeRunnerCommand.swift; sourceTree = "<group>"; };
 		09637A442B0B883B00F4F776 /* FixtureConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixtureConfig.swift; sourceTree = "<group>"; };
+		098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualViewLoadPhaseScenario.swift; sourceTree = "<group>"; };
 		09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkCallbackScenario.swift; sourceTree = "<group>"; };
 		9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentTabViewLoadScenario.swift; sourceTree = "<group>"; };
 		9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNavigationViewLoadScenario.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
+				098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -323,6 +326,7 @@
 				09637A3F2B06082200F4F776 /* Logging.m in Sources */,
 				CB3477182901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift in Sources */,
 				CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */,
+				098808E02B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift in Sources */,
 				01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */,
 				09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */,
 				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/ManualViewLoadPhaseScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualViewLoadPhaseScenario.swift
@@ -1,0 +1,19 @@
+//
+//  ManualViewLoadPhaseScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 24.11.23.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class ManualViewLoadPhaseScenario: Scenario {
+    override func run() {
+        let options = BugsnagPerformanceSpanOptions().setStartTime(Date())
+        let parentSpan = BugsnagPerformance.startViewLoadSpan(name: "ManualViewLoadPhaseScenario", viewType: .swiftUI, options:options)
+        let phaseSpan = BugsnagPerformance.startViewLoadPhaseSpan(name: "ManualViewLoadPhaseScenario", phase: "SomePhase", parentContext: parentSpan)
+        phaseSpan.end()
+        parentSpan.end()
+    }
+}


### PR DESCRIPTION
## Goal

Adds a swift-accessible API for view load phase spans, which will be used in the upcoming SwiftUI instrumentation API.

## Testing

Added e2e test
