### PR TITLE
[PLAT-11206] Add SwiftUI instrumentation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ env:
   LANG: "en_GB.UTF-8"
 
 agents:
-  queue: macos-12-arm
+  queue: macos-13-arm
 
 steps:
 
@@ -25,7 +25,7 @@ steps:
           - bundle exec upload-app --app=./features/fixtures/ios/output/Fixture.ipa --app-id-file=./features/fixtures/ios/output/ipa_url.txt
         artifact_paths:
           - features/fixtures/ios/output/ipa_url.txt
-          
+
       - label: "Fixture swizzling disabled"
         key: ios_fixture_swizzling_disabled
         commands:
@@ -34,7 +34,7 @@ steps:
           - bundle exec upload-app --app=./features/fixtures/ios/output/FixtureWithDisableSwizzling.ipa --app-id-file=./features/fixtures/ios/output/ipa_url_swizzling_disabled.txt
         artifact_paths:
           - features/fixtures/ios/output/ipa_url_swizzling_disabled.txt
-          
+
       - label: "Fixture swizzling premain"
         key: ios_fixture_swizzling_premain
         commands:
@@ -48,7 +48,7 @@ steps:
     steps:
       - label: "iOS 15 Unit Tests"
         commands:
-          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=15.0
+          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=15.0 DEVICE="iPhone 13"
         plugins:
           artifacts#v1.5.0:
             upload:
@@ -231,7 +231,7 @@ steps:
         concurrency: 5
         concurrency_group: browserstack-app
         concurrency_method: eager
-        
+
   - group: ":iphone: Swizzling disabled E2E Tests"
     steps:
       - label: "iOS 16 E2E Tests swizzling disabled"
@@ -287,7 +287,7 @@ steps:
         concurrency: 5
         concurrency_group: browserstack-app
         concurrency_method: eager
-        
+
       - label: "iOS 11 E2E Tests swizzling disabled"
         depends_on:
           - ios_fixture_swizzling_disabled
@@ -370,7 +370,7 @@ steps:
         concurrency: 5
         concurrency_group: browserstack-app
         concurrency_method: eager
-        
+
       - label: "iOS 11 E2E Tests swizzling premain"
         depends_on:
           - ios_fixture_swizzling_premain

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,16 +46,16 @@ steps:
 
   - group: ":xcode_simulator: Unit Tests"
     steps:
-      - label: "iOS 15 Unit Tests"
+      - label: "iOS 17 Unit Tests"
         commands:
-          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=15.0 DEVICE="iPhone 13"
+          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=17.0.1 DEVICE="iPhone 13"
         plugins:
           artifacts#v1.5.0:
             upload:
               - "logs/*"
-      - label: "iOS 11 Unit Tests"
+      - label: "iOS 13 Unit Tests"
         commands:
-          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=11.4
+          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=13.0
         plugins:
           artifacts#v1.5.0:
             upload:
@@ -177,61 +177,6 @@ steps:
         concurrency_group: browserstack-app
         concurrency_method: eager
 
-      - label: "iOS 12 E2E Tests"
-        depends_on:
-          - ios_fixture
-        timeout_in_minutes: 30
-        agents:
-          queue: opensource
-        plugins:
-          artifacts#v1.5.0:
-            download: "features/fixtures/ios/output/ipa_url.txt"
-            upload:
-              - "maze_output/failed/**/*"
-              - "maze_output/metrics.csv"
-              - "maze_output/maze_output.zip"
-          docker-compose#v4.8.0:
-            pull: cocoa-maze-runner
-            run: cocoa-maze-runner
-            command:
-              - "--app=@build/ipa_url.txt"
-              - "--device=IOS_12"
-              - "--fail-fast"
-              - "--farm=bs"
-              - "--order=random"
-              - "features/default"
-        concurrency: 5
-        concurrency_group: browserstack-app
-        concurrency_method: eager
-
-      - label: "iOS 11 E2E Tests"
-        depends_on:
-          - ios_fixture
-        timeout_in_minutes: 30
-        agents:
-          queue: opensource
-        plugins:
-          artifacts#v1.5.0:
-            download: "features/fixtures/ios/output/ipa_url.txt"
-            upload:
-              - "maze_output/failed/**/*"
-              - "maze_output/metrics.csv"
-              - "maze_output/maze_output.zip"
-          docker-compose#v4.8.0:
-            pull: cocoa-maze-runner-legacy
-            run: cocoa-maze-runner-legacy
-            command:
-              - "--app=@build/ipa_url.txt"
-              - "--appium-version=1.16.0"
-              - "--device=IOS_11"
-              - "--fail-fast"
-              - "--farm=bs"
-              - "--order=random"
-              - "features/default"
-        concurrency: 5
-        concurrency_group: browserstack-app
-        concurrency_method: eager
-
   - group: ":iphone: Swizzling disabled E2E Tests"
     steps:
       - label: "iOS 16 E2E Tests swizzling disabled"
@@ -280,33 +225,6 @@ steps:
               - "--app=@build/ipa_url_swizzling_disabled.txt"
               - "--appium-version=1.21.0"
               - "--device=IOS_14"
-              - "--fail-fast"
-              - "--farm=bs"
-              - "--order=random"
-              - "features/swizzling_disabled"
-        concurrency: 5
-        concurrency_group: browserstack-app
-        concurrency_method: eager
-
-      - label: "iOS 11 E2E Tests swizzling disabled"
-        depends_on:
-          - ios_fixture_swizzling_disabled
-        timeout_in_minutes: 30
-        agents:
-          queue: opensource
-        plugins:
-          artifacts#v1.5.0:
-            download: "features/fixtures/ios/output/ipa_url_swizzling_disabled.txt"
-            upload:
-              - "maze_output/failed/**/*"
-              - "maze_output/metrics.csv"
-          docker-compose#v4.8.0:
-            pull: cocoa-maze-runner-legacy
-            run: cocoa-maze-runner-legacy
-            command:
-              - "--app=@build/ipa_url_swizzling_disabled.txt"
-              - "--appium-version=1.16.0"
-              - "--device=IOS_11"
               - "--fail-fast"
               - "--farm=bs"
               - "--order=random"
@@ -370,31 +288,3 @@ steps:
         concurrency: 5
         concurrency_group: browserstack-app
         concurrency_method: eager
-
-      - label: "iOS 11 E2E Tests swizzling premain"
-        depends_on:
-          - ios_fixture_swizzling_premain
-        timeout_in_minutes: 30
-        agents:
-          queue: opensource
-        plugins:
-          artifacts#v1.5.0:
-            download: "features/fixtures/ios/output/ipa_url_swizzling_premain.txt"
-            upload:
-              - "maze_output/failed/**/*"
-              - "maze_output/metrics.csv"
-          docker-compose#v4.8.0:
-            pull: cocoa-maze-runner-legacy
-            run: cocoa-maze-runner-legacy
-            command:
-              - "--app=@build/ipa_url_swizzling_premain.txt"
-              - "--appium-version=1.16.0"
-              - "--device=IOS_11"
-              - "--fail-fast"
-              - "--farm=bs"
-              - "--order=random"
-              - "features/default"
-        concurrency: 5
-        concurrency_group: browserstack-app
-        concurrency_method: eager
-

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,20 +48,20 @@ steps:
     steps:
       - label: "iOS 17 Unit Tests"
         commands:
-          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=17.0.1 DEVICE="iPhone 13"
+          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=17.0.1 DEVICE="iPhone 14"
         plugins:
           artifacts#v1.5.0:
             upload:
               - "logs/*"
       - label: "iOS 13 Unit Tests"
         commands:
-          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=13.0
+          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=13.7
         plugins:
           artifacts#v1.5.0:
             upload:
               - "logs/*"
         agents:
-          queue: macos-11
+          queue: macos-12-arm
 
   - group: ":iphone: E2E Tests"
     steps:

--- a/BugsnagPerformance.podspec.json
+++ b/BugsnagPerformance.podspec.json
@@ -15,7 +15,7 @@
     "tag": "v1.1.3"
   },
   "platforms": {
-    "ios": "11.0"
+    "ios": "13.0"
   },
   "requires_arc": true,
   "source_files": "Sources/BugsnagPerformance/**/*",

--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -57,7 +57,7 @@
 		094FA7482B10EDE700112ED4 /* BugsnagPerformanceSwiftUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 094FA7322B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		094FA7522B10EEB600112ED4 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		09509B752ADFE9A900A358EC /* TracerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09509B742ADFE9A900A358EC /* TracerTests.mm */; };
-		0983A1962B1624C000DDF4FF /* BugsnagPerformanceSwiftUIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094FA7502B10EE5600112ED4 /* BugsnagPerformanceSwiftUIInstrumentation.swift */; };
+		096CBC172B1752F700534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096CBC152B1752F100534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift */; };
 		8A80DA8B2966CE940035BDA9 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		8A80DA912966CEB30035BDA9 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A80DA80296588840035BDA9 /* ConfigurationTests.swift */; };
 		962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F80F129DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift */; };
@@ -270,8 +270,8 @@
 		094FA7352B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = BugsnagPerformanceSwiftUI.docc; sourceTree = "<group>"; };
 		094FA73B2B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugsnagPerformanceSwiftUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		094FA7422B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugsnagPerformanceSwiftUITests.swift; sourceTree = "<group>"; };
-		094FA7502B10EE5600112ED4 /* BugsnagPerformanceSwiftUIInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BugsnagPerformanceSwiftUIInstrumentation.swift; path = ../../BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUIInstrumentation.swift; sourceTree = "<group>"; };
 		09509B742ADFE9A900A358EC /* TracerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TracerTests.mm; sourceTree = "<group>"; };
+		096CBC152B1752F100534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BugsnagPerformanceSwiftUIInstrumentation.swift; sourceTree = "<group>"; };
 		72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformance.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A80DA80296588840035BDA9 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		8A80DA872966CE940035BDA9 /* BugsnagPerformance-SwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagPerformance-SwiftTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -423,6 +423,7 @@
 			isa = PBXGroup;
 			children = (
 				0122C21429019770002D243C /* BugsnagPerformance */,
+				096CBC142B1752B000534F0C /* BugsnagPerformanceSwiftUI */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -433,7 +434,6 @@
 				0122C21529019770002D243C /* include */,
 				0122C21F29019770002D243C /* Private */,
 				0122C21B29019770002D243C /* Public */,
-				094FA74F2B10EE2100112ED4 /* SwiftUI */,
 			);
 			path = BugsnagPerformance;
 			sourceTree = "<group>";
@@ -627,12 +627,12 @@
 			path = BugsnagPerformanceSwiftUITests;
 			sourceTree = "<group>";
 		};
-		094FA74F2B10EE2100112ED4 /* SwiftUI */ = {
+		096CBC142B1752B000534F0C /* BugsnagPerformanceSwiftUI */ = {
 			isa = PBXGroup;
 			children = (
-				094FA7502B10EE5600112ED4 /* BugsnagPerformanceSwiftUIInstrumentation.swift */,
+				096CBC152B1752F100534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift */,
 			);
-			path = SwiftUI;
+			path = BugsnagPerformanceSwiftUI;
 			sourceTree = "<group>";
 		};
 		450CB5014AAED50046482044 /* Products */ = {
@@ -1033,7 +1033,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				094FA7362B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.docc in Sources */,
-				0983A1962B1624C000DDF4FF /* BugsnagPerformanceSwiftUIInstrumentation.swift in Sources */,
+				096CBC172B1752F700534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -49,7 +49,15 @@
 		01EAF980291AAF19007AC627 /* Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 01EAF97F291AAF19007AC627 /* Utils.h */; };
 		0921F02B2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0921F02C2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */; };
+		094FA7362B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.docc in Sources */ = {isa = PBXBuildFile; fileRef = 094FA7352B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.docc */; };
+		094FA73C2B10EDE700112ED4 /* BugsnagPerformanceSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 094FA7322B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.framework */; };
+		094FA7432B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094FA7422B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.swift */; };
+		094FA7442B10EDE700112ED4 /* BugsnagPerformanceSwiftUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 094FA7342B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		094FA7472B10EDE700112ED4 /* BugsnagPerformanceSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 094FA7322B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.framework */; };
+		094FA7482B10EDE700112ED4 /* BugsnagPerformanceSwiftUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 094FA7322B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		094FA7522B10EEB600112ED4 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		09509B752ADFE9A900A358EC /* TracerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09509B742ADFE9A900A358EC /* TracerTests.mm */; };
+		0983A1962B1624C000DDF4FF /* BugsnagPerformanceSwiftUIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094FA7502B10EE5600112ED4 /* BugsnagPerformanceSwiftUIInstrumentation.swift */; };
 		8A80DA8B2966CE940035BDA9 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		8A80DA912966CEB30035BDA9 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A80DA80296588840035BDA9 /* ConfigurationTests.swift */; };
 		962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F80F129DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift */; };
@@ -140,6 +148,34 @@
 			remoteGlobalIDString = B4A4A4DE1EA43C6C4D6D3894;
 			remoteInfo = "BugsnagPerformance-iOS";
 		};
+		094FA73D2B10EDE700112ED4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5DB9DB2E409A040615FFD4FE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 094FA7312B10EDE600112ED4;
+			remoteInfo = BugsnagPerformanceSwiftUI;
+		};
+		094FA73F2B10EDE700112ED4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5DB9DB2E409A040615FFD4FE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 96D415EF29E6ADC500AEE435;
+			remoteInfo = BugsnagPerformanceTestsApp;
+		};
+		094FA7452B10EDE700112ED4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5DB9DB2E409A040615FFD4FE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 094FA7312B10EDE600112ED4;
+			remoteInfo = BugsnagPerformanceSwiftUI;
+		};
+		094FA7542B10EEB600112ED4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5DB9DB2E409A040615FFD4FE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B4A4A4DE1EA43C6C4D6D3894;
+			remoteInfo = "BugsnagPerformance-iOS";
+		};
 		8A80DA8C2966CE940035BDA9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5DB9DB2E409A040615FFD4FE /* Project object */;
@@ -178,6 +214,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				966DD5022A211D7F002030B2 /* BugsnagPerformance.framework in Embed Frameworks */,
+				094FA7482B10EDE700112ED4 /* BugsnagPerformanceSwiftUI.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -228,6 +265,12 @@
 		01EF4A3E29067786003CC5A5 /* BugsnagPerformance.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BugsnagPerformance.xcconfig; sourceTree = "<group>"; };
 		0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceNetworkRequestInfo.h; sourceTree = "<group>"; };
 		0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagPerformanceNetworkRequestInfo.m; sourceTree = "<group>"; };
+		094FA7322B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformanceSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		094FA7342B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSwiftUI.h; sourceTree = "<group>"; };
+		094FA7352B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = BugsnagPerformanceSwiftUI.docc; sourceTree = "<group>"; };
+		094FA73B2B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugsnagPerformanceSwiftUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		094FA7422B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugsnagPerformanceSwiftUITests.swift; sourceTree = "<group>"; };
+		094FA7502B10EE5600112ED4 /* BugsnagPerformanceSwiftUIInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BugsnagPerformanceSwiftUIInstrumentation.swift; path = ../../BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUIInstrumentation.swift; sourceTree = "<group>"; };
 		09509B742ADFE9A900A358EC /* TracerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TracerTests.mm; sourceTree = "<group>"; };
 		72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformance.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A80DA80296588840035BDA9 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
@@ -329,6 +372,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		094FA72F2B10EDE600112ED4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				094FA7522B10EEB600112ED4 /* BugsnagPerformance.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		094FA7382B10EDE700112ED4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				094FA73C2B10EDE700112ED4 /* BugsnagPerformanceSwiftUI.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		24F72927E95AE2E3C8514901 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -353,6 +412,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				966DD5012A211D7F002030B2 /* BugsnagPerformance.framework in Frameworks */,
+				094FA7472B10EDE700112ED4 /* BugsnagPerformanceSwiftUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,6 +433,7 @@
 				0122C21529019770002D243C /* include */,
 				0122C21F29019770002D243C /* Private */,
 				0122C21B29019770002D243C /* Public */,
+				094FA74F2B10EE2100112ED4 /* SwiftUI */,
 			);
 			path = BugsnagPerformance;
 			sourceTree = "<group>";
@@ -549,6 +610,31 @@
 			path = BugsnagPerformanceTests;
 			sourceTree = "<group>";
 		};
+		094FA7332B10EDE600112ED4 /* BugsnagPerformanceSwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				094FA7342B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.h */,
+				094FA7352B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.docc */,
+			);
+			path = BugsnagPerformanceSwiftUI;
+			sourceTree = "<group>";
+		};
+		094FA7412B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests */ = {
+			isa = PBXGroup;
+			children = (
+				094FA7422B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.swift */,
+			);
+			path = BugsnagPerformanceSwiftUITests;
+			sourceTree = "<group>";
+		};
+		094FA74F2B10EE2100112ED4 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				094FA7502B10EE5600112ED4 /* BugsnagPerformanceSwiftUIInstrumentation.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
 		450CB5014AAED50046482044 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -556,6 +642,8 @@
 				0122C26529019CE1002D243C /* BugsnagPerformance-iOSTests.xctest */,
 				8A80DA872966CE940035BDA9 /* BugsnagPerformance-SwiftTests.xctest */,
 				96D415F029E6ADC500AEE435 /* BugsnagPerformanceTestsApp.app */,
+				094FA7322B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.framework */,
+				094FA73B2B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -591,6 +679,8 @@
 				0122C21329019770002D243C /* Sources */,
 				0122C25B29019C05002D243C /* Tests */,
 				96D415F129E6ADC500AEE435 /* BugsnagPerformanceTestsApp */,
+				094FA7332B10EDE600112ED4 /* BugsnagPerformanceSwiftUI */,
+				094FA7412B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests */,
 				450CB5014AAED50046482044 /* Products */,
 				0122C25629019904002D243C /* Frameworks */,
 			);
@@ -613,6 +703,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		094FA72D2B10EDE600112ED4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				094FA7442B10EDE700112ED4 /* BugsnagPerformanceSwiftUI.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B1F21BEBD2701C99E2C65B22 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -691,6 +789,44 @@
 			productReference = 0122C26529019CE1002D243C /* BugsnagPerformance-iOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		094FA7312B10EDE600112ED4 /* BugsnagPerformanceSwiftUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 094FA74D2B10EDE700112ED4 /* Build configuration list for PBXNativeTarget "BugsnagPerformanceSwiftUI" */;
+			buildPhases = (
+				094FA72D2B10EDE600112ED4 /* Headers */,
+				094FA72E2B10EDE600112ED4 /* Sources */,
+				094FA72F2B10EDE600112ED4 /* Frameworks */,
+				094FA7302B10EDE600112ED4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				094FA7552B10EEB600112ED4 /* PBXTargetDependency */,
+			);
+			name = BugsnagPerformanceSwiftUI;
+			productName = BugsnagPerformanceSwiftUI;
+			productReference = 094FA7322B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		094FA73A2B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 094FA74E2B10EDE700112ED4 /* Build configuration list for PBXNativeTarget "BugsnagPerformanceSwiftUITests" */;
+			buildPhases = (
+				094FA7372B10EDE700112ED4 /* Sources */,
+				094FA7382B10EDE700112ED4 /* Frameworks */,
+				094FA7392B10EDE700112ED4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				094FA73E2B10EDE700112ED4 /* PBXTargetDependency */,
+				094FA7402B10EDE700112ED4 /* PBXTargetDependency */,
+			);
+			name = BugsnagPerformanceSwiftUITests;
+			productName = BugsnagPerformanceSwiftUITests;
+			productReference = 094FA73B2B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		8A80DA862966CE940035BDA9 /* BugsnagPerformance-SwiftTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8A80DA8E2966CE940035BDA9 /* Build configuration list for PBXNativeTarget "BugsnagPerformance-SwiftTests" */;
@@ -723,6 +859,7 @@
 			);
 			dependencies = (
 				966DD5042A211D7F002030B2 /* PBXTargetDependency */,
+				094FA7462B10EDE700112ED4 /* PBXTargetDependency */,
 			);
 			name = BugsnagPerformanceTestsApp;
 			productName = BugsnagPerformanceTestsApp;
@@ -753,7 +890,7 @@
 		5DB9DB2E409A040615FFD4FE /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1420;
+				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = Bugsnag;
 				TargetAttributes = {
@@ -761,6 +898,17 @@
 						CreatedOnToolsVersion = 14.0.1;
 						DevelopmentTeam = 7W9PZ27Y5F;
 						LastSwiftMigration = 1420;
+						TestTargetID = 96D415EF29E6ADC500AEE435;
+					};
+					094FA7312B10EDE600112ED4 = {
+						CreatedOnToolsVersion = 15.0.1;
+						DevelopmentTeam = 7W9PZ27Y5F;
+						ProvisioningStyle = Automatic;
+					};
+					094FA73A2B10EDE700112ED4 = {
+						CreatedOnToolsVersion = 15.0.1;
+						DevelopmentTeam = 7W9PZ27Y5F;
+						ProvisioningStyle = Automatic;
 						TestTargetID = 96D415EF29E6ADC500AEE435;
 					};
 					8A80DA862966CE940035BDA9 = {
@@ -774,6 +922,9 @@
 						DevelopmentTeam = 7W9PZ27Y5F;
 						LastSwiftMigration = 1420;
 						ProvisioningStyle = Automatic;
+					};
+					B4A4A4DE1EA43C6C4D6D3894 = {
+						LastSwiftMigration = 1500;
 					};
 				};
 			};
@@ -791,15 +942,31 @@
 			projectRoot = "";
 			targets = (
 				B4A4A4DE1EA43C6C4D6D3894 /* BugsnagPerformance-iOS */,
+				094FA7312B10EDE600112ED4 /* BugsnagPerformanceSwiftUI */,
 				0122C26429019CE1002D243C /* BugsnagPerformance-iOSTests */,
 				8A80DA862966CE940035BDA9 /* BugsnagPerformance-SwiftTests */,
 				96D415EF29E6ADC500AEE435 /* BugsnagPerformanceTestsApp */,
+				094FA73A2B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		0122C26329019CE1002D243C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		094FA7302B10EDE600112ED4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		094FA7392B10EDE700112ED4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -858,6 +1025,23 @@
 				962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */,
 				CB747D1F299E4984003CA1B4 /* SpanOptionsTests.mm in Sources */,
 				CB0AD76C296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		094FA72E2B10EDE600112ED4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				094FA7362B10EDE600112ED4 /* BugsnagPerformanceSwiftUI.docc in Sources */,
+				0983A1962B1624C000DDF4FF /* BugsnagPerformanceSwiftUIInstrumentation.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		094FA7372B10EDE700112ED4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				094FA7432B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -931,6 +1115,26 @@
 			isa = PBXTargetDependency;
 			target = B4A4A4DE1EA43C6C4D6D3894 /* BugsnagPerformance-iOS */;
 			targetProxy = 0122C26A29019CE1002D243C /* PBXContainerItemProxy */;
+		};
+		094FA73E2B10EDE700112ED4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 094FA7312B10EDE600112ED4 /* BugsnagPerformanceSwiftUI */;
+			targetProxy = 094FA73D2B10EDE700112ED4 /* PBXContainerItemProxy */;
+		};
+		094FA7402B10EDE700112ED4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 96D415EF29E6ADC500AEE435 /* BugsnagPerformanceTestsApp */;
+			targetProxy = 094FA73F2B10EDE700112ED4 /* PBXContainerItemProxy */;
+		};
+		094FA7462B10EDE700112ED4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 094FA7312B10EDE600112ED4 /* BugsnagPerformanceSwiftUI */;
+			targetProxy = 094FA7452B10EDE700112ED4 /* PBXContainerItemProxy */;
+		};
+		094FA7552B10EEB600112ED4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B4A4A4DE1EA43C6C4D6D3894 /* BugsnagPerformance-iOS */;
+			targetProxy = 094FA7542B10EEB600112ED4 /* PBXContainerItemProxy */;
 		};
 		8A80DA8D2966CE940035BDA9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1018,10 +1222,133 @@
 			};
 			name = Release;
 		};
+		094FA7492B10EDE700112ED4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 7W9PZ27Y5F;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Bugsnag. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagPerformanceSwiftUI;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		094FA74A2B10EDE700112ED4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 7W9PZ27Y5F;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Bugsnag. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagPerformanceSwiftUI;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		094FA74B2B10EDE700112ED4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7W9PZ27Y5F;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagPerformanceSwiftUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BugsnagPerformanceTestsApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/BugsnagPerformanceTestsApp";
+			};
+			name = Debug;
+		};
+		094FA74C2B10EDE700112ED4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7W9PZ27Y5F;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagPerformanceSwiftUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BugsnagPerformanceTestsApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/BugsnagPerformanceTestsApp";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		289EE8EA8C7DF1558B8359CA /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 01EF4A3E29067786003CC5A5 /* BugsnagPerformance.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CLANG_MODULES_AUTOLINK = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1037,6 +1364,7 @@
 				PRODUCT_NAME = BugsnagPerformance;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1048,6 +1376,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 01EF4A3E29067786003CC5A5 /* BugsnagPerformance.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CLANG_MODULES_AUTOLINK = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1063,6 +1392,8 @@
 				PRODUCT_NAME = BugsnagPerformance;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1301,6 +1632,7 @@
 		96D4160229E6ADC600AEE435 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -1332,6 +1664,7 @@
 		96D4160329E6ADC600AEE435 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -1377,6 +1710,24 @@
 			buildConfigurations = (
 				289EE8EA8C7DF1558B8359CA /* Release */,
 				4229D9CAB6AC2A2AB4597A50 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		094FA74D2B10EDE700112ED4 /* Build configuration list for PBXNativeTarget "BugsnagPerformanceSwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				094FA7492B10EDE700112ED4 /* Debug */,
+				094FA74A2B10EDE700112ED4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		094FA74E2B10EDE700112ED4 /* Build configuration list for PBXNativeTarget "BugsnagPerformanceSwiftUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				094FA74B2B10EDE700112ED4 /* Debug */,
+				094FA74C2B10EDE700112ED4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -1240,7 +1240,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Bugsnag. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
@@ -1276,7 +1276,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Bugsnag. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
@@ -1359,6 +1359,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagPerformance;
 				PRODUCT_NAME = BugsnagPerformance;
@@ -1387,6 +1388,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagPerformance;
 				PRODUCT_NAME = BugsnagPerformance;

--- a/BugsnagPerformanceSwiftUI.podspec.json
+++ b/BugsnagPerformanceSwiftUI.podspec.json
@@ -1,0 +1,28 @@
+{
+  "name": "BugsnagPerformanceSwiftUI",
+  "version": "1.1.3",
+  "summary": "The Bugsnag performance SwiftUI monitoring framework for iOS.",
+  "homepage": "https://github.com/bugsnag/bugsnag-cocoa-performance",
+  "license": {
+    "type": "MIT",
+    "file": "LICENSE"
+  },
+  "authors": {
+    "Bugsnag": "notifiers@bugsnag.com"
+  },
+  "source": {
+    "git": "https://github.com/bugsnag/bugsnag-cocoa-performance.git",
+    "tag": "v1.1.3"
+  },
+  "platforms": {
+    "ios": "13.0"
+  },
+  "requires_arc": true,
+  "source_files": "Sources/BugsnagPerformanceSwiftUI/**/*",
+  "frameworks": [
+    "SwiftUI"
+  ],
+  "dependencies": {
+    "BugsnagPerformance": "~> 1.1.3"
+  }
+}

--- a/BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUI.docc/BugsnagPerformanceSwiftUI.md
+++ b/BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUI.docc/BugsnagPerformanceSwiftUI.md
@@ -1,0 +1,13 @@
+# ``BugsnagPerformanceSwiftUI``
+
+<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+
+- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->

--- a/BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUI.h
+++ b/BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUI.h
@@ -1,0 +1,19 @@
+//
+//  BugsnagPerformanceSwiftUI.h
+//  BugsnagPerformanceSwiftUI
+//
+//  Created by Karl Stenerud on 24.11.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for BugsnagPerformanceSwiftUI.
+FOUNDATION_EXPORT double BugsnagPerformanceSwiftUIVersionNumber;
+
+//! Project version string for BugsnagPerformanceSwiftUI.
+FOUNDATION_EXPORT const unsigned char BugsnagPerformanceSwiftUIVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <BugsnagPerformanceSwiftUI/PublicHeader.h>
+
+

--- a/BugsnagPerformanceSwiftUITests/BugsnagPerformanceSwiftUITests.swift
+++ b/BugsnagPerformanceSwiftUITests/BugsnagPerformanceSwiftUITests.swift
@@ -1,0 +1,37 @@
+//
+//  BugsnagPerformanceSwiftUITests.swift
+//  BugsnagPerformanceSwiftUITests
+//
+//  Created by Karl Stenerud on 24.11.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+import XCTest
+@testable import BugsnagPerformanceSwiftUI
+
+final class BugsnagPerformanceSwiftUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -17,6 +17,8 @@
 		011C69DD28F5747200C5BA3C /* SomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011C69DC28F5747200C5BA3C /* SomeView.swift */; };
 		011C69E128F5CA1E00C5BA3C /* IgnoredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011C69E028F5CA1E00C5BA3C /* IgnoredViewController.swift */; };
 		0185C46728F6C04B006F9BDC /* ExampleLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 0185C46628F6C04B006F9BDC /* ExampleLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0983A1752B14966B00DDF4FF /* BugsnagPerformance in Frameworks */ = {isa = PBXBuildFile; productRef = 0983A1742B14966B00DDF4FF /* BugsnagPerformance */; };
+		0983A1772B14966B00DDF4FF /* BugsnagPerformanceSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 0983A1762B14966B00DDF4FF /* BugsnagPerformanceSwiftUI */; };
 		CB572EF429C1B96100FD7A2A /* AnotherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011C69DE28F57F1500C5BA3C /* AnotherViewController.swift */; };
 		CBC90C4029C45DCB00280884 /* ForceUBSan.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC90C3F29C45DCB00280884 /* ForceUBSan.m */; };
 /* End PBXBuildFile section */
@@ -30,7 +32,6 @@
 		010656B028DB2E8E00F2A9A6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		010656B328DB2E8E00F2A9A6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		010656B528DB2E8E00F2A9A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		010656C028DB2F5E00F2A9A6 /* bugsnag-cocoa-performance */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "bugsnag-cocoa-performance"; path = ..; sourceTree = "<group>"; };
 		011C69DC28F5747200C5BA3C /* SomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomeView.swift; sourceTree = "<group>"; };
 		011C69DE28F57F1500C5BA3C /* AnotherViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnotherViewController.swift; sourceTree = "<group>"; };
 		011C69E028F5CA1E00C5BA3C /* IgnoredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoredViewController.swift; sourceTree = "<group>"; };
@@ -47,6 +48,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				010656C328DB543B00F2A9A6 /* BugsnagPerformance in Frameworks */,
+				0983A1772B14966B00DDF4FF /* BugsnagPerformanceSwiftUI in Frameworks */,
+				0983A1752B14966B00DDF4FF /* BugsnagPerformance in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,7 +105,6 @@
 		010656BF28DB2F5E00F2A9A6 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
-				010656C028DB2F5E00F2A9A6 /* bugsnag-cocoa-performance */,
 			);
 			name = Packages;
 			sourceTree = "<group>";
@@ -152,6 +154,8 @@
 			name = Example;
 			packageProductDependencies = (
 				010656C228DB543B00F2A9A6 /* BugsnagPerformance */,
+				0983A1742B14966B00DDF4FF /* BugsnagPerformance */,
+				0983A1762B14966B00DDF4FF /* BugsnagPerformanceSwiftUI */,
 			);
 			productName = Example;
 			productReference = 010656A428DB2E8C00F2A9A6 /* Example.app */;
@@ -203,6 +207,9 @@
 				Base,
 			);
 			mainGroup = 0106569B28DB2E8C00F2A9A6;
+			packageReferences = (
+				0983A1732B14966B00DDF4FF /* XCLocalSwiftPackageReference ".." */,
+			);
 			productRefGroup = 010656A528DB2E8C00F2A9A6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -407,6 +414,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -438,6 +446,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -546,10 +555,25 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		0983A1732B14966B00DDF4FF /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		010656C228DB543B00F2A9A6 /* BugsnagPerformance */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BugsnagPerformance;
+		};
+		0983A1742B14966B00DDF4FF /* BugsnagPerformance */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BugsnagPerformance;
+		};
+		0983A1762B14966B00DDF4FF /* BugsnagPerformanceSwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BugsnagPerformanceSwiftUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Example/Example/SomeView.swift
+++ b/Example/Example/SomeView.swift
@@ -6,6 +6,7 @@
 //
 
 import BugsnagPerformance
+import BugsnagPerformanceSwiftUI
 import SwiftUI
 
 @available(iOS 13.0.0, *)
@@ -16,7 +17,7 @@ struct SomeView: View {
         Text("Hello from SwiftUI 🙃")
             .onAppear {
                 span.end()
-            }
+            }.bugsnagTraced("My text view")
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ else
  else
   ifeq ($(PLATFORM),iOS)
    SDK?=iphonesimulator
-   DEVICE?=iPhone 8
+   DEVICE?=iPhone 11
    DESTINATION?=platform=iOS Simulator,name=$(DEVICE),OS=$(OS)
    RELEASE_DIR=Release-iphoneos
   else

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,9 @@ endif
 	@echo $(VERSION) > VERSION
 	@sed -i '' "s/\"version\": .*,/\"version\": \"$(VERSION)\",/" BugsnagPerformance.podspec.json
 	@sed -i '' "s/\"tag\": .*/\"tag\": \"v$(VERSION)\"/" BugsnagPerformance.podspec.json
+	@sed -i '' "s/\"version\": .*,/\"version\": \"$(VERSION)\",/" BugsnagPerformanceSwiftUI.podspec.json
+	@sed -i '' "s/\"tag\": .*/\"tag\": \"v$(VERSION)\"/" BugsnagPerformanceSwiftUI.podspec.json
+	@sed -i '' "s/\"BugsnagPerformance\": .*/\"BugsnagPerformance\": \"$(VERSION)\"/" BugsnagPerformanceSwiftUI.podspec.json
 	@sed -i '' "s/## TBD/## $(VERSION) ($(shell date '+%Y-%m-%d'))/" CHANGELOG.md
 	@sed -i '' -E "s/[0-9]+\.[0-9]+\.[0-9]+/$(VERSION)/g" .jazzy.yaml
 	@sed -i '' -E "s/[0-9]+\.[0-9]+\.[0-9]+/$(VERSION)/g" Sources/BugsnagPerformance/Private/Version.h

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,9 @@ let package = Package(
         .library(
             name: "BugsnagPerformance",
             targets: ["BugsnagPerformance"]),
+        .library(
+            name: "BugsnagPerformanceSwiftUI",
+            targets: ["BugsnagPerformanceSwiftUI"]),
     ],
     targets: [
         .target(
@@ -25,6 +28,11 @@ let package = Package(
                 .linkedFramework("UIKit"),
                 .linkedFramework("CoreTelephony"),
             ]
+        ),
+        .target(
+            name: "BugsnagPerformanceSwiftUI",
+            dependencies: ["BugsnagPerformance"],
+            path: "Sources/BugsnagPerformanceSwiftUI"
         ),
         .testTarget(
             name: "BugsnagPerformanceTests",

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -83,12 +83,7 @@ static NSDictionary *accessTechnologyMappingDictionary() {
 static NSString *getConnectionSubtype(NSString *networkType) {
     if ([networkType isEqual:connectionTypeCell]) {
 #if TARGET_OS_IOS
-        NSString *accessTechnology;
-        if (@available(iOS 12.0, *)) {
-            accessTechnology = [[CTTelephonyNetworkInfo new].serviceCurrentRadioAccessTechnology objectForKey:networkSubtypeKey];
-        } else {
-            accessTechnology = [CTTelephonyNetworkInfo new].currentRadioAccessTechnology;
-        }
+        NSString *accessTechnology = [[CTTelephonyNetworkInfo new].serviceCurrentRadioAccessTechnology objectForKey:networkSubtypeKey];
         if (accessTechnology) {
             return accessTechnologyMappingDictionary()[accessTechnology];
         }

--- a/Sources/BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUIInstrumentation.swift
+++ b/Sources/BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUIInstrumentation.swift
@@ -1,0 +1,63 @@
+//
+//  BugsnagPerformanceSwiftUIInstrumentation.swift
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 24.11.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+import SwiftUI
+import BugsnagPerformance
+
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
+public extension View {
+    func bugsnagTraced(_ viewName: String? = nil) -> some View {
+        return BugsnagTracedView(viewName) {
+            return self
+        }
+    }
+}
+
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
+public struct BugsnagTracedView<Content: View>: View {
+    let content: () -> Content
+    let name: String
+
+    public init(_ viewName: String? = nil, content: @escaping () -> Content) {
+        self.content = content
+        self.name = viewName ?? BugsnagTracedView.getViewName(content: Content.self)
+    }
+
+    private static func getViewName(content: Any) -> String {
+        let viewName = String(describing: content)
+        if let angleBracketIndex = viewName.firstIndex(of: "<") {
+            return String(viewName[viewName.startIndex ..< angleBracketIndex])
+        }
+        return viewName
+    }
+
+    public var body: some View {
+        let parentSpan = BugsnagPerformance.startViewLoadSpan(name: name, viewType: BugsnagPerformanceViewType.swiftUI)
+        let viewLoadSpan = BugsnagPerformance.startViewLoadPhaseSpan(name: name, phase: "loadView", parentContext: parentSpan)
+
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+            var viewAppearSpan: BugsnagPerformanceSpan? = nil
+            content()
+            .onAppear {
+                viewLoadSpan.end()
+                viewAppearSpan = BugsnagPerformance.startViewLoadPhaseSpan(name: name, phase: "View appearing", parentContext: parentSpan)
+            }
+            .task(priority: .background) {
+                viewAppearSpan?.end()
+                parentSpan.end()
+            }
+        } else {
+            content()
+            .onAppear {
+                viewLoadSpan.end()
+                parentSpan.end()
+            }
+
+        }
+    }
+}

--- a/Sources/BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUIInstrumentation.swift
+++ b/Sources/BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUIInstrumentation.swift
@@ -64,12 +64,13 @@ public struct BugsnagTracedView<Content: View>: View {
     }
 
     public var body: some View {
-        let firstViewLoadSpan = bsgViewContext.firstViewLoadSpan
+        var firstViewLoadSpan = bsgViewContext.firstViewLoadSpan
 
         if firstViewLoadSpan == nil {
             let opts = BugsnagPerformanceSpanOptions()
             opts.setParentContext(nil)
-            let thisViewLoadSpan = BugsnagPerformance.startViewLoadSpan(name: "\(name) (top-level view)", viewType: BugsnagPerformanceViewType.swiftUI, options: opts)
+            let thisViewLoadSpan = BugsnagPerformance.startViewLoadSpan(name: name, viewType: BugsnagPerformanceViewType.swiftUI, options: opts)
+            firstViewLoadSpan = thisViewLoadSpan
             bsgViewContext.firstViewLoadSpan = thisViewLoadSpan
             DispatchQueue.main.async {
                 thisViewLoadSpan.end()
@@ -78,7 +79,7 @@ public struct BugsnagTracedView<Content: View>: View {
 
         let opts = BugsnagPerformanceSpanOptions()
         opts.setParentContext(firstViewLoadSpan)
-        let thisViewLoadSpan = BugsnagPerformance.startViewLoadSpan(name: name, viewType: BugsnagPerformanceViewType.swiftUI, options: opts)
+        let thisViewLoadSpan = BugsnagPerformance.startViewLoadPhaseSpan(name: name, phase: "body", parentContext: firstViewLoadSpan!)
         defer {
             thisViewLoadSpan.end()
         }

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -248,6 +248,52 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
 
+  @skip_below_ios_15
+  Scenario: AutoInstrumentSwiftUIScenario_iOS-15-plus
+    Given I run "AutoInstrumentSwiftUIScenario"
+    And I wait for 3 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "[ViewLoad/SwiftUI]/My text view"
+    * a span field "name" equals "[ViewLoadPhase/loadView]/My text view"
+    * a span field "name" equals "[ViewLoadPhase/View appearing]/My text view"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "bugsnag.span.category" equals "view_load"
+    * a span string attribute "bugsnag.span.category" equals "view_load_phase"
+    * every span string attribute "bugsnag.view.name" equals "My text view"
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * a span string attribute "bugsnag.view.type" equals "SwiftUI"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.PerformanceFixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
+  @skip_ios_15_and_above
+  Scenario: AutoInstrumentSwiftUIScenario-iOS-below-15
+    Given I run "AutoInstrumentSwiftUIScenario"
+    And I wait for 2 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "[ViewLoad/SwiftUI]/My text view"
+    * a span field "name" equals "[ViewLoadPhase/loadView]/My text view"
+    # ios < 15 won't have the "view appearing" span
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "bugsnag.span.category" equals "view_load"
+    * a span string attribute "bugsnag.span.category" equals "view_load_phase"
+    * every span string attribute "bugsnag.view.name" equals "My text view"
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * a span string attribute "bugsnag.view.type" equals "SwiftUI"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.PerformanceFixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
   Scenario: Automatically start a network span that has a parent
     Given I run "AutoInstrumentNetworkWithParentScenario"
     And I wait for 2 seconds

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -248,46 +248,23 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
 
-  @skip_below_ios_15
-  Scenario: AutoInstrumentSwiftUIScenario_iOS-15-plus
+  Scenario: AutoInstrumentSwiftUIScenario
     Given I run "AutoInstrumentSwiftUIScenario"
     And I wait for 3 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "[ViewLoad/SwiftUI]/My text view"
-    * a span field "name" equals "[ViewLoadPhase/loadView]/My text view"
-    * a span field "name" equals "[ViewLoadPhase/View appearing]/My text view"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * every span field "kind" equals 1
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
-    * a span string attribute "bugsnag.span.category" equals "view_load"
-    * a span string attribute "bugsnag.span.category" equals "view_load_phase"
-    * every span string attribute "bugsnag.view.name" equals "My text view"
-    * a span bool attribute "bugsnag.span.first_class" is true
-    * a span string attribute "bugsnag.view.type" equals "SwiftUI"
-    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.PerformanceFixture"
-    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
-    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
-
-  @skip_ios_15_and_above
-  Scenario: AutoInstrumentSwiftUIScenario-iOS-below-15
-    Given I run "AutoInstrumentSwiftUIScenario"
-    And I wait for 2 spans
-    Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "[ViewLoad/SwiftUI]/My text view"
-    * a span field "name" equals "[ViewLoadPhase/loadView]/My text view"
+    * a span field "name" equals "[ViewLoad/SwiftUI]/My VStack view (top-level view)"
+    * a span field "name" equals "[ViewLoad/SwiftUI]/My VStack view"
+    * a span field "name" equals "[ViewLoad/SwiftUI]/My Image view"
     # ios < 15 won't have the "view appearing" span
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
-    * a span string attribute "bugsnag.span.category" equals "view_load"
-    * a span string attribute "bugsnag.span.category" equals "view_load_phase"
-    * every span string attribute "bugsnag.view.name" equals "My text view"
+    * every span string attribute "bugsnag.span.category" equals "view_load"
+    * a span string attribute "bugsnag.view.name" equals "My VStack view"
+    * a span string attribute "bugsnag.view.name" equals "My Image view"
     * a span bool attribute "bugsnag.span.first_class" is true
     * a span string attribute "bugsnag.view.type" equals "SwiftUI"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.PerformanceFixture"

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -253,16 +253,17 @@ Feature: Automatic instrumentation spans
     And I wait for 3 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "[ViewLoad/SwiftUI]/My VStack view (top-level view)"
     * a span field "name" equals "[ViewLoad/SwiftUI]/My VStack view"
-    * a span field "name" equals "[ViewLoad/SwiftUI]/My Image view"
+    * a span field "name" equals "[ViewLoadPhase/body]/My VStack view"
+    * a span field "name" equals "[ViewLoadPhase/body]/My Image view"
     # ios < 15 won't have the "view appearing" span
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span string attribute "bugsnag.span.category" equals "view_load"
+    * a span string attribute "bugsnag.span.category" equals "view_load"
+    * a span string attribute "bugsnag.span.category" equals "view_load_phase"
     * a span string attribute "bugsnag.view.name" equals "My VStack view"
     * a span string attribute "bugsnag.view.name" equals "My Image view"
     * a span bool attribute "bugsnag.span.first_class" is true

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		09637A412B060E7C00F4F776 /* CommandReaderThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A402B060E7C00F4F776 /* CommandReaderThread.swift */; };
 		09637A432B0617FE00F4F776 /* MazeRunnerCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A422B0617FE00F4F776 /* MazeRunnerCommand.swift */; };
 		09637A452B0B883B00F4F776 /* FixtureConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A442B0B883B00F4F776 /* FixtureConfig.swift */; };
+		0983A1792B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0983A1782B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift */; };
+		0983A17B2B14BB2000DDF4FF /* BugsnagPerformanceSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 0983A17A2B14BB2000DDF4FF /* BugsnagPerformanceSwiftUI */; };
 		098808E02B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */; };
 		09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */; };
 		9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */; };
@@ -80,6 +82,7 @@
 		09637A402B060E7C00F4F776 /* CommandReaderThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandReaderThread.swift; sourceTree = "<group>"; };
 		09637A422B0617FE00F4F776 /* MazeRunnerCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MazeRunnerCommand.swift; sourceTree = "<group>"; };
 		09637A442B0B883B00F4F776 /* FixtureConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixtureConfig.swift; sourceTree = "<group>"; };
+		0983A1782B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentSwiftUIScenario.swift; sourceTree = "<group>"; };
 		098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualViewLoadPhaseScenario.swift; sourceTree = "<group>"; };
 		09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkCallbackScenario.swift; sourceTree = "<group>"; };
 		9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentTabViewLoadScenario.swift; sourceTree = "<group>"; };
@@ -115,6 +118,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				01A414C82912CA18003152A4 /* Bugsnag in Frameworks */,
+				0983A17B2B14BB2000DDF4FF /* BugsnagPerformanceSwiftUI in Frameworks */,
 				01FE4DC028E1AEDF00D1F239 /* BugsnagPerformance in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -189,6 +193,7 @@
 				CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
 				CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */,
+				0983A1782B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift */,
 				9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */,
 				0185C47128F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift */,
 				CB572EAC29BB829800FD7A2A /* BackgroundForegroundScenario.swift */,
@@ -204,6 +209,7 @@
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
 				CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */,
+				098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */,
 				01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */,
 				CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */,
 				CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */,
@@ -212,7 +218,6 @@
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
-				098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -246,6 +251,7 @@
 			packageProductDependencies = (
 				01FE4DBF28E1AEDF00D1F239 /* BugsnagPerformance */,
 				01A414C72912CA18003152A4 /* Bugsnag */,
+				0983A17A2B14BB2000DDF4FF /* BugsnagPerformanceSwiftUI */,
 			);
 			productName = Fixture;
 			productReference = 01FE4DA528E1AEBD00D1F239 /* Fixture.app */;
@@ -321,6 +327,7 @@
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
 				01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */,
+				0983A1792B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift in Sources */,
 				CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */,
 				CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */,
 				09637A3F2B06082200F4F776 /* Logging.m in Sources */,
@@ -502,7 +509,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -534,7 +541,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -592,6 +599,10 @@
 		01FE4DBF28E1AEDF00D1F239 /* BugsnagPerformance */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BugsnagPerformance;
+		};
+		0983A17A2B14BB2000DDF4FF /* BugsnagPerformanceSwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BugsnagPerformanceSwiftUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/features/fixtures/ios/Scenarios/AutoInstrumentSwiftUIScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentSwiftUIScenario.swift
@@ -1,0 +1,34 @@
+//
+//  AutoInstrumentSwiftUIScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 27.11.23.
+//
+
+import SwiftUI
+import BugsnagPerformance
+import BugsnagPerformanceSwiftUI
+
+@objcMembers
+class AutoInstrumentSwiftUIScenario: Scenario {
+    override func run() {
+        if #available(iOS 13.0.0, *) {
+            UIApplication.shared.windows[0].rootViewController!.present(
+                UIHostingController(rootView: AutoInstrumentSwiftUIScenario_View()), animated: true)
+        } else {
+            fatalError("SwiftUI is not available on this version of iOS")
+        }
+    }
+}
+
+@available(iOS 13.0.0, *)
+struct AutoInstrumentSwiftUIScenario_View: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .bugsnagTraced("My text view")
+        }
+        .padding()
+    }
+}

--- a/features/fixtures/ios/Scenarios/AutoInstrumentSwiftUIScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentSwiftUIScenario.swift
@@ -27,8 +27,9 @@ struct AutoInstrumentSwiftUIScenario_View: View {
         VStack {
             Image(systemName: "globe")
                 .imageScale(.large)
-                .bugsnagTraced("My text view")
+                .bugsnagTraced("My Image view")
         }
+        .bugsnagTraced("My VStack view")
         .padding()
     }
 }

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+def skip_above(os, version)
+  skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == os and Maze.config.os_version > version
+end
+
+def skip_below(os, version)
+  skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == os and Maze.config.os_version < version
+end
+
+def skip_between(os, version_lo, version_hi)
+  skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == os and Maze.config.os_version >= version_lo and Maze.config.os_version <= version_hi
+end
+
+Before('@skip_below_ios_15') do |_scenario|
+  skip_below('ios', 15.00)
+end
+
+Before('@skip_ios_15_and_above') do |_scenario|
+  skip_above('ios', 14.99)
+end
+
 When('I run {string}') do |scenario_name|
   Maze::Server.commands.add({ action: "run_scenario", args: [scenario_name] })
   # Ensure fixture has read the command


### PR DESCRIPTION
## Goal

This PR adds support for instrumenting SwiftUI views.

## Design

Views can be instrumented by wrapping them in a `BugsnagTracedView`, or by calling the view extension function `bugsnagTraced`:

```swift

import SwiftUI
import BugsnagPerformanceSwiftUI

struct ContentView: View {
    var body: some View {
        VStack {
            Image(systemName: "globe")
                .imageScale(.large)
                .foregroundStyle(.tint)
            Text("Hello, world!")
        }
        .padding()
        .bugsnagTraced("My traced view")
    }
}
```

## Testing

Added e2e tests
