### PR TITLE
build: added absolute framework size to dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -3,8 +3,24 @@
 # vim: set ft=ruby
 
 def framework_size
+  def _(number) # Formats a number with thousands separated by ','
+    number.to_s.reverse.scan(/.{1,3}/).join(',').reverse
+  end
+
   old_binary = 'DerivedData.old/Build/Products/Release-iphoneos/BugsnagPerformance.framework/BugsnagPerformance'
   new_binary = 'DerivedData.new/Build/Products/Release-iphoneos/BugsnagPerformance.framework/BugsnagPerformance'
+
+  size_after = File.size(new_binary)
+  size_before = File.size(old_binary)
+
+  case true
+  when size_after == size_before
+    markdown("**`BugsnagPerformance.framework`** binary size did not change - #{_(size_after)} bytes")
+  when size_after < size_before
+    markdown("**`BugsnagPerformance.framework`** binary size decreased by #{_(size_before - size_after)} bytes from #{_(size_before)} to #{_(size_after)} :tada:")
+  when size_after > size_before
+    markdown("**`BugsnagPerformance.framework`** binary size increased by #{_(size_after - size_before)} bytes from #{_(size_before)} to #{_(size_after)}")
+  end
 
   markdown <<~MARKDOWN
     ```


### PR DESCRIPTION
## Goal

Add the same Danger reporting as bugsnag-cocoa to show absolute size of framework and summary of the net change.
