### PR TITLE
[PLAT-11315] Discard unfinished spans when the app goes into the background

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -58,6 +58,9 @@
 		094FA7522B10EEB600112ED4 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		09509B752ADFE9A900A358EC /* TracerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09509B742ADFE9A900A358EC /* TracerTests.mm */; };
 		096CBC172B1752F700534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096CBC152B1752F100534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift */; };
+		0986B7C02B287C9D00BD2CA3 /* WeakSpansList.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0986B7BF2B287C9D00BD2CA3 /* WeakSpansList.mm */; };
+		09B473072B23087D0024CF11 /* WeakSpansList.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B473052B23087D0024CF11 /* WeakSpansList.h */; };
+		09B4730A2B2313570024CF11 /* WeakSpansListTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09B473092B2313570024CF11 /* WeakSpansListTests.mm */; };
 		8A80DA8B2966CE940035BDA9 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		8A80DA912966CEB30035BDA9 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A80DA80296588840035BDA9 /* ConfigurationTests.swift */; };
 		962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F80F129DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift */; };
@@ -272,6 +275,9 @@
 		094FA7422B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugsnagPerformanceSwiftUITests.swift; sourceTree = "<group>"; };
 		09509B742ADFE9A900A358EC /* TracerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TracerTests.mm; sourceTree = "<group>"; };
 		096CBC152B1752F100534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BugsnagPerformanceSwiftUIInstrumentation.swift; sourceTree = "<group>"; };
+		0986B7BF2B287C9D00BD2CA3 /* WeakSpansList.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WeakSpansList.mm; sourceTree = "<group>"; };
+		09B473052B23087D0024CF11 /* WeakSpansList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WeakSpansList.h; sourceTree = "<group>"; };
+		09B473092B2313570024CF11 /* WeakSpansListTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WeakSpansListTests.mm; sourceTree = "<group>"; };
 		72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformance.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A80DA80296588840035BDA9 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		8A80DA872966CE940035BDA9 /* BugsnagPerformance-SwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagPerformance-SwiftTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -540,6 +546,8 @@
 				CBF621052919418F004BEE0B /* Uploader.h */,
 				01EAF97F291AAF19007AC627 /* Utils.h */,
 				015836C3291264E0002F54C8 /* Version.h */,
+				09B473052B23087D0024CF11 /* WeakSpansList.h */,
+				0986B7BF2B287C9D00BD2CA3 /* WeakSpansList.mm */,
 				CBE8EA18294B5AB800702950 /* Worker.h */,
 				CBE8EA19294B5AB800702950 /* Worker.mm */,
 			);
@@ -605,6 +613,7 @@
 				CB2B8A9A2A0924A50054FBBE /* SpanTests.mm */,
 				CB747D20299E5458003CA1B4 /* TimeTests.mm */,
 				09509B742ADFE9A900A358EC /* TracerTests.mm */,
+				09B473092B2313570024CF11 /* WeakSpansListTests.mm */,
 				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
 			);
 			path = BugsnagPerformanceTests;
@@ -735,6 +744,7 @@
 				CBE0873329FA984C007455F2 /* BugsnagPerformanceViewType+Private.h in Headers */,
 				CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */,
 				CBEC51C0296DB312009C0CE3 /* JSON.h in Headers */,
+				09B473072B23087D0024CF11 /* WeakSpansList.h in Headers */,
 				0921F02B2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h in Headers */,
 				0122C24A29019770002D243C /* AppStartupInstrumentation.h in Headers */,
 				CB04969B2915194E0097E526 /* OtlpUploader.h in Headers */,
@@ -1013,6 +1023,7 @@
 				CB0AD75B295F27DD002A3FB6 /* WorkerTests.mm in Sources */,
 				CBEC51C3296EC0AC009C0CE3 /* JSONTests.mm in Sources */,
 				01A414C52912B93F003152A4 /* ResourceAttributesTests.mm in Sources */,
+				09B4730A2B2313570024CF11 /* WeakSpansListTests.mm in Sources */,
 				CB2B8A9B2A0924A50054FBBE /* SpanTests.mm in Sources */,
 				CBEC51CE296EEF52009C0CE3 /* PersistenceTests.mm in Sources */,
 				96D55C882A1EE26A006D1F29 /* SpanStackingHandlerTests.mm in Sources */,
@@ -1074,6 +1085,7 @@
 				CBEC51C1296DB312009C0CE3 /* JSON.mm in Sources */,
 				CBEBE59B29F671A800BF0B4F /* Instrumentation.mm in Sources */,
 				0122C24029019770002D243C /* SpanData.mm in Sources */,
+				0986B7C02B287C9D00BD2CA3 /* WeakSpansList.mm in Sources */,
 				96D4160C29F276E400AEE435 /* SpanAttributesProvider.mm in Sources */,
 				CB68FABA2A3C27B9005B2CDB /* PersistentDeviceID.mm in Sources */,
 				CBF7C5E2297A8E9100D47719 /* Gzip.m in Sources */,

--- a/Sources/BugsnagPerformance/Private/AppStateTracker.h
+++ b/Sources/BugsnagPerformance/Private/AppStateTracker.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,readonly) BOOL isInForeground;
 
 @property(nonatomic,readwrite,strong) void (^onTransitionToForeground)(void);
+@property(nonatomic,readwrite,strong) void (^onTransitionToBackground)(void);
 
 @end
 

--- a/Sources/BugsnagPerformance/Private/AppStateTracker.m
+++ b/Sources/BugsnagPerformance/Private/AppStateTracker.m
@@ -182,6 +182,10 @@ static bool GetIsForeground(void) {
 - (void) handleAppBackgroundEvent {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     _isInForeground = NO;
+    void (^callback)(void) = self.onTransitionToBackground;
+    if (callback != nil) {
+        callback();
+    }
 }
 
 @end

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -101,6 +101,7 @@ private:
     bool sendCurrentBatchTask() noexcept;
     bool sendRetriesTask() noexcept;
     bool sendPValueRequestTask() noexcept;
+    bool sweepTracerTask() noexcept;
 
     // Event reactions
     void onBatchFull() noexcept;
@@ -109,6 +110,7 @@ private:
     void onFilesystemError() noexcept;
     void onWorkInterval() noexcept;
     void onAppEnteredForeground() noexcept;
+    void onAppEnteredBackground() noexcept;
 
     // Utility
     void wakeWorker() noexcept;

--- a/Sources/BugsnagPerformance/Private/WeakSpansList.h
+++ b/Sources/BugsnagPerformance/Private/WeakSpansList.h
@@ -1,0 +1,74 @@
+//
+//  WeakSpansList.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 08.12.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <mutex>
+
+@interface BSGWeakSpanPointer: NSObject
+
+// We use a weak wrapper because NSPointerArray.weakObjectsPointerArray's compact method is broken.
+@property(nonatomic,readonly,weak) BugsnagPerformanceSpan *span;
+
+- (instancetype) initWithSpan:(BugsnagPerformanceSpan *)span;
+
++ (instancetype) pointerWithSpan:(BugsnagPerformanceSpan *)span;
+
+@end
+
+namespace bugsnag {
+
+class WeakSpansList {
+public:
+    WeakSpansList()
+    : spans_([NSMutableArray new])
+    {}
+
+    void add(BugsnagPerformanceSpan *span) noexcept {
+        auto ptr = [BSGWeakSpanPointer pointerWithSpan:span];
+        std::lock_guard<std::mutex> guard(mutex_);
+        [spans_ addObject:ptr];
+    }
+
+    void compact() noexcept {
+        std::lock_guard<std::mutex> guard(mutex_);
+        bool canCompact = false;
+        for (BSGWeakSpanPointer *ptr in spans_) {
+            if (!ptr.span.isValid) {
+                canCompact = true;
+                break;
+            }
+        }
+        if (canCompact) {
+            auto newSpans = [NSMutableArray arrayWithCapacity:spans_.count];
+            for (BSGWeakSpanPointer *ptr in spans_) {
+                if (ptr.span.isValid) {
+                    [newSpans addObject:ptr];
+                }
+            }
+            spans_ = newSpans;
+        }
+    }
+
+    void abortAll() noexcept {
+        std::lock_guard<std::mutex> guard(mutex_);
+        for (BSGWeakSpanPointer *ptr in spans_) {
+            [ptr.span abort];
+        }
+        [spans_ removeAllObjects];
+    }
+
+    NSUInteger count() noexcept {
+        return spans_.count;
+    }
+
+private:
+    std::mutex mutex_;
+    NSMutableArray *spans_;
+};
+
+}

--- a/Sources/BugsnagPerformance/Private/WeakSpansList.mm
+++ b/Sources/BugsnagPerformance/Private/WeakSpansList.mm
@@ -1,0 +1,24 @@
+//
+//  WeakSpansList.c
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 12.12.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "WeakSpansList.h"
+
+@implementation BSGWeakSpanPointer
+
+- (instancetype) initWithSpan:(BugsnagPerformanceSpan *)span {
+    if ((self = [super init])) {
+        _span = span;
+    }
+    return self;
+}
+
++ (instancetype) pointerWithSpan:(BugsnagPerformanceSpan *)span {
+    return [[self alloc] initWithSpan:span];
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
+++ b/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
@@ -1,0 +1,70 @@
+//
+//  WeakSpansListTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 08.12.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "WeakSpansList.h"
+#import "BugsnagPerformanceSpan+Private.h"
+#import "SpanOptions.h"
+
+using namespace bugsnag;
+
+@interface WeakSpansListTests : XCTestCase
+
+@end
+
+static BugsnagPerformanceSpan *createSpan() {
+    return [[BugsnagPerformanceSpan alloc]
+            initWithSpan:std::make_unique<Span>(@"test",
+                                                IdGenerator::generateTraceId(),
+                                                IdGenerator::generateSpanId(),
+                                                IdGenerator::generateSpanId(),
+                                                SpanOptions().startTime,
+                                                BSGFirstClassNo,
+                                                ^void(std::shared_ptr<SpanData>) {
+                                                })];
+}
+
+@implementation WeakSpansListTests
+
+- (void)testAllReleased {
+    WeakSpansList list;
+    @autoreleasepool {
+        list.add(createSpan());
+        list.add(createSpan());
+        list.add(createSpan());
+    }
+    XCTAssertEqual(3U, list.count());
+    list.compact();
+    XCTAssertEqual(0U, list.count());
+}
+
+- (void)testNoneReleased {
+    WeakSpansList list;
+    list.add(createSpan());
+    list.add(createSpan());
+    list.add(createSpan());
+    XCTAssertEqual(3U, list.count());
+    list.compact();
+    XCTAssertEqual(3U, list.count());
+}
+
+- (void)testSomeReleased {
+    WeakSpansList list;
+    list.add(createSpan());
+    @autoreleasepool {
+        list.add(createSpan());
+        list.add(createSpan());
+        list.add(createSpan());
+    }
+    list.add(createSpan());
+    XCTAssertEqual(5U, list.count());
+    list.compact();
+    XCTAssertEqual(2U, list.count());
+}
+
+@end


### PR DESCRIPTION
## Goal

Spans that are still open when the app is backgrounded will end up with ridiculously long durations. Throw out unended spans when backgrounding the app instead.

## Testing

Since we can't automate app backgrounding in a reliable way, I tested this manually.

The new weak span list component also has unit tests.
