### PR TITLE
Clear firstViewLoadSpan on main run loop

### DIFF
--- a/Sources/BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUIInstrumentation.swift
+++ b/Sources/BugsnagPerformanceSwiftUI/BugsnagPerformanceSwiftUIInstrumentation.swift
@@ -73,6 +73,7 @@ public struct BugsnagTracedView<Content: View>: View {
             firstViewLoadSpan = thisViewLoadSpan
             bsgViewContext.firstViewLoadSpan = thisViewLoadSpan
             DispatchQueue.main.async {
+                bsgViewContext.firstViewLoadSpan = nil
                 thisViewLoadSpan.end()
             }
         }


### PR DESCRIPTION
## Case

The SwiftUI instrumentation code wasn't clearing `bsgViewContext.firstViewLoadSpan`, which meant that ALL subsequent spans would become children of the very first SwiftUI view load span in a particular scene.

Clear `bsgViewContext.firstViewLoadSpan` on the next main dispatch queue run.

## Testing

Tested manually
