### PR TITLE
[PLAT-11269] Delay the initial P value scenario

### DIFF
--- a/features/default/initial-p-value.feature
+++ b/features/default/initial-p-value.feature
@@ -7,6 +7,7 @@ Feature: Initial P values
     * the sampling request "Bugsnag-Span-Sampling" header equals "1:0"
     * the sampling request "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the sampling request payload field "resourceSpans" is an array with 0 elements
+    Then I set the sampling probability for the next traces to "0"
     Then I invoke "step2"
     And I should receive no traces
 

--- a/features/fixtures/ios/Scenarios/InitialPScenario.swift
+++ b/features/fixtures/ios/Scenarios/InitialPScenario.swift
@@ -9,14 +9,15 @@ import BugsnagPerformance
 
 @objcMembers
 class InitialPScenario: Scenario {
+    let initialDelayBeforeSpans = 5.0
 
     override func configure() {
         super.configure()
-        config.internal.initialRecurringWorkDelay = 0
+        config.internal.initialRecurringWorkDelay = initialDelayBeforeSpans
     }
     override func run() {
         // Wait to receive an initial P value response.
-        waitForCurrentBatch()
+        Thread.sleep(forTimeInterval: initialDelayBeforeSpans + 0.1)
         BugsnagPerformance.startSpan(name: "First").end()
     }
 


### PR DESCRIPTION
## Goal

Guessing that the initial P value scenario might sometimes start sending spans before it has received the P value response from the server, delay creating any spans for awhile to give time for the response to be received, even if it is a little slow.
