### PR TITLE
Ignore internal network requests in e2e tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,8 @@ steps:
         command: pod lib lint BugsnagPerformance.podspec.json
 
       - label: "Example"
+        env:
+          XCODE_VERSION: 15.0.1
         command: ./Example/build.sh
 
       - label: "Fixture"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', '~>8.4.0'
+gem 'bugsnag-maze-runner', '~>8.0'
 
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'integration/v8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,9 @@ GEM
     appium_lib_core (5.4.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 4.2, < 4.6)
-    bugsnag (6.26.0)
+    bugsnag (6.26.1)
       concurrent-ruby (~> 1.0)
-    bugsnag-maze-runner (8.4.1)
+    bugsnag-maze-runner (8.15.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -78,13 +78,13 @@ GEM
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
       uri_template (~> 0.7)
-    mime-types (3.5.1)
+    mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.1205)
     multi_test (0.1.2)
-    nokogiri (1.15.5-arm64-darwin)
+    nokogiri (1.16.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.5-x86_64-darwin)
+    nokogiri (1.16.0-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -92,7 +92,7 @@ GEM
     racc (1.7.3)
     rack (2.2.8)
     rake (12.3.3)
-    regexp_parser (2.8.3)
+    regexp_parser (2.9.0)
     rexml (3.2.6)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)
@@ -120,10 +120,11 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES
-  bugsnag-maze-runner (~> 8.4.0)
+  bugsnag-maze-runner (~> 8.0)
 
 BUNDLED WITH
-   2.3.18
+   2.4.8

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -462,19 +462,7 @@ Feature: Automatic instrumentation spans
 
   Scenario: Automatically start a network span that is a file:// scheme
     Given I run "AutoInstrumentFileURLRequestScenario"
-    And I wait for 2 seconds
-    And I wait for 1 span
-    # We should only see the request to http://bs-local.com:9339/command, not the file:// request
-    Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "parentSpanId" exists
-    * a span field "parentSpanId" is greater than 0
-    * a span field "parentSpanId" does not exist
-    * a span field "name" equals "[HTTP/GET]"
-    * a span string attribute "http.url" matches the regex "http://.*:9339/command"
-    * a span string attribute "http.method" equals "GET"
-    * a span integer attribute "http.status_code" is greater than 0
-    * a span integer attribute "http.response_content_length" is greater than 0
+    Then I should receive no traces
 
   Scenario: Don't send an auto network span that failed to send
     Given I run "AutoInstrumentNetworkBadAddressScenario"

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkBadAddressScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkBadAddressScenario.swift
@@ -14,6 +14,7 @@ class AutoInstrumentNetworkBadAddressScenario: Scenario {
         super.configure()
         config.autoInstrumentNetworkRequests = true
         config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+            super.ignoreInternalRequests(info: info)
             let testUrl = info.url
             if (testUrl == nil) {
                 return info

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkCallbackScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkCallbackScenario.swift
@@ -14,6 +14,7 @@ class AutoInstrumentNetworkCallbackScenario: Scenario {
         super.configure()
         config.autoInstrumentNetworkRequests = true
         config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+            super.ignoreInternalRequests(info: info)
 
             let testUrl = info.url
             if (testUrl == nil) {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkMultiple.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkMultiple.swift
@@ -14,6 +14,7 @@ class AutoInstrumentNetworkMultiple: Scenario {
         super.configure()
         config.autoInstrumentNetworkRequests = true
         config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+            super.ignoreInternalRequests(info: info)
             let testUrl = info.url
             if (testUrl == nil) {
                 return info

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkNoParentScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkNoParentScenario.swift
@@ -14,6 +14,7 @@ class AutoInstrumentNetworkNoParentScenario: Scenario {
         super.configure()
         config.autoInstrumentNetworkRequests = true
         config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+            super.ignoreInternalRequests(info: info)
             let testUrl = info.url
             if (testUrl == nil) {
                 return info

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkWithParentScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkWithParentScenario.swift
@@ -14,6 +14,7 @@ class AutoInstrumentNetworkWithParentScenario: Scenario {
         super.configure()
         config.autoInstrumentNetworkRequests = true
         config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+            super.ignoreInternalRequests(info: info)
             let testUrl = info.url
             if (testUrl == nil) {
                 return info

--- a/features/fixtures/ios/Scenarios/ManualNetworkCallbackScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualNetworkCallbackScenario.swift
@@ -21,6 +21,7 @@ class ManualNetworkCallbackScenario: Scenario {
         super.configure()
         config.autoInstrumentNetworkRequests = false
         config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+            super.ignoreInternalRequests(info: info)
 
             let testUrl = info.url
             if (testUrl == nil) {

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -36,6 +36,21 @@ class Scenario: NSObject {
         config.autoInstrumentNetworkRequests = false
         config.autoInstrumentViewControllers = false
         config.endpoint = fixtureConfig.tracesURL
+        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+            self.ignoreInternalRequests(info: info)
+
+            return info
+        }
+    }
+    
+    func ignoreInternalRequests(info: BugsnagPerformanceNetworkRequestInfo) {
+        if (info.url == nil) {
+            return
+        }
+        let urlString = info.url!.absoluteString
+        if (urlString.hasSuffix("/metrics") || urlString.hasSuffix("/command")) {
+            info.url = nil
+        }
     }
     
     func clearPersistentData() {


### PR DESCRIPTION
## Goal

Ignore internal network requests in e2e tests.

## Design

The `/command` and `/metrics` Maze Runner endpoints should be completely ignored by the e2e tests.

## Testing

Covered by CI.