### PR TITLE
Fixes for pre-loaded views instrumentation

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -32,6 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)endWithAbsoluteTime:(CFAbsoluteTime)endTime;
 
 - (SpanId)parentId;
+- (NSString *)name;
+- (void)updateName:(NSString *)name;
+- (NSDate *_Nullable)startTime;
+- (NSDate *_Nullable)endTime;
+- (void)updateStartTime:(NSDate *)startTime;
 
 @end
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -13,6 +13,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface ViewLoadInstrumentationState : NSObject
+@property (nonatomic) BOOL loadViewPhaseSpanCreated;
+@property (nonatomic) BOOL viewDidLoadPhaseSpanCreated;
+@property (nonatomic) BOOL viewWillAppearPhaseSpanCreated;
+@property (nonatomic) BOOL viewDidAppearPhaseSpanCreated;
+@property (nonatomic) BOOL viewWillLayoutSubviewsPhaseSpanCreated;
+@property (nonatomic) BOOL viewDidLayoutSubviewsPhaseSpanCreated;
+@property (nonatomic) BOOL isMarkedAsPreloaded;
+@property (nonatomic, nullable, strong) NSDate *viewDidLoadEndTime;
+@end
+
 namespace bugsnag {
 class ViewLoadInstrumentation: public PhasedStartup {
 public:
@@ -55,6 +66,7 @@ private:
     void endEarlySpanPhase() noexcept;
     bool canCreateSpans(UIViewController *viewController) noexcept;
     bool isClassObserved(Class cls) noexcept;
+    void adjustSpanIfPreloaded(BugsnagPerformanceSpan *span, ViewLoadInstrumentationState *instrumentationState, NSDate *viewWillAppearStartTime, UIViewController *viewController) noexcept;
 
     bool isEnabled_{true};
     bool swizzleViewLoadPreMain_{true};

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -27,6 +27,7 @@ static constexpr int kAssociatedViewLoadSpan = 0;
 static constexpr int kAssociatedViewAppearingSpan = 0;
 static constexpr int kAssociatedSubviewLayoutSpan = 0;
 static constexpr int kAssociatedViewLoadInstrumentationState = 0;
+static constexpr CGFloat kViewWillAppearPreloadedDelayThreshold = 1.0;
 
 @implementation ViewLoadInstrumentationState
 @end
@@ -203,7 +204,7 @@ void ViewLoadInstrumentation::adjustSpanIfPreloaded(BugsnagPerformanceSpan *span
     if (instrumentationState.isMarkedAsPreloaded || viewDidLoadEndTime == nil) {
         return;
     }
-    auto isPreloaded = [viewWillAppearStartTime timeIntervalSinceDate: viewDidLoadEndTime] > 1.0;
+    auto isPreloaded = [viewWillAppearStartTime timeIntervalSinceDate: viewDidLoadEndTime] > kViewWillAppearPreloadedDelayThreshold;
     if (isPreloaded) {
         auto viewType = BugsnagPerformanceViewTypeUIKit;
         auto className = NSStringFromClass([viewController class]);

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -102,6 +102,14 @@ public:
     TraceId traceId() {return data_->traceId;}
     SpanId spanId() {return data_->spanId;}
     SpanId parentId() {return data_->parentId;}
+    NSString *name() {return data_->name;}
+    CFAbsoluteTime startTime() {return data_->startTime;}
+    CFAbsoluteTime endTime() {return data_->endTime;}
+    void updateName(NSString *name) {data_->name = name;}
+    void updateStartTime(CFAbsoluteTime time) noexcept {
+        data_->startTime = time;
+        startClock_ = currentMonotonicClockNsecIfUnset(time);
+    }
 
 private:
     std::shared_ptr<SpanData> data_;

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -18,6 +18,7 @@ public:
     NSDictionary *appStartSpanAttributes(NSString *firstViewName, bool isColdLaunch) noexcept;
     NSDictionary *appStartPhaseSpanAttributes(NSString *phase) noexcept;
     NSDictionary *viewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
+    NSDictionary *preloadedViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
     NSDictionary *viewLoadPhaseSpanAttributes(NSString *className, NSString *phase) noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -145,6 +145,15 @@ SpanAttributesProvider::viewLoadSpanAttributes(NSString *className, BugsnagPerfo
 }
 
 NSDictionary *
+SpanAttributesProvider::preloadedViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept {
+    return @{
+        @"bugsnag.span.category": @"view_load",
+        @"bugsnag.view.name": [NSString stringWithFormat:@"%@ (pre-loaded)", className],
+        @"bugsnag.view.type": getBugsnagPerformanceViewTypeName(viewType)
+    };
+}
+
+NSDictionary *
 SpanAttributesProvider::viewLoadPhaseSpanAttributes(NSString *className, NSString *phase) noexcept {
     return @{
         @"bugsnag.span.category": @"view_load_phase",

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -58,6 +58,26 @@ using namespace bugsnag;
     return _span->parentId();
 }
 
+- (NSString *)name {
+    return _span->name();
+}
+
+- (NSDate *)startTime {
+    return [NSDate dateWithTimeIntervalSinceReferenceDate:_span->startTime()];
+}
+
+- (NSDate *)endTime {
+    return [NSDate dateWithTimeIntervalSinceReferenceDate:_span->endTime()];
+}
+
+- (void)updateStartTime:(NSDate *)startTime {
+    _span->updateStartTime(dateToAbsoluteTime(startTime));
+}
+
+- (void)updateName:(NSString *)name {
+    _span->updateName(name);
+}
+
 - (BOOL)isValid {
     return !_span->isEnded();
 }


### PR DESCRIPTION
## Goal

Adjust view load spans for pre-loaded views so they reflect the actual time it took to load the view.

## Design

If the view is detected as pre-loaded on viewWillAppear, the span start time is adjusted and the view name is appended with "(pre-loaded)" suffix

## Changeset

View load span adjustments on viewWillAppear
Removed the viewWillDisappear fallback which was also causing very long spans that weren't necessarily even presented to the User
