### PR TITLE
[PLAT-11456] Make sure all paths of weak span list are protected with a mutex

### DIFF
--- a/Sources/BugsnagPerformance/Private/WeakSpansList.h
+++ b/Sources/BugsnagPerformance/Private/WeakSpansList.h
@@ -63,6 +63,7 @@ public:
     }
 
     NSUInteger count() noexcept {
+        std::lock_guard<std::mutex> guard(mutex_);
         return spans_.count;
     }
 


### PR DESCRIPTION
The `count` method of weak span list wasn't protected by a mutex, causing TSAN issues.
