### PR TITLE
Fixed the issue causing PrivacyInfo collisions when using Cocoapods

### DIFF
--- a/BugsnagPerformance.podspec.json
+++ b/BugsnagPerformance.podspec.json
@@ -19,9 +19,9 @@
   },
   "requires_arc": true,
   "source_files": "Sources/BugsnagPerformance/**/*",
-  "resources": [
-    "Sources/BugsnagPerformance/resources/PrivacyInfo.xcprivacy"
-  ],
+  "resource_bundles": {
+      "BugsnagPerformance": ["Sources/BugsnagPerformance/resources/PrivacyInfo.xcprivacy"]
+  },
   "public_header_files": "Sources/BugsnagPerformance/include/BugsnagPerformance/*.h",
   "prefix_header_file": false,
   "frameworks": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fixed the issue causing PrivacyInfo collisions when using Cocoapods
+  [246](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/246)
+
 ## 1.4.0 (2024-01-31)
 
 ### Enhancements


### PR DESCRIPTION
## Goal

Installing Bugsnag using Cocoapods was causing file collisions if the app had its own PrivacyInfo file

## Design

Avoid the collisions by using resource_bundles instead of resources

## Changeset

Replaces resources with resource_bundles in the podspec

## Testing

Manual testing on an example app