### PR TITLE
Use ObjC strings instead of C strings to avoid lifetime race condition

### DIFF
--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -55,15 +55,15 @@ void ViewLoadInstrumentation::earlySetup() noexcept {
         classToIsObserved_[[UIViewController class]] = true;
         __block auto classToIsObserved = &classToIsObserved_;
         __block bool *isEnabled = &isEnabled_;
-        __block auto appPath = NSBundle.mainBundle.bundlePath.UTF8String;
+        __block auto appPath = NSBundle.mainBundle.bundlePath;
         auto initInstrumentation = ^(id self) {
             auto viewControllerClass = [self class];
-            auto viewControllerBundlePath = [NSBundle bundleForClass: viewControllerClass].bundlePath.UTF8String;
-            if (strstr(viewControllerBundlePath, appPath)
+            auto viewControllerBundlePath = [NSBundle bundleForClass: viewControllerClass].bundlePath;
+            if ([viewControllerBundlePath containsString:appPath]
 #if TARGET_OS_SIMULATOR
                 // and those loaded from BUILT_PRODUCTS_DIR, because Xcode
                 // doesn't embed them when building for the Simulator.
-                || strstr(viewControllerBundlePath, "/DerivedData/")
+                || [viewControllerBundlePath containsString:@"/DerivedData/"]
 #endif
                 ) {
                 if (*isEnabled && !isClassObserved(viewControllerClass)) {


### PR DESCRIPTION
## Goal

This section of code was incorrectly holding a pointer to the result of `NSString.UTF8String` beyond the original string's lifetime, resulting in ASAN errors.

## Design

Just use the Objective-C String class directly for the string comparisons.
