### PR TITLE
Karl fix 10 second delay

### DIFF
--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -605,7 +605,7 @@ Feature: Automatic instrumentation spans
     Given I run "ComplexViewScenario"
     And I wait for 27 spans
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Span-Sampling" header equals "1:21"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:27"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoadPhase/loadView]/Fixture.ViewController"
     * a span field "name" equals "[ViewLoadPhase/viewDidLoad]/Fixture.ViewController"

--- a/features/fixtures/ios/Scenarios/AutoInstrumentGenericViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentGenericViewLoadScenario.swift
@@ -21,6 +21,10 @@ class AutoInstrumentGenericViewLoadScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentViewControllers = true
+        // This test can generate a variable number of spans depending on the OS version,
+        // so use a timed send instead.
+        config.internal.autoTriggerExportOnBatchSize = 100
+        config.internal.performWorkInterval = 1
     }
 
     override func run() {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNavigationViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNavigationViewLoadScenario.swift
@@ -15,6 +15,10 @@ class AutoInstrumentNavigationViewLoadScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentViewControllers = true
+        // This test can generate a variable number of spans depending on the OS version,
+        // so use a timed send instead.
+        config.internal.autoTriggerExportOnBatchSize = 100
+        config.internal.performWorkInterval = 1
     }
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentPreLoadedViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentPreLoadedViewLoadScenario.swift
@@ -15,6 +15,10 @@ class AutoInstrumentPreLoadedViewLoadScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentViewControllers = true
+        // This test can generate a variable number of spans depending on the OS version,
+        // so use a timed send instead.
+        config.internal.autoTriggerExportOnBatchSize = 100
+        config.internal.performWorkInterval = 1
     }
 
     override func run() {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentSubViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentSubViewLoadScenario.swift
@@ -13,6 +13,10 @@ class AutoInstrumentSubViewLoadScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentViewControllers = true
+        // This test can generate a variable number of spans depending on the OS version,
+        // so use a timed send instead.
+        config.internal.autoTriggerExportOnBatchSize = 100
+        config.internal.performWorkInterval = 1
     }
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentTabViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentTabViewLoadScenario.swift
@@ -15,6 +15,10 @@ class AutoInstrumentTabViewLoadScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentViewControllers = true
+        // This test can generate a variable number of spans depending on the OS version,
+        // so use a timed send instead.
+        config.internal.autoTriggerExportOnBatchSize = 100
+        config.internal.performWorkInterval = 1
     }
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentViewLoadScenario.swift
@@ -13,6 +13,10 @@ class AutoInstrumentViewLoadScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentViewControllers = true
+        // This test can generate a variable number of spans depending on the OS version,
+        // so use a timed send instead.
+        config.internal.autoTriggerExportOnBatchSize = 100
+        config.internal.performWorkInterval = 1
     }
 
     override func run() {

--- a/features/fixtures/ios/Scenarios/ComplexViewScenario.swift
+++ b/features/fixtures/ios/Scenarios/ComplexViewScenario.swift
@@ -13,15 +13,17 @@ class ComplexViewScenario: Scenario {
     override func configure() {
          super.configure()
          config.autoInstrumentViewControllers = true
+        // This test can generate a variable number of spans depending on the OS version,
+        // so use a timed send instead.
+        config.internal.autoTriggerExportOnBatchSize = 100
+        config.internal.performWorkInterval = 1
      }
 
      override func run() {
-         NSLog("### ComplexViewScenario.run: start")
          let viewController = ComplexViewScenario_ViewController()
          _ = viewController.view
          UIApplication.shared.windows[0].rootViewController!.present(
              viewController, animated: true)
-         NSLog("### ComplexViewScenario.run: end")
      }
  }
 

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -58,9 +58,6 @@ end
 
 def run_command(action, args)
   Maze::Server.commands.add({ action: action, args: args })
-  # Ensure fixture has read the command
-  count = 100
-  sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
 end
 
 # Note:


### PR DESCRIPTION
## Goal

Remove the effective 10 second delay between commands issued by maze runner.

## Design

Some old code was improperly imposing a 10s delay between all commands.
