### PR TITLE
[PLAT-12032] Detect app backgrounding earlier so we can cancel spans

### DIFF
--- a/Sources/BugsnagPerformance/Private/AppStateTracker.h
+++ b/Sources/BugsnagPerformance/Private/AppStateTracker.h
@@ -17,6 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,readwrite,strong) void (^onTransitionToForeground)(void);
 @property(nonatomic,readwrite,strong) void (^onTransitionToBackground)(void);
 
+@property(nonatomic,readwrite,strong) void (^onAppFinishedLaunching)(void);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/AppStateTracker.m
+++ b/Sources/BugsnagPerformance/Private/AppStateTracker.m
@@ -132,6 +132,10 @@ static bool GetIsForeground(void) {
 
 #if BSG_TARGET_APPKIT
         [notificationCenter addObserver:self
+                               selector:@selector(handleAppLaunchEvent)
+                                   name:NSApplicationDidFinishLaunchingNotification
+                                 object:nil];
+        [notificationCenter addObserver:self
                                selector:@selector(handleAppForegroundEvent)
                                    name:NSApplicationDidBecomeActiveNotification
                                  object:nil];
@@ -143,6 +147,10 @@ static bool GetIsForeground(void) {
 
 #if BSG_TARGET_UIKIT
         [notificationCenter addObserver:self
+                               selector:@selector(handleAppLaunchEvent)
+                                   name:UIApplicationDidFinishLaunchingNotification
+                                 object:nil];
+        [notificationCenter addObserver:self
                                selector:@selector(handleAppForegroundEvent)
                                    name:UIApplicationDidBecomeActiveNotification
                                  object:nil];
@@ -153,6 +161,10 @@ static bool GetIsForeground(void) {
 #endif
 
 #if BSG_TARGET_WATCHKIT
+        [notificationCenter addObserver:self
+                               selector:@selector(handleAppLaunchEvent)
+                                   name:WKApplicationDidFinishLaunchingNotification
+                                 object:nil];
         [notificationCenter addObserver:self
                                selector:@selector(handleAppForegroundEvent)
                                    name:WKApplicationDidBecomeActiveNotification
@@ -168,6 +180,13 @@ static bool GetIsForeground(void) {
 
 - (void)dealloc {
     [NSNotificationCenter.defaultCenter removeObserver:self];
+}
+
+- (void) handleAppLaunchEvent {
+    void (^callback)(void) = self.onAppFinishedLaunching;
+    if (callback != nil) {
+        callback();
+    }
 }
 
 - (void) handleAppForegroundEvent {

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -104,7 +104,6 @@ private:
     NSArray<Task> *buildRecurringTasks() noexcept;
     bool sendCurrentBatchTask() noexcept;
     bool sendRetriesTask() noexcept;
-    bool sendPValueRequestTask() noexcept;
     bool sweepTracerTask() noexcept;
 
     // Event reactions
@@ -114,6 +113,7 @@ private:
     void onFilesystemError() noexcept;
     void onWorkInterval() noexcept;
     void onAppEnteredForeground() noexcept;
+    void onAppFinishedLaunching() noexcept;
 
     // Utility
     void wakeWorker() noexcept;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -114,7 +114,6 @@ private:
     void onFilesystemError() noexcept;
     void onWorkInterval() noexcept;
     void onAppEnteredForeground() noexcept;
-    void onAppEnteredBackground() noexcept;
 
     // Utility
     void wakeWorker() noexcept;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -98,6 +98,7 @@ private:
     CFTimeInterval probabilityRequestsPauseForSeconds_{0};
     uint64_t maxPackageContentLength_{1000000};
     std::atomic<bool> isStarted_{false};
+    bool hasCheckedAppStartDuration_{false};
 
     // Tasks
     NSArray<Task> *buildInitialTasks() noexcept;
@@ -113,9 +114,11 @@ private:
     void onFilesystemError() noexcept;
     void onWorkInterval() noexcept;
     void onAppEnteredForeground() noexcept;
+    void onAppEnteredBackground() noexcept;
     void onAppFinishedLaunching() noexcept;
 
     // Utility
+    void checkAppStartDuration() noexcept;
     void wakeWorker() noexcept;
     void uploadPValueRequest() noexcept;
     void uploadPackage(std::unique_ptr<OtlpPackage> package, bool isRetry) noexcept;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
@@ -29,6 +29,15 @@ public:
 
     void didStartViewLoadSpan(NSString *name) noexcept;
     void willCallMainFunction() noexcept;
+    void abortAllSpans() noexcept;
+
+    /**
+     * Returns the time from when the earliest BugsnagPerformance code ran (__attribute__((constructor(101))))
+     * until we received UIApplicationDidFinishLaunchingNotification (or the current time, if that hasn't happened yet).
+     */
+    CFAbsoluteTime appStartDuration() noexcept;
+
+    CFAbsoluteTime timeSinceAppFirstBecameActive() noexcept;
 
 private:
     bool isEnabled_{true};

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -122,6 +122,25 @@ void AppStartupInstrumentation::disable() noexcept {
     }
 }
 
+CFAbsoluteTime AppStartupInstrumentation::appStartDuration() noexcept {
+    CFAbsoluteTime endTime = didFinishLaunchingAtTime_ > 0 ? didFinishLaunchingAtTime_ : CFAbsoluteTimeGetCurrent();
+    return endTime - didStartProcessAtTime_;
+}
+
+CFAbsoluteTime AppStartupInstrumentation::timeSinceAppFirstBecameActive() noexcept {
+    if (didBecomeActiveAtTime_ == 0) {
+        return 0;
+    }
+    return CFAbsoluteTimeGetCurrent() - didBecomeActiveAtTime_;
+}
+
+void AppStartupInstrumentation::abortAllSpans() noexcept {
+    [preMainSpan_ abortUnconditionally];
+    [postMainSpan_ abortUnconditionally];
+    [uiInitSpan_ abortUnconditionally];
+    [appStartSpan_ abortUnconditionally];
+}
+
 void
 AppStartupInstrumentation::onAppDidFinishLaunching() noexcept {
     std::lock_guard<std::mutex> guard(mutex_);

--- a/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
@@ -31,9 +31,12 @@ public:
     void earlySetup() noexcept;
     void configure(BugsnagPerformanceConfiguration *config) noexcept;
     void start() noexcept;
+    void abortAppStartupSpans() noexcept;
 
     void didStartViewLoadSpan(NSString *name) noexcept { appStartupInstrumentation_->didStartViewLoadSpan(name); }
     void willCallMainFunction() noexcept { appStartupInstrumentation_->willCallMainFunction(); }
+    CFAbsoluteTime appStartDuration() noexcept { return appStartupInstrumentation_->appStartDuration(); }
+    CFAbsoluteTime timeSinceAppFirstBecameActive() noexcept { return appStartupInstrumentation_->timeSinceAppFirstBecameActive(); }
 
 private:
     Instrumentation() = delete;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.mm
@@ -33,3 +33,7 @@ void Instrumentation::start() noexcept {
     viewLoadInstrumentation_->start();
     networkInstrumentation_->start();
 }
+
+void Instrumentation::abortAppStartupSpans() noexcept {
+    appStartupInstrumentation_->abortAllSpans();
+}

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -111,7 +111,9 @@ NSDictionary *
 OtlpTraceEncoding::encode(const std::vector<std::shared_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept {
     auto encodedSpans = [NSMutableArray arrayWithCapacity:spans.size()];
     for (const auto &span: spans) {
-        [encodedSpans addObject:encode(*span.get())];
+        if (span->isValid()) {
+            [encodedSpans addObject:encode(*span.get())];
+        }
     }
     
     // message ExportTraceServiceRequest / message TracesData

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -73,6 +73,7 @@ public:
     }
 
     void abort() noexcept {
+        data_->markInvalid();
         isEnded_ = true;
     }
 

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -72,7 +72,14 @@ public:
         return isEnded_;
     }
 
-    void abort() noexcept {
+    void abortIfOpen() noexcept {
+        if (!isEnded_) {
+            data_->markInvalid();
+            isEnded_ = true;
+        }
+    }
+
+    void abortUnconditionally() noexcept {
         data_->markInvalid();
         isEnded_ = true;
     }

--- a/Sources/BugsnagPerformance/Private/SpanData.h
+++ b/Sources/BugsnagPerformance/Private/SpanData.h
@@ -36,7 +36,10 @@ public:
     bool hasAttribute(NSString *attributeName, id value) noexcept;
 
     void updateSamplingProbability(double value) noexcept;
-    
+
+    void markInvalid() noexcept { isValid_ = false; };
+    bool isValid() noexcept { return isValid_; }
+
     TraceId traceId{0};
     SpanId spanId{0};
     SpanId parentId{0};
@@ -50,5 +53,6 @@ public:
 
 private:
     std::mutex mutex_;
+    bool isValid_{true};
 };
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -45,7 +45,7 @@ Tracer::start() noexcept {
 
 void
 Tracer::abortAllOpenSpans() noexcept {
-    potentiallyOpenSpans_->abortAll();
+    potentiallyOpenSpans_->abortAllOpen();
 }
 
 void
@@ -150,7 +150,7 @@ Tracer::startViewLoadPhaseSpan(NSString *className,
 
 void Tracer::cancelQueuedSpan(BugsnagPerformanceSpan *span) noexcept {
     if (span) {
-        [span abort];
+        [span abortIfOpen];
         batch_->removeSpan(span.traceId, span.spanId);
     }
 }

--- a/Sources/BugsnagPerformance/Private/WeakSpansList.h
+++ b/Sources/BugsnagPerformance/Private/WeakSpansList.h
@@ -54,10 +54,18 @@ public:
         }
     }
 
-    void abortAll() noexcept {
+    void abortAllUnconditionally() noexcept {
         std::lock_guard<std::mutex> guard(mutex_);
         for (BSGWeakSpanPointer *ptr in spans_) {
-            [ptr.span abort];
+            [ptr.span abortUnconditionally];
+        }
+        [spans_ removeAllObjects];
+    }
+
+    void abortAllOpen() noexcept {
+        std::lock_guard<std::mutex> guard(mutex_);
+        for (BSGWeakSpanPointer *ptr in spans_) {
+            [ptr.span abortIfOpen];
         }
         [spans_ removeAllObjects];
     }

--- a/Sources/BugsnagPerformance/Private/Worker.mm
+++ b/Sources/BugsnagPerformance/Private/Worker.mm
@@ -12,6 +12,7 @@
 @interface Worker ()
 
 @property(readwrite,atomic) NSTimeInterval initialRecurringWorkDelay;
+@property(readwrite,atomic) BOOL isStarted;
 @property(readwrite,atomic) BOOL shouldEnd;
 @property(readonly,nonatomic) NSCondition *condition;
 @property(readonly,nonatomic) NSThread *thread;
@@ -29,6 +30,8 @@
         _thread = [[NSThread alloc] initWithTarget:self selector:@selector(run) object:nil];
         _initialTasks = initialTasks;
         _recurringTasks = recurringTasks;
+        _isStarted = false;
+        _shouldEnd = false;
     }
     return self;
 }
@@ -90,14 +93,17 @@
 }
 
 - (void) start {
+    self.isStarted = true;
     self.shouldEnd = false;
     [self.thread start];
 }
 
 - (void) wake {
-    [self.condition lock];
-    [self.condition signal];
-    [self.condition unlock];
+    if (self.isStarted) {
+        [self.condition lock];
+        [self.condition signal];
+        [self.condition unlock];
+    }
 }
 
 - (void) destroy {

--- a/Sources/BugsnagPerformance/Private/Worker.mm
+++ b/Sources/BugsnagPerformance/Private/Worker.mm
@@ -56,6 +56,12 @@
 }
 
 - (void) run {
+    // Start off asleep
+    [self sleep];
+    if (self.shouldEnd) {
+        return;
+    }
+
     [self performInitialWork];
 
     if (self.initialRecurringWorkDelay > 0) {
@@ -73,9 +79,7 @@
             }
 
             // Once there's no work getting done, go to sleep.
-            [self.condition lock];
-            [self.condition wait];
-            [self.condition unlock];
+            [self sleep];
         }
     }
 }
@@ -96,6 +100,12 @@
     self.isStarted = true;
     self.shouldEnd = false;
     [self.thread start];
+}
+
+- (void) sleep {
+    [self.condition lock];
+    [self.condition wait];
+    [self.condition unlock];
 }
 
 - (void) wake {

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -146,6 +146,11 @@ static NSString *defaultEndpoint = @"https://otlp.bugsnag.com/v1/traces";
         _initialSamplingProbability = 1.0;
 
         _maxPackageContentLength = 1000000;
+
+        // This gives time for the app to finish loading so that we can receive
+        // any important notifications before the first work cycle is started.
+        // It also gives time for us to receive our initial P value from the server.
+        _initialRecurringWorkDelay = 1.0;
     }
     return self;
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -25,11 +25,12 @@ using namespace bugsnag;
     }
 }
 
-// We want direct ivar access to avoid accessors copying unique_ptrs
-#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+- (void)abortIfOpen {
+    self.span->abortIfOpen();
+}
 
-- (void)abort {
-    self.span->abort();
+- (void)abortUnconditionally {
+    self.span->abortUnconditionally();
 }
 
 - (void)end {

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
@@ -28,7 +28,9 @@ OBJC_EXPORT
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (void)abort;
+- (void)abortIfOpen;
+
+- (void)abortUnconditionally;
 
 - (void)end;
 

--- a/Tests/BugsnagPerformanceTests/WorkerTests.mm
+++ b/Tests/BugsnagPerformanceTests/WorkerTests.mm
@@ -36,19 +36,24 @@
 - (void)testNoTasks {
     auto workerTester = [WorkerTester workerWithInitialTaskCount:0
                                               recurringTaskCount:0];
-    
+
     auto worker = workerTester.worker;
-    
+
     XCTAssertEqual(workerTester.initialTaskCounter, 0);
     XCTAssertEqual(workerTester.recurringTaskCounter, 0);
-    
+
     [worker start];
-    
+
     XCTAssertEqual(workerTester.initialTaskCounter, 0);
     XCTAssertEqual(workerTester.recurringTaskCounter, 0);
-    
+
     [worker wake];
-    
+
+    XCTAssertEqual(workerTester.initialTaskCounter, 0);
+    XCTAssertEqual(workerTester.recurringTaskCounter, 0);
+
+    [worker wake];
+
     XCTAssertEqual(workerTester.initialTaskCounter, 0);
     XCTAssertEqual(workerTester.recurringTaskCounter, 0);
 }
@@ -63,6 +68,12 @@
     XCTAssertEqual(workerTester.recurringTaskCounter, 0);
     
     [worker start];
+    [NSThread sleepForTimeInterval:0.1];
+
+    XCTAssertEqual(workerTester.initialTaskCounter, 0);
+    XCTAssertEqual(workerTester.recurringTaskCounter, 0);
+
+    [worker wake];
     [NSThread sleepForTimeInterval:0.1];
     
     XCTAssertEqual(workerTester.initialTaskCounter, 1);
@@ -86,6 +97,12 @@
     
     [worker start];
     [NSThread sleepForTimeInterval:0.1];
+
+    XCTAssertEqual(workerTester.initialTaskCounter, 0);
+    XCTAssertEqual(workerTester.recurringTaskCounter, 0);
+
+    [worker wake];
+    [NSThread sleepForTimeInterval:0.1];
     
     XCTAssertEqual(workerTester.initialTaskCounter, 0);
     XCTAssertEqual(workerTester.recurringTaskCounter, 1);
@@ -108,6 +125,12 @@
     
     [worker start];
     [NSThread sleepForTimeInterval:0.1];
+
+    XCTAssertEqual(workerTester.initialTaskCounter, 0);
+    XCTAssertEqual(workerTester.recurringTaskCounter, 0);
+
+    [worker wake];
+    [NSThread sleepForTimeInterval:0.1];
     
     XCTAssertEqual(workerTester.initialTaskCounter, 1);
     XCTAssertEqual(workerTester.recurringTaskCounter, 1);
@@ -129,6 +152,12 @@
     XCTAssertEqual(workerTester.recurringTaskCounter, 0);
     
     [worker start];
+    [NSThread sleepForTimeInterval:0.1];
+
+    XCTAssertEqual(workerTester.initialTaskCounter, 0);
+    XCTAssertEqual(workerTester.recurringTaskCounter, 0);
+
+    [worker wake];
     [NSThread sleepForTimeInterval:0.1];
     
     XCTAssertEqual(workerTester.initialTaskCounter, 2);

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -25,8 +25,6 @@ class Scenario: NSObject {
 
     func configure() {
         logDebug("Scenario.configure()")
-        // Make sure the initial P value has time to be fully received before sending spans
-        config.internal.initialRecurringWorkDelay = 0.5
         config.internal.clearPersistenceOnStart = true
         config.internal.autoTriggerExportOnBatchSize = 1
         config.apiKey = "12312312312312312312312312312312"


### PR DESCRIPTION
## Goal

If the app is backgrounded before starting Bugsnag, any early spans opened before this were remaining active instead of being cancelled. This led to incredibly long app start spans in some cases.

There are also cases where the app startup was getting interrupted for unknown reasons, also resulting in unnaturally long app startup spans.

We need to mitigate these edge cases.

## Design

Check for both a long app start time, and the app being backgrounded immediately after start. In both cases, we discard the app startup spans.

Since notifications can be received before the app starts (and thus before Bugsnag is started), connect the notifications in the early setup code rather than in the start code.

Track `NSApplicationDidFinishLaunchingNotification` and use it to detect unnaturally long app launches (also checking from `BugsnagPerformanceImpl::start()`).

Launch the initial P value request right in the start code rather than in the worker thread because the worker thread start will now be delayed.

## Testing

Manual testing since we don't have reliable e2e backgrounding test support yet.