### PR TITLE
[PLAT-12123] Add cross-talk API

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -67,6 +67,9 @@
 		09D59E1B2BDFE0D900199E1B /* NetworkHeaderInjector.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09D59E192BDFE0D900199E1B /* NetworkHeaderInjector.mm */; };
 		09D807F52B9756B000D01DF5 /* BugsnagPerformanceSwiftUI.docc in Sources */ = {isa = PBXBuildFile; fileRef = 09D807F42B9756B000D01DF5 /* BugsnagPerformanceSwiftUI.docc */; };
 		09D807F62B9756B000D01DF5 /* BugsnagPerformanceSwiftUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 09D807F32B9756B000D01DF5 /* BugsnagPerformanceSwiftUI.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09E313042BF363020081F219 /* CrossTalkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E313032BF363020081F219 /* CrossTalkTests.m */; };
+		09FFD4402BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 09FFD43E2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.h */; };
+		09FFD4412BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09FFD43F2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm */; };
 		8A80DA8B2966CE940035BDA9 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		8A80DA912966CEB30035BDA9 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A80DA80296588840035BDA9 /* ConfigurationTests.swift */; };
 		960EECF12B23DF9B009FAA11 /* BugsnagPerformanceTrackedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960EECED2B237561009FAA11 /* BugsnagPerformanceTrackedViewController.swift */; };
@@ -298,6 +301,9 @@
 		09D807F12B9756B000D01DF5 /* BugsnagPerformanceSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformanceSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		09D807F32B9756B000D01DF5 /* BugsnagPerformanceSwiftUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSwiftUI.h; sourceTree = "<group>"; };
 		09D807F42B9756B000D01DF5 /* BugsnagPerformanceSwiftUI.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = BugsnagPerformanceSwiftUI.docc; sourceTree = "<group>"; };
+		09E313032BF363020081F219 /* CrossTalkTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CrossTalkTests.m; sourceTree = "<group>"; };
+		09FFD43E2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceCrossTalkAPI.h; sourceTree = "<group>"; };
+		09FFD43F2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceCrossTalkAPI.mm; sourceTree = "<group>"; };
 		72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformance.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A80DA80296588840035BDA9 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		8A80DA872966CE940035BDA9 /* BugsnagPerformance-iOSTestsSwift.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagPerformance-iOSTestsSwift.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -517,6 +523,8 @@
 				CB572EA929BB783200FD7A2A /* AppStateTracker.m */,
 				CBE8EA1C294B5E1500702950 /* Batch.h */,
 				967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */,
+				09FFD43E2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.h */,
+				09FFD43F2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm */,
 				CBE8EA14294B528100702950 /* BugsnagPerformanceImpl.h */,
 				CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */,
 				CB78819B29E587CE00A58906 /* BugsnagPerformanceLibrary.h */,
@@ -534,6 +542,8 @@
 				0122C22929019770002D243C /* Instrumentation */,
 				CBEC51BE296DB311009C0CE3 /* JSON.h */,
 				CBEC51BF296DB311009C0CE3 /* JSON.mm */,
+				09D59E182BDFE0D900199E1B /* NetworkHeaderInjector.h */,
+				09D59E192BDFE0D900199E1B /* NetworkHeaderInjector.mm */,
 				CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */,
 				CBB48A3B295EE1E10044E9AC /* ObjCUtils.mm */,
 				CB04969529150D860097E526 /* OtlpPackage.h */,
@@ -581,8 +591,6 @@
 				0986B7BF2B287C9D00BD2CA3 /* WeakSpansList.mm */,
 				CBE8EA18294B5AB800702950 /* Worker.h */,
 				CBE8EA19294B5AB800702950 /* Worker.mm */,
-				09D59E182BDFE0D900199E1B /* NetworkHeaderInjector.h */,
-				09D59E192BDFE0D900199E1B /* NetworkHeaderInjector.mm */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -629,6 +637,7 @@
 				CB0AD75C29641B59002A3FB6 /* BatchTests.mm */,
 				CB0AD76B296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm */,
 				0122C25F29019C05002D243C /* BugsnagPerformanceTests.mm */,
+				09E313032BF363020081F219 /* CrossTalkTests.m */,
 				CBEC51C8296ED98F009C0CE3 /* FileBasedTest.h */,
 				CBEC51C9296ED98F009C0CE3 /* FileBasedTest.m */,
 				CBEC51D82976D54B009C0CE3 /* FilesystemTests.m */,
@@ -789,6 +798,7 @@
 				015836C4291264E0002F54C8 /* Version.h in Headers */,
 				01A58C0E29092D25006E4DF7 /* Sampler.h in Headers */,
 				0122C23929019770002D243C /* BugsnagPerformanceViewType.h in Headers */,
+				09FFD4402BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.h in Headers */,
 				0122C23A29019770002D243C /* BugsnagPerformanceConfiguration.h in Headers */,
 				CBA22C962A0137230066A2C1 /* EarlyConfiguration.h in Headers */,
 				CB68FAB92A3C27B9005B2CDB /* PersistentDeviceID.h in Headers */,
@@ -1117,6 +1127,7 @@
 				CBEC51D92976D54B009C0CE3 /* FilesystemTests.m in Sources */,
 				CB0AD75D29641B59002A3FB6 /* BatchTests.mm in Sources */,
 				CB68FABC2A3C4208005B2CDB /* PersistentDeviceIDTest.mm in Sources */,
+				09E313042BF363020081F219 /* CrossTalkTests.m in Sources */,
 				CB747D21299E5458003CA1B4 /* TimeTests.mm in Sources */,
 				0122C27129019CEF002D243C /* OtlpTraceEncodingTests.mm in Sources */,
 				09509B752ADFE9A900A358EC /* TracerTests.mm in Sources */,
@@ -1179,6 +1190,7 @@
 				CBEBE59229F2783C00BF0B4F /* Swizzle.mm in Sources */,
 				01A58C0F29092D25006E4DF7 /* Sampler.mm in Sources */,
 				CBA22C972A0137230066A2C1 /* EarlyConfiguration.mm in Sources */,
+				09FFD4412BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm in Sources */,
 				CBEC51C1296DB312009C0CE3 /* JSON.mm in Sources */,
 				CBEBE59B29F671A800BF0B4F /* Instrumentation.mm in Sources */,
 				0122C24029019770002D243C /* SpanData.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.h
@@ -1,0 +1,26 @@
+//
+//  BugsnagPerformanceCrossTalkAPI.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 10.05.24.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SpanStackingHandler.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagPerformanceCrossTalkAPI : NSObject
+
+#pragma mark Mandatory Methods
+
++ (instancetype) sharedInstance;
+
+#pragma mark Configuration and Internal Functions
+
+@property(nonatomic) std::shared_ptr<SpanStackingHandler> spanStackingHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
@@ -1,0 +1,135 @@
+//
+//  BugsnagPerformanceCrossTalkAPI.mm
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 10.05.24.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagPerformanceCrossTalkAPI.h"
+#import <objc/runtime.h>
+
+@implementation BugsnagPerformanceCrossTalkAPI
+
+#pragma mark Exposed API
+
+/**
+ * Return the current trace and span IDs as strings in a 2-entry array, or return nil if no current span exists.
+ *
+ * array[0] is an NSString containing the trace ID
+ * array[1] is an NSString containing the span ID
+ */
+- (NSArray * _Nullable)getCurrentTraceAndSpanIdV1 {
+    auto spanStackingHandler = self.spanStackingHandler;
+    if (spanStackingHandler == nullptr) {
+        return nil;
+    }
+    auto span = spanStackingHandler->currentSpan();
+    if (span == nil) {
+        return nil;
+    }
+    return @[
+        [NSString stringWithFormat:@"%llx%llx", span.traceId.hi, span.traceId.lo],
+        [NSString stringWithFormat:@"%llx", span.spanId]
+    ];
+}
+
+#pragma mark Internal Functionality
+
+static NSString *BSGUserInfoKeyMapped = @"mapped";
+static NSString *BSGUserInfoValueMappedYes = @"YES";
+static NSString *BSGUserInfoValueMappedNo = @"NO";
+
+/**
+ * Map a named API to a method with the specified selector.
+ * If an error occurs, the user info dictionary of the error will contain a field "mapped".
+ * If "mapped" is "YES", then the selector has been mapped to a null implementation (does nothing, returns nil).
+ * If "mapped" is "NO", then no mapping has occurred, and the method doesn't exist (alling it will result in no such selector).
+ */
++ (NSError *)mapAPINamed:(NSString * _Nonnull)apiName toSelector:(SEL)toSelector {
+    NSError *err = nil;
+    // By default, we map to a "do nothing" implementation in case we don't find a real one.
+    SEL fromSelector = @selector(internal_doNothing);
+
+    // Note: ALWAYS ALWAYS ALWAYS check every single API mapping with a unit test!!!
+    if ([apiName isEqualToString:@"getCurrentTraceAndSpanIdV1"]) {
+        fromSelector = @selector(getCurrentTraceAndSpanIdV1);
+    } else {
+        err = [NSError errorWithDomain:@"com.bugsnag.BugsnagCocoaPerformance"
+                                  code:0
+                              userInfo:@{
+            NSLocalizedDescriptionKey:[NSString stringWithFormat:@"No such API: %@", apiName],
+            BSGUserInfoKeyMapped:BSGUserInfoValueMappedYes
+        }];
+    }
+
+    Method method = class_getInstanceMethod(self.class, fromSelector);
+    if (method == nil) {
+        return [NSError errorWithDomain:@"com.bugsnag.BugsnagCocoaPerformance"
+                                  code:0
+                              userInfo:@{
+            NSLocalizedDescriptionKey:[NSString stringWithFormat:
+                                       @"class_getInstanceMethod (while mapping api %@): Failed to find instance method %@ in class %@",
+                                       apiName,
+                                       NSStringFromSelector(fromSelector),
+                                       self.class],
+            BSGUserInfoKeyMapped:BSGUserInfoValueMappedNo
+        }];
+    }
+
+    IMP imp = method_getImplementation(method);
+    if (imp == nil) {
+        return [NSError errorWithDomain:@"com.bugsnag.BugsnagCocoaPerformance"
+                                  code:0
+                              userInfo:@{
+            NSLocalizedDescriptionKey:[NSString stringWithFormat:
+                                       @"method_getImplementation (while mapping api %@): Failed to find implementation of instance method %@ in class %@",
+                                       apiName,
+                                       NSStringFromSelector(fromSelector),
+                                       self.class],
+            BSGUserInfoKeyMapped:BSGUserInfoValueMappedNo
+        }];
+    }
+
+    const char* encoding = method_getTypeEncoding(method);
+    if (encoding == nil) {
+        return [NSError errorWithDomain:@"com.bugsnag.BugsnagCocoaPerformance"
+                                  code:0
+                              userInfo:@{
+            NSLocalizedDescriptionKey:[NSString stringWithFormat:
+                                       @"method_getTypeEncoding (while mapping api %@): Failed to find signature of instance method %@ in class %@",
+                                       apiName,
+                                       NSStringFromSelector(fromSelector),
+                                       self.class],
+            BSGUserInfoKeyMapped:BSGUserInfoValueMappedNo
+        }];
+    }
+
+    if (!class_addMethod(self.class, toSelector, imp, encoding)) {
+        return [NSError errorWithDomain:@"com.bugsnag.BugsnagCocoaPerformance"
+                                  code:0
+                              userInfo:@{
+            NSLocalizedDescriptionKey:[NSString stringWithFormat:
+                                       @"class_addMethod (while mapping api %@): Failed to add instance method %@ to class %@",
+                                       apiName,
+                                       NSStringFromSelector(fromSelector),
+                                       self.class],
+            BSGUserInfoKeyMapped:BSGUserInfoValueMappedNo
+        }];
+    }
+
+    return err;
+}
+
+- (void * _Nullable)internal_doNothing {
+    return NULL;
+}
+
++ (instancetype) sharedInstance {
+    static id sharedInstance;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ sharedInstance = [[self alloc] init]; });
+    return sharedInstance;
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -13,6 +13,7 @@
 #import "Utils.h"
 #import "SpanAttributesProvider.h"
 #import "SpanStackingHandler.h"
+#import "BugsnagPerformanceCrossTalkAPI.h"
 
 using namespace bugsnag;
 
@@ -97,6 +98,8 @@ void BugsnagPerformanceImpl::earlySetup() noexcept {
     batch_->earlySetup();
     instrumentation_->earlySetup();
     [worker_ earlySetup];
+
+    BugsnagPerformanceCrossTalkAPI.sharedInstance.spanStackingHandler = spanStackingHandler_;
 }
 
 void BugsnagPerformanceImpl::configure(BugsnagPerformanceConfiguration *config) noexcept {

--- a/Tests/BugsnagPerformanceTests/CrossTalkTests.m
+++ b/Tests/BugsnagPerformanceTests/CrossTalkTests.m
@@ -1,0 +1,73 @@
+//
+//  CrossTalkTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 14.05.24.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <objc/runtime.h>
+
+@interface CrossTalkAPITester: NSObject
+
+// Do NOT make implementations for any of these selectors.
+
+- (NSString *) shouldNotFindThisMethod;
+
+#pragma mark API Methods to Test
+
+- (NSArray *) testingGetCurrentTraceAndSpanIdV1;
+
+@end
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincomplete-implementation"
+@implementation CrossTalkAPITester
+
+static id crossTalkRealAPI = nil;
+
++ (void)initialize {
+    Class cls = NSClassFromString(@"BugsnagPerformanceCrossTalkAPI");
+    crossTalkRealAPI = [cls sharedInstance];
+}
+
++ (instancetype _Nullable)sharedInstance {
+    return crossTalkRealAPI;
+}
+
++ (NSError *)mapAPINamed:(NSString * _Nonnull)apiName toSelector:(SEL)toSelector {
+    return [[crossTalkRealAPI class] mapAPINamed:apiName toSelector:toSelector];
+}
+
+@end
+#pragma clang diagnostic pop
+
+
+@interface CrossTalkTests : XCTestCase
+@end
+
+@implementation CrossTalkTests
+
+- (void)testClientInstantiation {
+    CrossTalkAPITester *api = CrossTalkAPITester.sharedInstance;
+    // sharedInstance will be nil if we couldn't find the API class.
+    XCTAssertNotNil(api);
+}
+
+- (void)testAPINotFound {
+    NSError *err = [CrossTalkAPITester mapAPINamed:@"shouldNotFindThisMethod" toSelector:@selector(shouldNotFindThisMethod)];
+    // Should be mapped (to a null implementation)
+    XCTAssertEqualObjects(err.userInfo[@"mapped"], @"YES");
+    // It should still execute without crashing, even though it will do nothing and return nil.
+    XCTAssertNil([CrossTalkAPITester.sharedInstance shouldNotFindThisMethod]);
+}
+
+// You MUST make one test per API and version. Declare a selector in CrossTalkAPI and write a test here.
+
+- (void)testGetCurrentTraceAndSpanIdV1 {
+    XCTAssertNil([CrossTalkAPITester mapAPINamed:@"getCurrentTraceAndSpanIdV1" toSelector:@selector(testingGetCurrentTraceAndSpanIdV1)]);
+    [CrossTalkAPITester.sharedInstance testingGetCurrentTraceAndSpanIdV1];
+}
+
+@end


### PR DESCRIPTION
## Goal

Add a cross-talk API. This API can be connected to by another native library (and is being added to bugsnag-cocoa here: https://github.com/bugsnag/bugsnag-cocoa/pull/1649 )

## Design

The cross-talk API is a well-known, uniquely named class (`BugsnagPerformanceCrossTalkAPI`) that can be loaded by name from native code in another library using `NSClassFromString()`.

The calling code can then request that a named API be mapped to a particular selector using `mapAPINamed:toSelector:`. All methods are mapped onto `BugsnagPerformanceCrossTalkAPI` itself.

The mapping request includes a string representing the method the caller wants, and the selector they are expecting to use.

```objc
[cls mapAPINamed:@"getCurrentTraceAndSpanIdV1" toSelector:@selector(getCurrentTraceAndSpanId)];
```

If we're not willing to map that method, we map instead to a "null implementation" that does nothing and returns nil. This allows us to version any exposed API, and also deprecate them later without breaking any clients.

`BugsnagPerformanceCrossTalkAPI` is implemented as a singleton to ensure that only one instance ever exists across all libraries using it (including this library when it configures the object). Exposed functions are designed to work even while unconfigured (whereby they return nil).

## Testing

Added unit tests, and also tested in a test app with bugsnag-cocoa.
