### PR TITLE
[PLAT-12192] Catch badly behaved Apple APIs and report any errors generated rather than crashing

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -35,6 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)endWithAbsoluteTime:(CFAbsoluteTime)endTime;
 
+- (void)endOnDestroy;
+
 - (SpanId)parentId;
 - (NSString *)name;
 - (void)updateName:(NSString *)name;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.h
@@ -37,6 +37,7 @@ private:
     void markEarlySpan(BugsnagPerformanceSpan *span) noexcept;
     void endEarlySpansPhase() noexcept;
     void NSURLSessionTask_resume(NSURLSessionTask *task) noexcept;
+    bool canTraceTask(NSURLSessionTask *task) noexcept;
 
     bool isEnabled_{true};
     std::shared_ptr<Tracer> tracer_;

--- a/Sources/BugsnagPerformance/Private/NetworkHeaderInjector.mm
+++ b/Sources/BugsnagPerformance/Private/NetworkHeaderInjector.mm
@@ -37,7 +37,11 @@ void NetworkHeaderInjector::injectHeaders(NSURLSessionTask *task, BugsnagPerform
         return;
     }
 
-    NSURLRequest *request = task.currentRequest;
+    NSURLRequest *request = getTaskCurrentRequest(task, nil);
+    if (request == nil) {
+        return;
+    }
+
     if ([request isKindOfClass:NSMutableURLRequest.class]) {
         NSMutableURLRequest *mutableRequest = (NSMutableURLRequest *)request;
         [mutableRequest setValue:headerValue forHTTPHeaderField:headerName];
@@ -64,7 +68,7 @@ BOOL NetworkHeaderInjector::shouldAddTracePropagationHeaders(NSURL *url) noexcep
 }
 
 void NetworkHeaderInjector::injectTraceParentIfMatches(NSURLSessionTask *task, BugsnagPerformanceSpan * _Nullable span) {
-    if (shouldAddTracePropagationHeaders(task.originalRequest.URL)) {
+    if (shouldAddTracePropagationHeaders(getTaskRequest(task, nil).URL)) {
         injectHeaders(task, span);
     }
 }

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -109,9 +109,11 @@ OtlpTraceEncoding::encode(const SpanData &span) noexcept {
 
 NSDictionary *
 OtlpTraceEncoding::encode(const std::vector<std::shared_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept {
+    BSGLogDebug(@"OtlpTraceEncoding::encode(%zu)", spans.size());
     auto encodedSpans = [NSMutableArray arrayWithCapacity:spans.size()];
     for (const auto &span: spans) {
         if (span->isValid()) {
+            BSGLogTrace(@"OtlpTraceEncoding::encode: span %@", span->name);
             [encodedSpans addObject:encode(*span.get())];
         }
     }

--- a/Sources/BugsnagPerformance/Private/OtlpUploader.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpUploader.mm
@@ -7,6 +7,7 @@
 //
 
 #import "OtlpUploader.h"
+#import "Utils.h"
 
 using namespace bugsnag;
 
@@ -28,6 +29,7 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
 };
 
 void OtlpUploader::upload(OtlpPackage &package, UploadResultCallback callback) noexcept {
+    BSGLogDebug(@"OtlpUploader::upload(package, callback)");
     auto urlRequest = [NSMutableURLRequest requestWithURL:(NSURL *)endpoint_];
     [urlRequest setValue:apiKey_ forHTTPHeaderField:@"Bugsnag-Api-Key"];
 
@@ -54,11 +56,14 @@ void OtlpUploader::upload(OtlpPackage &package, UploadResultCallback callback) n
     [[NSURLSession.sharedSession dataTaskWithRequest:urlRequest completionHandler:
       ^(__unused NSData *responseData, NSURLResponse *response, __unused NSError *taskError) {
         if (callback) {
-            callback(getUploadResult(response));
+            auto uploadResult = getUploadResult(response);
+            BSGLogDebug(@"OtlpUploader::upload: callback(%d)", uploadResult);
+            callback(uploadResult);
         }
         if (newProbabilityCallback_) {
             auto newProbability = getNewProbability(response);
             if (newProbability >= 0 && newProbability <= 1) {
+                BSGLogTrace(@"OtlpUploader::upload: newProbabilityCallback_(%f)", newProbability);
                 newProbabilityCallback_(newProbability);
             }
         }

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -14,8 +14,9 @@ public:
     SpanAttributesProvider() noexcept;
     ~SpanAttributesProvider() {};
     
-    NSDictionary *networkSpanUrlAttributes(NSURL *url) noexcept;
-    NSDictionary *networkSpanAttributes(NSURL *url, NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept;
+    NSDictionary *networkSpanUrlAttributes(NSURL *url, NSError *encounteredError) noexcept;
+    NSDictionary *networkSpanAttributes(NSURL *url, NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics,
+                                        NSError *encounteredError) noexcept;
     NSDictionary *appStartSpanAttributes(NSString *firstViewName, bool isColdLaunch) noexcept;
     NSDictionary *appStartPhaseSpanAttributes(NSString *phase) noexcept;
     NSDictionary *viewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -103,15 +103,21 @@ static void addNonZero(NSMutableDictionary *dict, NSString *key, NSNumber *value
 NSDictionary *
 SpanAttributesProvider::networkSpanAttributes(NSURL *url,
                                               NSURLSessionTask *task,
-                                              NSURLSessionTaskMetrics *metrics) noexcept {
+                                              NSURLSessionTaskMetrics *metrics,
+                                              NSError *encounteredError) noexcept {
+    BSGLogTrace(@"SpanAttributesProvider::networkSpanAttributes(%@, task, metrics, error)", url);
     auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
     auto attributes = [NSMutableDictionary new];
     attributes[@"bugsnag.span.category"] = @"network";
     if (url != nil) {
         attributes[@"http.url"] = url.absoluteString;
     }
+    if (encounteredError != nil) {
+        BSGLogTrace(@"SpanAttributesProvider::networkSpanAttributes: Caller encountered error \"%@\". Adding instrumentation_message attribute", encounteredError.description);
+        attributes[@"bugsnag.instrumentation_message"] = encounteredError.description;
+    }
     attributes[@"http.flavor"] = getHTTPFlavour(metrics);
-    attributes[@"http.method"] = task.originalRequest.HTTPMethod;
+    attributes[@"http.method"] = getTaskRequest(task, nil).HTTPMethod;
     attributes[@"http.status_code"] = httpResponse ? @(httpResponse.statusCode) : @0;
     attributes[@"net.host.connection.type"] = getConnectionType(task, metrics);
     attributes[@"net.host.connection.subtype"] = getConnectionSubtype(attributes[@"net.host.connection.type"]);
@@ -121,12 +127,18 @@ SpanAttributesProvider::networkSpanAttributes(NSURL *url,
 }
 
 NSDictionary *
-SpanAttributesProvider::networkSpanUrlAttributes(NSURL *url) noexcept {
+SpanAttributesProvider::networkSpanUrlAttributes(NSURL *url, NSError *encounteredError) noexcept {
+    BSGLogTrace(@"SpanAttributesProvider::networkSpanUrlAttributes(%@)", url);
+    NSMutableDictionary *attributes = [NSMutableDictionary new];
     NSString *urlString = url.absoluteString;
-    if (urlString == nil) {
-        return @{};
+    if (urlString != nil) {
+        attributes[@"http.url"] = urlString;
     }
-    return @{@"http.url": (NSString * _Nonnull)urlString};
+    if (encounteredError != nil) {
+        BSGLogTrace(@"SpanAttributesProvider::networkSpanUrlAttributes: Caller encountered error \"%@\". Adding instrumentation_message attribute", encounteredError.description);
+        attributes[@"bugsnag.instrumentation_message"] = encounteredError.description;
+    }
+    return attributes;
 }
 
 NSDictionary *

--- a/Sources/BugsnagPerformance/Private/Utils.h
+++ b/Sources/BugsnagPerformance/Private/Utils.h
@@ -15,9 +15,10 @@
 #define BSG_LOGLEVEL_WARN 20
 #define BSG_LOGLEVEL_INFO 30
 #define BSG_LOGLEVEL_DEBUG 40
+#define BSG_LOGLEVEL_TRACE 50
 
 #ifndef BSG_LOG_LEVEL
-#define BSG_LOG_LEVEL BSG_LOGLEVEL_INFO
+#define BSG_LOG_LEVEL BSG_LOGLEVEL_TRACE
 #endif
 
 #define BSG_LOG_PREFIX "[BugsnagPerformance]"
@@ -44,6 +45,12 @@
 #define BSGLogDebug(...)    NSLog(@ BSG_LOG_PREFIX " [DEBUG] " __VA_ARGS__)
 #else
 #define BSGLogDebug(format, ...)
+#endif
+
+#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_TRACE
+#define BSGLogTrace(...)    NSLog(@ BSG_LOG_PREFIX " [TRACE] " __VA_ARGS__)
+#else
+#define BSGLogTrace(format, ...)
 #endif
 
 namespace bugsnag {
@@ -100,5 +107,78 @@ static inline dispatch_time_t absoluteTimeToNanoseconds(CFAbsoluteTime time) {
 static inline dispatch_time_t intervalToNanoseconds(NSTimeInterval interval) {
     return (dispatch_time_t) (interval * NSEC_PER_SEC);
 }
+
+/**
+ * Try to fetch the original request from a task. Fills out error if the task throws an exception and we can't get the request.
+ *
+ * This function is necessary because Apple deliberately breaks their own public API by throwing an exception
+ * to signal that something isn't supported by a particular subclass (and also doesn't document this).
+ */
+static inline NSURLRequest *getTaskOriginalRequest(NSURLSessionTask *task, NSError **error) {
+    NSURLRequest *req = nil;
+
+    try {
+        req = task.originalRequest;
+        BSGLogTrace(@"Fetched originalRequest %@ from task %@", req, task);
+    } catch(NSException *e) {
+        if (error != nil) {
+            NSString *errorDesc = [NSString stringWithFormat:
+                                   @"%@ threw exception %@ while accessing originalRequest",
+                                   e,
+                                   task.class];
+            *error = [NSError errorWithDomain:@"com.bugsnag.bugsnag-cocoa-performance"
+                                         code:100
+                                     userInfo:@{NSLocalizedDescriptionKey:errorDesc}];
+            BSGLogTrace(@"Failed to fetch originalRequest from task %@: %@", task, *error);
+        }
+    }
+
+    return req;
+}
+
+/**
+ * Try to fetch the current request from a task. Fills out error
+ * if the task throws an exception and we can't get the request.
+ *
+ * This function is necessary because Apple deliberately breaks their own public API by throwing an exception
+ * to signal that something isn't supported by a particular subclass (and also doesn't document this).
+ */
+static inline NSURLRequest *getTaskCurrentRequest(NSURLSessionTask *task, NSError **error) {
+    NSURLRequest *req = nil;
+
+    try {
+        req = task.currentRequest;
+        BSGLogTrace(@"Fetched currentRequest %@ from task %@", req, task);
+    } catch(NSException *e) {
+        if (error != nil) {
+            NSString *errorDesc = [NSString stringWithFormat:
+                                   @"%@ threw exception %@ while accessing currentRequest",
+                                   e,
+                                   task.class];
+            *error = [NSError errorWithDomain:@"com.bugsnag.bugsnag-cocoa-performance"
+                                         code:100
+                                     userInfo:@{NSLocalizedDescriptionKey:errorDesc}];
+            BSGLogTrace(@"Failed to fetch currentRequest from task %@: %@", task, *error);
+        }
+    }
+
+    return req;
+}
+
+/**
+ * Try to fetch the original request from a task, falling back to the current request. Fills out error
+ * if the task throws an exception and we can't get the request.
+ *
+ * This function is necessary because Apple deliberately breaks their own public API by throwing an exception
+ * to signal that something isn't supported by a particular subclass (and also doesn't document this).
+ */
+static inline NSURLRequest *getTaskRequest(NSURLSessionTask *task, NSError **error) {
+    NSURLRequest *req = getTaskOriginalRequest(task, error);
+    if (req != nil) {
+        return req;
+    }
+    return getTaskCurrentRequest(task, error);
+}
+
 
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -45,6 +45,10 @@ using namespace bugsnag;
     self.span->end(endTime);
 }
 
+- (void)endOnDestroy {
+    self.span->spanDestroyAction = EndOnSpanDestroy;
+}
+
 - (TraceId)traceId {
     return self.span->traceId();
 }

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -601,6 +601,26 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
 
+  Scenario: Automatically start a network span triggered by AVAssetDownloadURLSession (must not crash)
+    Given I run "AutoInstrumentAVAssetScenario"
+    And I wait for 2 seconds
+    And I wait for 2 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "parentSpanId" does not exist
+    * a span field "name" equals "[HTTP/GET]"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "bugsnag.instrumentation_message" matches the regex "Error.*"
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * a span bool attribute "bugsnag.span.first_class" does not exist
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.PerformanceFixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
   Scenario: ComplexViewScenario
     Given I run "ComplexViewScenario"
     And I wait for 27 spans

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		0983A1792B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0983A1782B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift */; };
 		0983A17B2B14BB2000DDF4FF /* BugsnagPerformanceSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0983A17A2B14BB2000DDF4FF /* BugsnagPerformanceSwift */; };
 		098808E02B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */; };
+		099331FC2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099331FB2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift */; };
 		09D59E172BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D59E162BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift */; };
 		09D59E1D2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */; };
 		09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */; };
@@ -95,6 +96,7 @@
 		096EE5EE2B3C2B3E006059CE /* AutoInstrumentSwiftUIDeferredScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentSwiftUIDeferredScenario.swift; sourceTree = "<group>"; };
 		0983A1782B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentSwiftUIScenario.swift; sourceTree = "<group>"; };
 		098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualViewLoadPhaseScenario.swift; sourceTree = "<group>"; };
+		099331FB2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentAVAssetScenario.swift; sourceTree = "<group>"; };
 		09D59E162BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkTracePropagationScenario.swift; sourceTree = "<group>"; };
 		09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkTracePropagationScenario.swift; sourceTree = "<group>"; };
 		09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkCallbackScenario.swift; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 			isa = PBXGroup;
 			children = (
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
+				099331FB2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift */,
 				CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */,
 				960EECE82B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift */,
 				9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */,
@@ -360,6 +363,7 @@
 				01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */,
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
+				099331FC2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift in Sources */,
 				01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */,
 				960EECE92B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift in Sources */,
 				0983A1792B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/AutoInstrumentAVAssetScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentAVAssetScenario.swift
@@ -1,0 +1,53 @@
+//
+//  AutoInstrumentAVAssetScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 06.06.24.
+//
+
+import Foundation
+import AVFoundation
+
+@objcMembers
+class AutoInstrumentAVAssetScenario: Scenario, AVAssetDownloadDelegate {
+
+    override func configure() {
+        super.configure()
+        config.autoInstrumentNetworkRequests = true
+        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+            super.ignoreInternalRequests(info: info)
+            let testUrl = info.url
+            if (testUrl == nil) {
+                return info
+            }
+            if (self.isMazeRunnerAdministrationURL(url: testUrl!)) {
+                info.url = nil
+            }
+            return info
+        }
+    }
+
+    func query(string: String) {
+        let url = URL(string: string, relativeTo: fixtureConfig.reflectURL)!
+        let currentFileName = "the-file"
+        let configuration = URLSessionConfiguration.background(withIdentifier: currentFileName)
+
+        let downloadSession = AVAssetDownloadURLSession(configuration: configuration,
+                                                        assetDownloadDelegate: self,
+                                  delegateQueue: OperationQueue.main)
+        let asset = AVURLAsset(url: url)
+        let downloadTask = downloadSession.makeAssetDownloadTask(asset: asset,
+                                                                 assetTitle: currentFileName,
+                                                                 assetArtworkData: nil,
+                                                                 options: nil)
+        downloadTask!.resume()
+    }
+
+    override func run() {
+        // Force the automatic spans to be sent in a separate trace that we will discard
+        waitForCurrentBatch()
+        let span = BugsnagPerformance.startSpan(name: "parentSpan")
+        span.end();
+        query(string: "?status=200")
+    }
+}


### PR DESCRIPTION
## Goal

Apple breaks their own `NSURLSessionTask` APIs by throwing exceptions to mark them as unsupported, so we must work around this or else we'll crash.

## Design

Affected APIs are now guarded with try/catch, and a new attribute field `bugsnag.instrumentation_message` has been added to allow reporting the error to the backend.

Because the request can't be fetched from an `AVAssetDownloadTask`, it never goes through a metrics collection phase either, meaning that we can only rely upon the destructor for closing the span. This behaviour can be triggered by calling `endOnDestroy` on the span (which we now do whenever we fail to fetch a request from a task).

I've also added some permanent trace and debug logging because I got tired of adding it every time something breaks :P

## Testing

New e2e tests that check using `AVAssetDownloadTask`.
