### PR TITLE
[PLAT-12205] Remove duplicate makeCurrentContext check

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -413,23 +413,15 @@ void BugsnagPerformanceImpl::uploadPackage(std::unique_ptr<OtlpPackage> package,
 
 #pragma mark Spans
 
-void BugsnagPerformanceImpl::possiblyMakeSpanCurrent(BugsnagPerformanceSpan *span, SpanOptions &options) {
-    if (options.makeCurrentContext) {
-        spanStackingHandler_->push(span);
-    }
-}
-
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name) noexcept {
     SpanOptions options;
     auto span = tracer_->startCustomSpan(name, options);
-    possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name, BugsnagPerformanceSpanOptions *optionsIn) noexcept {
     auto options = SpanOptions(optionsIn);
     auto span = tracer_->startCustomSpan(name, options);
-    possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
@@ -437,7 +429,6 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *clas
     SpanOptions options;
     auto span = tracer_->startViewLoadSpan(viewType, className, options);
     [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
-    possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
@@ -445,7 +436,6 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *clas
     auto options = SpanOptions(optionsIn);
     auto span = tracer_->startViewLoadSpan(viewType, className, options);
     [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
-    possiblyMakeSpanCurrent(span, options);
     return span;
 }
 
@@ -455,7 +445,6 @@ void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, Bug
     auto className = [NSString stringWithUTF8String:object_getClassName(controller)];
     auto span = tracer_->startViewLoadSpan(viewType, className, options);
     [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
-    possiblyMakeSpanCurrent(span, options);
 
     std::lock_guard<std::mutex> guard(viewControllersToSpansMutex_);
     [viewControllersToSpans_ setObject:span forKey:controller];

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -617,7 +617,7 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.instrumentation_message" matches the regex "Error.*"
     * a span bool attribute "bugsnag.span.first_class" is true
     * a span bool attribute "bugsnag.span.first_class" does not exist
-    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.PerformanceFixture"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.cocoaperformance"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
 


### PR DESCRIPTION

## Goal

The check for `makeCurrentContext` was being done both in `BugsnagPerformanceImpl.mm` and `Tracer.mm`, causing it to double-add to the stack, making them leak.

## Design

Remove the implementation in `BugsnagPerformanceImpl.mm`

## Testing

Reran all tests to make sure nothing was accidentally depending on this (anything that is must be checked for correctness).
