### PR TITLE
Fixed a crash on reportNetworkRequestSpan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fixed a crash on reportNetworkRequestSpan when networkRequestCallback is not set in the configuration. [277](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/277)
+
 ## 1.6.0 (2024-06-11)
 
 ### Enhancements

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -108,7 +108,11 @@ void BugsnagPerformanceImpl::configure(BugsnagPerformanceConfiguration *config) 
     probabilityValueExpiresAfterSeconds_ = config.internal.probabilityValueExpiresAfterSeconds;
     probabilityRequestsPauseForSeconds_ = config.internal.probabilityRequestsPauseForSeconds;
     maxPackageContentLength_ = config.internal.maxPackageContentLength;
-    networkRequestCallback_ = config.networkRequestCallback;
+    
+    auto networkRequestCallback = config.networkRequestCallback;
+    if (networkRequestCallback != nullptr) {
+        networkRequestCallback_ = (BugsnagPerformanceNetworkRequestCallback _Nonnull)networkRequestCallback;
+    }
 
     configuration_ = config;
     persistentState_->configure(config);

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -137,8 +137,8 @@ Feature: Manual creation of spans
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
 
-  Scenario: Manually start a network span without setting callback
-    Given I run "ManualNetworkSpanCallbackNotSetScenario"
+  Scenario: Manually start a network span with callback set to nil
+    Given I run "ManualNetworkSpanCallbackSetToNilScenario"
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header is present

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -137,6 +137,28 @@ Feature: Manual creation of spans
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
 
+  Scenario: Manually start a network span without setting callback
+    Given I run "ManualNetworkSpanCallbackNotSetScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header is present
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.cocoaperformance"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+    * a span field "name" equals "[HTTP/GET]"
+    * a span string attribute "http.flavor" exists
+    * a span string attribute "http.method" equals "GET"
+    * a span integer attribute "http.status_code" is greater than 0
+    * a span integer attribute "http.response_content_length" is greater than 0
+    * a span string attribute "net.host.connection.type" equals "wifi"
+    * a span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * a span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * a span field "kind" equals 1
+    * a span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" does not exist
+
   Scenario: Manually start and end a span field "with" batching
     Given I run "BatchingScenario"
     And I wait for 2 spans

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */; };
 		9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */; };
 		967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */; };
+		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackNotSetScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackNotSetScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
 		CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */; };
@@ -109,6 +110,7 @@
 		9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentTabViewLoadScenario.swift; sourceTree = "<group>"; };
 		9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNavigationViewLoadScenario.swift; sourceTree = "<group>"; };
 		967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseStageNotEnabledScenario.swift; sourceTree = "<group>"; };
+		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackNotSetScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackNotSetScenario.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
 		CB211D0629EEB615008F748D /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "BugsnagPerformanceConfiguration+Private.h"; path = "../../../../Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
@@ -233,6 +235,7 @@
 				CBC90C4229C466BD00280884 /* ForceUBSan.m */,
 				CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */,
 				09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */,
+				96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackNotSetScenario.swift */,
 				CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */,
 				09D59E162BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
@@ -361,6 +364,7 @@
 				9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */,
 				01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */,
 				01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */,
+				96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackNotSetScenario.swift in Sources */,
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
 				099331FC2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift in Sources */,

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -46,7 +46,7 @@
 		9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */; };
 		9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */; };
 		967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */; };
-		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackNotSetScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackNotSetScenario.swift */; };
+		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
 		CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */; };
@@ -110,7 +110,7 @@
 		9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentTabViewLoadScenario.swift; sourceTree = "<group>"; };
 		9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNavigationViewLoadScenario.swift; sourceTree = "<group>"; };
 		967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseStageNotEnabledScenario.swift; sourceTree = "<group>"; };
-		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackNotSetScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackNotSetScenario.swift; sourceTree = "<group>"; };
+		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackSetToNilScenario.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
 		CB211D0629EEB615008F748D /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "BugsnagPerformanceConfiguration+Private.h"; path = "../../../../Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
@@ -235,7 +235,7 @@
 				CBC90C4229C466BD00280884 /* ForceUBSan.m */,
 				CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */,
 				09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */,
-				96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackNotSetScenario.swift */,
+				96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */,
 				CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */,
 				09D59E162BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
@@ -364,7 +364,7 @@
 				9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */,
 				01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */,
 				01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */,
-				96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackNotSetScenario.swift in Sources */,
+				96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */,
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
 				099331FC2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/ManualNetworkSpanCallbackNotSetScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualNetworkSpanCallbackNotSetScenario.swift
@@ -1,0 +1,44 @@
+//
+//  ManualNetworkSpanCallbackNotSetScenario.swift
+//  Fixture
+//
+//  Created by Robert B on 21/06/2024.
+//
+
+import BugsnagPerformance
+import os
+
+class MyCallbackNotSetNetworkDelegate: NSObject {
+    static let shared = MyCallbackNotSetNetworkDelegate()
+    public let urlConfiguration = URLSessionConfiguration.default
+    public var urlSession: URLSession!
+ 
+    private override init() {
+        super.init()
+        self.urlSession = URLSession(configuration: urlConfiguration, delegate: self, delegateQueue: OperationQueue())
+    }
+}
+
+extension MyCallbackNotSetNetworkDelegate : URLSessionDataDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        BugsnagPerformance.reportNetworkRequestSpan(task: task, metrics: metrics)
+    }
+}
+
+@objcMembers
+class ManualNetworkSpanCallbackNotSetScenario: Scenario {
+
+    func query(string: String) {
+        let url = URL(string: string, relativeTo: fixtureConfig.reflectURL)!
+        MyCallbackNotSetNetworkDelegate.shared.urlSession.dataTask(with: url).resume()
+    }
+    
+    override func configure() {
+        super.configure()
+        config.networkRequestCallback = nil
+    }
+
+    override func run() {
+        query(string: "?status=200")
+    }
+}

--- a/features/fixtures/ios/Scenarios/ManualNetworkSpanCallbackSetToNilScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualNetworkSpanCallbackSetToNilScenario.swift
@@ -1,5 +1,5 @@
 //
-//  ManualNetworkSpanCallbackNotSetScenario.swift
+//  ManualNetworkSpanCallbackSetToNilScenario.swift
 //  Fixture
 //
 //  Created by Robert B on 21/06/2024.
@@ -8,8 +8,8 @@
 import BugsnagPerformance
 import os
 
-class MyCallbackNotSetNetworkDelegate: NSObject {
-    static let shared = MyCallbackNotSetNetworkDelegate()
+class MyCallbackSetToNilNetworkDelegate: NSObject {
+    static let shared = MyCallbackSetToNilNetworkDelegate()
     public let urlConfiguration = URLSessionConfiguration.default
     public var urlSession: URLSession!
  
@@ -19,18 +19,18 @@ class MyCallbackNotSetNetworkDelegate: NSObject {
     }
 }
 
-extension MyCallbackNotSetNetworkDelegate : URLSessionDataDelegate {
+extension MyCallbackSetToNilNetworkDelegate : URLSessionDataDelegate {
     func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
         BugsnagPerformance.reportNetworkRequestSpan(task: task, metrics: metrics)
     }
 }
 
 @objcMembers
-class ManualNetworkSpanCallbackNotSetScenario: Scenario {
+class ManualNetworkSpanCallbackSetToNilScenario: Scenario {
 
     func query(string: String) {
         let url = URL(string: string, relativeTo: fixtureConfig.reflectURL)!
-        MyCallbackNotSetNetworkDelegate.shared.urlSession.dataTask(with: url).resume()
+        MyCallbackSetToNilNetworkDelegate.shared.urlSession.dataTask(with: url).resume()
     }
     
     override func configure() {


### PR DESCRIPTION
## Goal

Prevent a crash when User calls reportNetworkRequestSpan without setting networkRequestCallback on BugsnagPerformanceConfiguration

## Changeset

Added a safeguard preventing a null being assigned to networkRequestCallback_ in BugsnagPerformanceImpl class

## Testing

E2E tests