### PR TITLE
[PLAT-12317] Allow setting the parent context by span ID and trace ID rather than requiring an actual span object

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		096CBC172B1752F700534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096CBC152B1752F100534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift */; };
 		09856B9E2B9606A500620907 /* BugsnagPerformanceSwiftUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094FA7422B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.swift */; };
 		0986B7C02B287C9D00BD2CA3 /* WeakSpansList.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0986B7BF2B287C9D00BD2CA3 /* WeakSpansList.mm */; };
+		0987F2792C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 0987F2772C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0987F27A2C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0987F2782C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm */; };
 		09B473072B23087D0024CF11 /* WeakSpansList.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B473052B23087D0024CF11 /* WeakSpansList.h */; };
 		09B4730A2B2313570024CF11 /* WeakSpansListTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09B473092B2313570024CF11 /* WeakSpansListTests.mm */; };
 		09D59E1A2BDFE0D900199E1B /* NetworkHeaderInjector.h in Headers */ = {isa = PBXBuildFile; fileRef = 09D59E182BDFE0D900199E1B /* NetworkHeaderInjector.h */; };
@@ -294,6 +296,8 @@
 		09509B742ADFE9A900A358EC /* TracerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TracerTests.mm; sourceTree = "<group>"; };
 		096CBC152B1752F100534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BugsnagPerformanceSwiftUIInstrumentation.swift; sourceTree = "<group>"; };
 		0986B7BF2B287C9D00BD2CA3 /* WeakSpansList.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WeakSpansList.mm; sourceTree = "<group>"; };
+		0987F2772C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanContext.h; sourceTree = "<group>"; };
+		0987F2782C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceSpanContext.mm; sourceTree = "<group>"; };
 		09B473052B23087D0024CF11 /* WeakSpansList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WeakSpansList.h; sourceTree = "<group>"; };
 		09B473092B2313570024CF11 /* WeakSpansListTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WeakSpansListTests.mm; sourceTree = "<group>"; };
 		09D59E182BDFE0D900199E1B /* NetworkHeaderInjector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkHeaderInjector.h; sourceTree = "<group>"; };
@@ -496,9 +500,10 @@
 				CB0AD76929657381002A3FB6 /* BugsnagPerformanceErrors.h */,
 				0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */,
 				0122C21729019770002D243C /* BugsnagPerformanceSpan.h */,
+				0987F2772C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h */,
 				CB7FD92F299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h */,
-				0122C21829019770002D243C /* BugsnagPerformanceViewType.h */,
 				960EECF22B24C89A009FAA11 /* BugsnagPerformanceTrackedViewContainer.h */,
+				0122C21829019770002D243C /* BugsnagPerformanceViewType.h */,
 			);
 			path = BugsnagPerformance;
 			sourceTree = "<group>";
@@ -511,6 +516,7 @@
 				CB0AD7672965734F002A3FB6 /* BugsnagPerformanceErrors.m */,
 				0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */,
 				0122C21E29019770002D243C /* BugsnagPerformanceSpan.mm */,
+				0987F2782C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm */,
 				CB7FD931299D2F7700499E13 /* BugsnagPerformanceSpanOptions.m */,
 			);
 			path = Public;
@@ -807,6 +813,7 @@
 				96D55C832A1EBA35006D1F29 /* SpanActivityState.h in Headers */,
 				CBE0873329FA984C007455F2 /* BugsnagPerformanceViewType+Private.h in Headers */,
 				CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */,
+				0987F2792C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h in Headers */,
 				CBEC51C0296DB312009C0CE3 /* JSON.h in Headers */,
 				09B473072B23087D0024CF11 /* WeakSpansList.h in Headers */,
 				0921F02B2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h in Headers */,
@@ -1181,6 +1188,7 @@
 				CB572EAB29BB783200FD7A2A /* AppStateTracker.m in Sources */,
 				CBE8EA17294B528100702950 /* BugsnagPerformanceImpl.mm in Sources */,
 				0122C23E29019770002D243C /* BugsnagPerformanceSpan.mm in Sources */,
+				0987F27A2C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm in Sources */,
 				CBEC51DD2976F1F9009C0CE3 /* RetryQueue.mm in Sources */,
 				01A414CE2913C0F0003152A4 /* SpanAttributes.mm in Sources */,
 				CB34771E29068C350033759C /* NSURLSession+Instrumentation.mm in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Span parentage APIs now require a BugsnagPerformanceSpanContext, which BugsnagPerformanceSpan is now a subclass of. You no longer need to assign a Bugsnag span as a parent. [280](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/280)
+
 ## 1.6.1 (2024-06-24)
 
 ### Bug fixes

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -53,7 +53,7 @@ public:
                                               BugsnagPerformanceSpanOptions *options) noexcept;
 
     BugsnagPerformanceSpan *startViewLoadPhaseSpan(NSString *className, NSString *phase,
-                                                   BugsnagPerformanceSpan *parentContext) noexcept;
+                                                   BugsnagPerformanceSpanContext *parentContext) noexcept;
 
     void startViewLoadSpan(UIViewController *controller, BugsnagPerformanceSpanOptions *options) noexcept;
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -455,7 +455,7 @@ void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, Bug
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadPhaseSpan(NSString *className, NSString *phase,
-                                                                       BugsnagPerformanceSpan *parentContext) noexcept {
+                                                                       BugsnagPerformanceSpanContext *parentContext) noexcept {
     auto span = tracer_->startViewLoadPhaseSpan(className, phase, parentContext);
     [span addAttributes:spanAttributesProvider_->viewLoadPhaseSpanAttributes(className, phase)];
     return span;

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -14,7 +14,7 @@ namespace bugsnag {
 
 class SpanOptions {
 public:
-    SpanOptions(BugsnagPerformanceSpan *parentContext,
+    SpanOptions(BugsnagPerformanceSpanContext *parentContext,
                 CFAbsoluteTime startTime,
                 bool makeCurrentContext,
                 BSGFirstClass firstClass)
@@ -39,7 +39,7 @@ public:
                   BSGFirstClassUnset)
     {}
     
-    BugsnagPerformanceSpan *parentContext{nil};
+    BugsnagPerformanceSpanContext *parentContext{nil};
     CFAbsoluteTime startTime{CFABSOLUTETIME_INVALID};
     bool makeCurrentContext{false};
     BSGFirstClass firstClass{BSGFirstClassUnset};

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -55,7 +55,7 @@ public:
 
     BugsnagPerformanceSpan *startViewLoadPhaseSpan(NSString *className,
                                                    NSString *phase,
-                                                   BugsnagPerformanceSpan *parentContext) noexcept;
+                                                   BugsnagPerformanceSpanContext *parentContext) noexcept;
 
     void cancelQueuedSpan(BugsnagPerformanceSpan *span) noexcept;
 

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -149,7 +149,7 @@ Tracer::startNetworkSpan(NSString *httpMethod, SpanOptions options) noexcept {
 BugsnagPerformanceSpan *
 Tracer::startViewLoadPhaseSpan(NSString *className,
                                NSString *phase,
-                               BugsnagPerformanceSpan *parentContext) noexcept {
+                               BugsnagPerformanceSpanContext *parentContext) noexcept {
     NSString *name = [NSString stringWithFormat:@"[ViewLoadPhase/%@]/%@", phase, className];
     SpanOptions options;
     options.parentContext = parentContext;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -44,7 +44,7 @@ using namespace bugsnag;
 
 + (BugsnagPerformanceSpan *)startViewLoadPhaseSpanWithName:(NSString *)name
                                                      phase:(NSString *)phase
-                                             parentContext:(BugsnagPerformanceSpan *)parentContext {
+                                             parentContext:(BugsnagPerformanceSpanContext *)parentContext {
     return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startViewLoadPhaseSpan(name, phase, parentContext);
 }
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanContext.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanContext.mm
@@ -1,0 +1,25 @@
+//
+//  BugsnagPerformanceSpanContext.mm
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 01.07.24.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+
+@implementation BugsnagPerformanceSpanContext
+
+- (instancetype) initWithTraceId:(TraceId) traceId spanId:(SpanId) spanId {
+    if ((self = [super init])) {
+        _traceId = traceId;
+        _spanId = spanId;
+    }
+    return self;
+}
+
+- (instancetype) initWithTraceIdHi:(uint64_t)traceIdHi traceIdLo:(uint64_t)traceIdLo spanId:(SpanId)spanId {
+    return [self initWithTraceId:TraceId{.hi=traceIdHi, .lo=traceIdLo} spanId:spanId];
+}
+
+@end

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -7,12 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 
 @interface BugsnagPerformanceSpanOptions()
 @property(nonatomic,strong) NSDate *startTime_;
-@property(nonatomic,strong) BugsnagPerformanceSpan *parentContext_;
+@property(nonatomic,strong) BugsnagPerformanceSpanContext *parentContext_;
 @property(nonatomic) BOOL makeCurrentContext_;
 @property(nonatomic) BSGFirstClass firstClass_;
 @end
@@ -33,7 +33,7 @@
 }
 
 - (instancetype)initWithStartTime:(NSDate *)startTime
-                    parentContext:(BugsnagPerformanceSpan *)parentContext
+                    parentContext:(BugsnagPerformanceSpanContext *)parentContext
                makeCurrentContext:(BOOL)makeCurrentContext
                        firstClass:(BSGFirstClass)firstClass {
     if ((self = [super init])) {
@@ -50,7 +50,7 @@
     return _startTime;
 }
 
-- (BugsnagPerformanceSpan *)parentContext {
+- (BugsnagPerformanceSpanContext *)parentContext {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     return _parentContext;
 }
@@ -71,7 +71,7 @@
     return self;
 }
 
-- (instancetype)setParentContext:(BugsnagPerformanceSpan *)parentContext {
+- (instancetype)setParentContext:(BugsnagPerformanceSpanContext *)parentContext {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     _parentContext = parentContext;
     return self;

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -8,6 +8,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceErrors.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
 #import <BugsnagPerformance/BugsnagPerformanceNetworkRequestInfo.h>
@@ -53,7 +54,7 @@ OBJC_EXPORT
 
 + (BugsnagPerformanceSpan *)startViewLoadPhaseSpanWithName:(NSString *)name
                                                      phase:(NSString *)phase
-                                             parentContext:(BugsnagPerformanceSpan *)parentContext
+                                             parentContext:(BugsnagPerformanceSpanContext *)parentContext
   NS_SWIFT_NAME(startViewLoadPhaseSpan(name:phase:parentContext:));
 
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
@@ -5,28 +5,20 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
-#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef union {
-    __uint128_t value;
-    struct {
-        uint64_t lo;
-        uint64_t hi;
-    };
-} TraceId;
-
-typedef uint64_t SpanId;
-
 OBJC_EXPORT
-@interface BugsnagPerformanceSpan : NSObject
+@interface BugsnagPerformanceSpan : BugsnagPerformanceSpanContext
 
-@property(nonatomic,readonly) TraceId traceId;
-@property(nonatomic,readonly) SpanId spanId;
 @property(nonatomic,readonly) BOOL isValid;
 
 - (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype) initWithTraceId:(TraceId)traceId spanId:(SpanId)spanId NS_UNAVAILABLE;
+
+- (instancetype) initWithTraceIdHi:(uint64_t)traceIdHi traceIdLo:(uint64_t)traceIdLo spanId:(SpanId)spanId NS_UNAVAILABLE;
 
 - (void)abortIfOpen;
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
@@ -1,0 +1,35 @@
+//
+//  BugsnagPerformanceSpanContext.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 01.07.24.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef union {
+    __uint128_t value;
+    struct {
+        uint64_t lo;
+        uint64_t hi;
+    };
+} TraceId;
+
+typedef uint64_t SpanId;
+
+OBJC_EXPORT
+@interface BugsnagPerformanceSpanContext : NSObject
+
+@property(nonatomic,readonly) TraceId traceId;
+@property(nonatomic,readonly) SpanId spanId;
+
+- (instancetype) initWithTraceId:(TraceId)traceId spanId:(SpanId)spanId;
+
+- (instancetype) initWithTraceIdHi:(uint64_t)traceIdHi traceIdLo:(uint64_t)traceIdLo spanId:(SpanId)spanId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -6,6 +6,8 @@
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+
 typedef NS_ENUM(uint8_t, BSGFirstClass) {
     BSGFirstClassNo = 0,
     BSGFirstClassYes = 1,
@@ -20,7 +22,7 @@ OBJC_EXPORT
 @property(nonatomic, readonly) NSDate * _Nullable startTime;
 
 // The context that this span is to be a child of, or nil if this will be a top-level span.
-@property(nonatomic, readonly) BugsnagPerformanceSpan * _Nullable parentContext;
+@property(nonatomic, readonly) BugsnagPerformanceSpanContext * _Nullable parentContext;
 
 // If true, the span will be added to the current context stack.
 @property(nonatomic, readonly) BOOL makeCurrentContext;
@@ -30,7 +32,7 @@ OBJC_EXPORT
 
 
 - (instancetype _Nonnull)setStartTime:(NSDate * _Nullable)startTime;
-- (instancetype _Nonnull)setParentContext:(BugsnagPerformanceSpan * _Nullable)parentContext;
+- (instancetype _Nonnull)setParentContext:(BugsnagPerformanceSpanContext * _Nullable)parentContext;
 - (instancetype _Nonnull)setMakeCurrentContext:(BOOL)makeCurrentContext;
 - (instancetype _Nonnull)setFirstClass:(BSGFirstClass)firstClass;
 

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -214,6 +214,24 @@ Feature: Manual creation of spans
     # Note: The child span ends up first in the list of spans.
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" matches the regex "^[A-Fa-f0-9]{16}$"
 
+  Scenario: Manually start and end child span with a manually defined parent
+    Given I run "ManualParentSpanScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.cocoaperformance"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+    * a span field "name" equals "SpanChild"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" equals "123456789abcdef0fedcba9876543210"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    # Note: The child span ends up first in the list of spans.
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals "23456789abcdef01"
+
   Scenario: Manually start and end first-class = yes span
     Given I run "FirstClassYesScenario"
     And I wait for 1 span

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC628E1D5A400D1F239 /* Fixture.swift */; };
 		0921F02E2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */; };
 		09301DC12B63A65A000A7C12 /* ComplexViewScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */; };
+		093EE63D2C32E5B900632B30 /* ManualParentSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */; };
 		09637A3C2B0607F300F4F776 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A3B2B0607F300F4F776 /* Logging.swift */; };
 		09637A3F2B06082200F4F776 /* Logging.m in Sources */ = {isa = PBXBuildFile; fileRef = 09637A3E2B06082200F4F776 /* Logging.m */; };
 		09637A412B060E7C00F4F776 /* CommandReaderThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A402B060E7C00F4F776 /* CommandReaderThread.swift */; };
@@ -88,6 +89,7 @@
 		01FE4DC628E1D5A400D1F239 /* Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
 		0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkCallbackScenario.swift; sourceTree = "<group>"; };
 		09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplexViewScenario.swift; sourceTree = "<group>"; };
+		093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualParentSpanScenario.swift; sourceTree = "<group>"; };
 		09637A3B2B0607F300F4F776 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		09637A3D2B06082200F4F776 /* Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Logging.h; sourceTree = "<group>"; };
 		09637A3E2B06082200F4F776 /* Logging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Logging.m; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 				96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */,
 				CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */,
 				09D59E162BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift */,
+				093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
 				CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */,
@@ -356,6 +359,7 @@
 				09D59E1D2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */,
+				093EE63D2C32E5B900632B30 /* ManualParentSpanScenario.swift in Sources */,
 				01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */,
 				096EE5EF2B3C2B3E006059CE /* AutoInstrumentSwiftUIDeferredScenario.swift in Sources */,
 				CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/ManualParentSpanScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualParentSpanScenario.swift
@@ -1,0 +1,26 @@
+//
+//  ManualParentSpanScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 01.07.24.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class ManualParentSpanScenario: Scenario {
+
+    override func configure() {
+        super.configure()
+        config.internal.autoTriggerExportOnBatchSize = 1;
+    }
+
+    override func run() {
+        let opts = BugsnagPerformanceSpanOptions()
+        opts.setParentContext(BugsnagPerformanceSpanContext(traceIdHi: 0x123456789abcdef0,
+                                                    traceIdLo: 0xfedcba9876543210,
+                                                    spanId: 0x23456789abcdef01))
+        let spanChild = BugsnagPerformance.startSpan(name: "SpanChild", options: opts)
+        spanChild.end()
+    }
+}


### PR DESCRIPTION
## Goal

Setting the parent ID of a span required an existing Bugsnag span, which made it impossible to receive a span from an outside source and make it a parent of a Bugsnag span.

## Design

`BugsnagPerformanceSpan` has been made a subclass of `BugsnagPerformanceSpanContext`, and the APIs relating to span parentage have been updated to take a `BugsnagPerformanceSpanContext` (or subclass) instead.

The API changes will not break existing usage since it's technically more permissive than before.

## Testing

Added a new e2e test.
