### PR TITLE
Verify network callback pointer

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		096CBC172B1752F700534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096CBC152B1752F100534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift */; };
 		09856B9E2B9606A500620907 /* BugsnagPerformanceSwiftUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094FA7422B10EDE700112ED4 /* BugsnagPerformanceSwiftUITests.swift */; };
 		0986B7C02B287C9D00BD2CA3 /* WeakSpansList.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0986B7BF2B287C9D00BD2CA3 /* WeakSpansList.mm */; };
+		0987F2792C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 0987F2772C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0987F27A2C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0987F2782C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm */; };
 		09B473072B23087D0024CF11 /* WeakSpansList.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B473052B23087D0024CF11 /* WeakSpansList.h */; };
 		09B4730A2B2313570024CF11 /* WeakSpansListTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09B473092B2313570024CF11 /* WeakSpansListTests.mm */; };
 		09D59E1A2BDFE0D900199E1B /* NetworkHeaderInjector.h in Headers */ = {isa = PBXBuildFile; fileRef = 09D59E182BDFE0D900199E1B /* NetworkHeaderInjector.h */; };
@@ -294,6 +296,8 @@
 		09509B742ADFE9A900A358EC /* TracerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TracerTests.mm; sourceTree = "<group>"; };
 		096CBC152B1752F100534F0C /* BugsnagPerformanceSwiftUIInstrumentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BugsnagPerformanceSwiftUIInstrumentation.swift; sourceTree = "<group>"; };
 		0986B7BF2B287C9D00BD2CA3 /* WeakSpansList.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WeakSpansList.mm; sourceTree = "<group>"; };
+		0987F2772C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanContext.h; sourceTree = "<group>"; };
+		0987F2782C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceSpanContext.mm; sourceTree = "<group>"; };
 		09B473052B23087D0024CF11 /* WeakSpansList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WeakSpansList.h; sourceTree = "<group>"; };
 		09B473092B2313570024CF11 /* WeakSpansListTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WeakSpansListTests.mm; sourceTree = "<group>"; };
 		09D59E182BDFE0D900199E1B /* NetworkHeaderInjector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkHeaderInjector.h; sourceTree = "<group>"; };
@@ -496,9 +500,10 @@
 				CB0AD76929657381002A3FB6 /* BugsnagPerformanceErrors.h */,
 				0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */,
 				0122C21729019770002D243C /* BugsnagPerformanceSpan.h */,
+				0987F2772C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h */,
 				CB7FD92F299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h */,
-				0122C21829019770002D243C /* BugsnagPerformanceViewType.h */,
 				960EECF22B24C89A009FAA11 /* BugsnagPerformanceTrackedViewContainer.h */,
+				0122C21829019770002D243C /* BugsnagPerformanceViewType.h */,
 			);
 			path = BugsnagPerformance;
 			sourceTree = "<group>";
@@ -511,6 +516,7 @@
 				CB0AD7672965734F002A3FB6 /* BugsnagPerformanceErrors.m */,
 				0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */,
 				0122C21E29019770002D243C /* BugsnagPerformanceSpan.mm */,
+				0987F2782C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm */,
 				CB7FD931299D2F7700499E13 /* BugsnagPerformanceSpanOptions.m */,
 			);
 			path = Public;
@@ -807,6 +813,7 @@
 				96D55C832A1EBA35006D1F29 /* SpanActivityState.h in Headers */,
 				CBE0873329FA984C007455F2 /* BugsnagPerformanceViewType+Private.h in Headers */,
 				CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */,
+				0987F2792C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h in Headers */,
 				CBEC51C0296DB312009C0CE3 /* JSON.h in Headers */,
 				09B473072B23087D0024CF11 /* WeakSpansList.h in Headers */,
 				0921F02B2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h in Headers */,
@@ -1181,6 +1188,7 @@
 				CB572EAB29BB783200FD7A2A /* AppStateTracker.m in Sources */,
 				CBE8EA17294B528100702950 /* BugsnagPerformanceImpl.mm in Sources */,
 				0122C23E29019770002D243C /* BugsnagPerformanceSpan.mm in Sources */,
+				0987F27A2C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm in Sources */,
 				CBEC51DD2976F1F9009C0CE3 /* RetryQueue.mm in Sources */,
 				01A414CE2913C0F0003152A4 /* SpanAttributes.mm in Sources */,
 				CB34771E29068C350033759C /* NSURLSession+Instrumentation.mm in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Span parentage APIs now require a BugsnagPerformanceSpanContext, which BugsnagPerformanceSpan is now a subclass of. You no longer need to assign a Bugsnag span as a parent. [280](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/280)
+
 ## 1.6.1 (2024-06-24)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## TBD
 
+### Bug fixes
+
+* Handle case where the user manually sets the network callback to nil. [281](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/281)
+
 ### Enhancements
 
 * Span parentage APIs now require a BugsnagPerformanceSpanContext, which BugsnagPerformanceSpan is now a subclass of. You no longer need to assign a Bugsnag span as a parent. [280](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/280)

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -53,7 +53,7 @@ public:
                                               BugsnagPerformanceSpanOptions *options) noexcept;
 
     BugsnagPerformanceSpan *startViewLoadPhaseSpan(NSString *className, NSString *phase,
-                                                   BugsnagPerformanceSpan *parentContext) noexcept;
+                                                   BugsnagPerformanceSpanContext *parentContext) noexcept;
 
     void startViewLoadSpan(UIViewController *controller, BugsnagPerformanceSpanOptions *options) noexcept;
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -455,7 +455,7 @@ void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, Bug
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadPhaseSpan(NSString *className, NSString *phase,
-                                                                       BugsnagPerformanceSpan *parentContext) noexcept {
+                                                                       BugsnagPerformanceSpanContext *parentContext) noexcept {
     auto span = tracer_->startViewLoadPhaseSpan(className, phase, parentContext);
     [span addAttributes:spanAttributesProvider_->viewLoadPhaseSpanAttributes(className, phase)];
     return span;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.h
@@ -50,7 +50,7 @@ private:
     NSMutableArray<BugsnagPerformanceSpan *> * _Nullable earlySpans_;
     NSSet<NSRegularExpression *> * _Nullable propagateTraceParentToUrlsMatching_;
     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector_;
-    BugsnagPerformanceNetworkRequestCallback networkRequestCallback_;
+    BugsnagPerformanceNetworkRequestCallback networkRequestCallback_{nil};
 };
 }
 

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -14,7 +14,7 @@ namespace bugsnag {
 
 class SpanOptions {
 public:
-    SpanOptions(BugsnagPerformanceSpan *parentContext,
+    SpanOptions(BugsnagPerformanceSpanContext *parentContext,
                 CFAbsoluteTime startTime,
                 bool makeCurrentContext,
                 BSGFirstClass firstClass)
@@ -39,7 +39,7 @@ public:
                   BSGFirstClassUnset)
     {}
     
-    BugsnagPerformanceSpan *parentContext{nil};
+    BugsnagPerformanceSpanContext *parentContext{nil};
     CFAbsoluteTime startTime{CFABSOLUTETIME_INVALID};
     bool makeCurrentContext{false};
     BSGFirstClass firstClass{BSGFirstClassUnset};

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -55,7 +55,7 @@ public:
 
     BugsnagPerformanceSpan *startViewLoadPhaseSpan(NSString *className,
                                                    NSString *phase,
-                                                   BugsnagPerformanceSpan *parentContext) noexcept;
+                                                   BugsnagPerformanceSpanContext *parentContext) noexcept;
 
     void cancelQueuedSpan(BugsnagPerformanceSpan *span) noexcept;
 

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -149,7 +149,7 @@ Tracer::startNetworkSpan(NSString *httpMethod, SpanOptions options) noexcept {
 BugsnagPerformanceSpan *
 Tracer::startViewLoadPhaseSpan(NSString *className,
                                NSString *phase,
-                               BugsnagPerformanceSpan *parentContext) noexcept {
+                               BugsnagPerformanceSpanContext *parentContext) noexcept {
     NSString *name = [NSString stringWithFormat:@"[ViewLoadPhase/%@]/%@", phase, className];
     SpanOptions options;
     options.parentContext = parentContext;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -44,7 +44,7 @@ using namespace bugsnag;
 
 + (BugsnagPerformanceSpan *)startViewLoadPhaseSpanWithName:(NSString *)name
                                                      phase:(NSString *)phase
-                                             parentContext:(BugsnagPerformanceSpan *)parentContext {
+                                             parentContext:(BugsnagPerformanceSpanContext *)parentContext {
     return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startViewLoadPhaseSpan(name, phase, parentContext);
 }
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanContext.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanContext.mm
@@ -1,0 +1,25 @@
+//
+//  BugsnagPerformanceSpanContext.mm
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 01.07.24.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+
+@implementation BugsnagPerformanceSpanContext
+
+- (instancetype) initWithTraceId:(TraceId) traceId spanId:(SpanId) spanId {
+    if ((self = [super init])) {
+        _traceId = traceId;
+        _spanId = spanId;
+    }
+    return self;
+}
+
+- (instancetype) initWithTraceIdHi:(uint64_t)traceIdHi traceIdLo:(uint64_t)traceIdLo spanId:(SpanId)spanId {
+    return [self initWithTraceId:TraceId{.hi=traceIdHi, .lo=traceIdLo} spanId:spanId];
+}
+
+@end

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -7,12 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 
 @interface BugsnagPerformanceSpanOptions()
 @property(nonatomic,strong) NSDate *startTime_;
-@property(nonatomic,strong) BugsnagPerformanceSpan *parentContext_;
+@property(nonatomic,strong) BugsnagPerformanceSpanContext *parentContext_;
 @property(nonatomic) BOOL makeCurrentContext_;
 @property(nonatomic) BSGFirstClass firstClass_;
 @end
@@ -33,7 +33,7 @@
 }
 
 - (instancetype)initWithStartTime:(NSDate *)startTime
-                    parentContext:(BugsnagPerformanceSpan *)parentContext
+                    parentContext:(BugsnagPerformanceSpanContext *)parentContext
                makeCurrentContext:(BOOL)makeCurrentContext
                        firstClass:(BSGFirstClass)firstClass {
     if ((self = [super init])) {
@@ -50,7 +50,7 @@
     return _startTime;
 }
 
-- (BugsnagPerformanceSpan *)parentContext {
+- (BugsnagPerformanceSpanContext *)parentContext {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     return _parentContext;
 }
@@ -71,7 +71,7 @@
     return self;
 }
 
-- (instancetype)setParentContext:(BugsnagPerformanceSpan *)parentContext {
+- (instancetype)setParentContext:(BugsnagPerformanceSpanContext *)parentContext {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     _parentContext = parentContext;
     return self;

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -8,6 +8,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceErrors.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
 #import <BugsnagPerformance/BugsnagPerformanceNetworkRequestInfo.h>
@@ -53,7 +54,7 @@ OBJC_EXPORT
 
 + (BugsnagPerformanceSpan *)startViewLoadPhaseSpanWithName:(NSString *)name
                                                      phase:(NSString *)phase
-                                             parentContext:(BugsnagPerformanceSpan *)parentContext
+                                             parentContext:(BugsnagPerformanceSpanContext *)parentContext
   NS_SWIFT_NAME(startViewLoadPhaseSpan(name:phase:parentContext:));
 
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
@@ -5,28 +5,20 @@
 //  Created by Nick Dowell on 23/09/2022.
 //
 
-#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef union {
-    __uint128_t value;
-    struct {
-        uint64_t lo;
-        uint64_t hi;
-    };
-} TraceId;
-
-typedef uint64_t SpanId;
-
 OBJC_EXPORT
-@interface BugsnagPerformanceSpan : NSObject
+@interface BugsnagPerformanceSpan : BugsnagPerformanceSpanContext
 
-@property(nonatomic,readonly) TraceId traceId;
-@property(nonatomic,readonly) SpanId spanId;
 @property(nonatomic,readonly) BOOL isValid;
 
 - (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype) initWithTraceId:(TraceId)traceId spanId:(SpanId)spanId NS_UNAVAILABLE;
+
+- (instancetype) initWithTraceIdHi:(uint64_t)traceIdHi traceIdLo:(uint64_t)traceIdLo spanId:(SpanId)spanId NS_UNAVAILABLE;
 
 - (void)abortIfOpen;
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
@@ -1,0 +1,35 @@
+//
+//  BugsnagPerformanceSpanContext.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 01.07.24.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef union {
+    __uint128_t value;
+    struct {
+        uint64_t lo;
+        uint64_t hi;
+    };
+} TraceId;
+
+typedef uint64_t SpanId;
+
+OBJC_EXPORT
+@interface BugsnagPerformanceSpanContext : NSObject
+
+@property(nonatomic,readonly) TraceId traceId;
+@property(nonatomic,readonly) SpanId spanId;
+
+- (instancetype) initWithTraceId:(TraceId)traceId spanId:(SpanId)spanId;
+
+- (instancetype) initWithTraceIdHi:(uint64_t)traceIdHi traceIdLo:(uint64_t)traceIdLo spanId:(SpanId)spanId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -6,6 +6,8 @@
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+
 typedef NS_ENUM(uint8_t, BSGFirstClass) {
     BSGFirstClassNo = 0,
     BSGFirstClassYes = 1,
@@ -20,7 +22,7 @@ OBJC_EXPORT
 @property(nonatomic, readonly) NSDate * _Nullable startTime;
 
 // The context that this span is to be a child of, or nil if this will be a top-level span.
-@property(nonatomic, readonly) BugsnagPerformanceSpan * _Nullable parentContext;
+@property(nonatomic, readonly) BugsnagPerformanceSpanContext * _Nullable parentContext;
 
 // If true, the span will be added to the current context stack.
 @property(nonatomic, readonly) BOOL makeCurrentContext;
@@ -30,7 +32,7 @@ OBJC_EXPORT
 
 
 - (instancetype _Nonnull)setStartTime:(NSDate * _Nullable)startTime;
-- (instancetype _Nonnull)setParentContext:(BugsnagPerformanceSpan * _Nullable)parentContext;
+- (instancetype _Nonnull)setParentContext:(BugsnagPerformanceSpanContext * _Nullable)parentContext;
 - (instancetype _Nonnull)setMakeCurrentContext:(BOOL)makeCurrentContext;
 - (instancetype _Nonnull)setFirstClass:(BSGFirstClass)firstClass;
 

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -214,6 +214,24 @@ Feature: Manual creation of spans
     # Note: The child span ends up first in the list of spans.
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" matches the regex "^[A-Fa-f0-9]{16}$"
 
+  Scenario: Manually start and end child span with a manually defined parent
+    Given I run "ManualParentSpanScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.cocoaperformance"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+    * a span field "name" equals "SpanChild"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" equals "123456789abcdef0fedcba9876543210"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    # Note: The child span ends up first in the list of spans.
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals "23456789abcdef01"
+
   Scenario: Manually start and end first-class = yes span
     Given I run "FirstClassYesScenario"
     And I wait for 1 span

--- a/features/default/network.feature
+++ b/features/default/network.feature
@@ -14,6 +14,20 @@ Feature: Automatic instrumentation spans
     * a span string attribute "http.url" equals "https://bugsnag.com"
     * a span string attribute "http.url" equals "https://bugsnag.com/changed"
 
+  Scenario: AutoInstrumentNullNetworkCallbackScenario
+    Given I run "AutoInstrumentNullNetworkCallbackScenario"
+    # Wait for our request plus the mazerunner requests
+    And I wait for 3 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "[HTTP/GET]"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "http.url" equals "https://bugsnag.com"
+
   Scenario: ManualNetworkCallbackScenario
     Given I run "ManualNetworkCallbackScenario"
     And I wait for exactly 2 spans

--- a/features/default/network.feature
+++ b/features/default/network.feature
@@ -16,8 +16,10 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentNullNetworkCallbackScenario
     Given I run "AutoInstrumentNullNetworkCallbackScenario"
-    # Wait for our request plus the mazerunner requests
-    And I wait for 3 spans
+    # Wait for a long time because there can be a LOT of maze-runner related URL requests before the scenario starts.
+    And I wait for 20 seconds
+    # There will actually be any number of requests by this point since we're not filtering at all.
+    And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[HTTP/GET]"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		09637A432B0617FE00F4F776 /* MazeRunnerCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A422B0617FE00F4F776 /* MazeRunnerCommand.swift */; };
 		09637A452B0B883B00F4F776 /* FixtureConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A442B0B883B00F4F776 /* FixtureConfig.swift */; };
 		096EE5EF2B3C2B3E006059CE /* AutoInstrumentSwiftUIDeferredScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096EE5EE2B3C2B3E006059CE /* AutoInstrumentSwiftUIDeferredScenario.swift */; };
+		097FFC0B2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097FFC0A2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift */; };
 		0983A1792B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0983A1782B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift */; };
 		0983A17B2B14BB2000DDF4FF /* BugsnagPerformanceSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0983A17A2B14BB2000DDF4FF /* BugsnagPerformanceSwift */; };
 		098808E02B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */; };
@@ -97,6 +98,7 @@
 		09637A422B0617FE00F4F776 /* MazeRunnerCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MazeRunnerCommand.swift; sourceTree = "<group>"; };
 		09637A442B0B883B00F4F776 /* FixtureConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixtureConfig.swift; sourceTree = "<group>"; };
 		096EE5EE2B3C2B3E006059CE /* AutoInstrumentSwiftUIDeferredScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentSwiftUIDeferredScenario.swift; sourceTree = "<group>"; };
+		097FFC0A2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNullNetworkCallbackScenario.swift; sourceTree = "<group>"; };
 		0983A1782B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentSwiftUIScenario.swift; sourceTree = "<group>"; };
 		098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualViewLoadPhaseScenario.swift; sourceTree = "<group>"; };
 		099331FB2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentAVAssetScenario.swift; sourceTree = "<group>"; };
@@ -221,6 +223,7 @@
 				09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */,
 				09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
+				097FFC0A2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift */,
 				96284DCD2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift */,
 				CBC90CE329D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift */,
 				096EE5EE2B3C2B3E006059CE /* AutoInstrumentSwiftUIDeferredScenario.swift */,
@@ -372,6 +375,7 @@
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
 				099331FC2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift in Sources */,
+				097FFC0B2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift in Sources */,
 				01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */,
 				960EECE92B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift in Sources */,
 				0983A1792B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift in Sources */,

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC628E1D5A400D1F239 /* Fixture.swift */; };
 		0921F02E2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */; };
 		09301DC12B63A65A000A7C12 /* ComplexViewScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */; };
+		093EE63D2C32E5B900632B30 /* ManualParentSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */; };
 		09637A3C2B0607F300F4F776 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A3B2B0607F300F4F776 /* Logging.swift */; };
 		09637A3F2B06082200F4F776 /* Logging.m in Sources */ = {isa = PBXBuildFile; fileRef = 09637A3E2B06082200F4F776 /* Logging.m */; };
 		09637A412B060E7C00F4F776 /* CommandReaderThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A402B060E7C00F4F776 /* CommandReaderThread.swift */; };
@@ -88,6 +89,7 @@
 		01FE4DC628E1D5A400D1F239 /* Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
 		0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkCallbackScenario.swift; sourceTree = "<group>"; };
 		09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplexViewScenario.swift; sourceTree = "<group>"; };
+		093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualParentSpanScenario.swift; sourceTree = "<group>"; };
 		09637A3B2B0607F300F4F776 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		09637A3D2B06082200F4F776 /* Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Logging.h; sourceTree = "<group>"; };
 		09637A3E2B06082200F4F776 /* Logging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Logging.m; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 				96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */,
 				CBE6B66A28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift */,
 				09D59E162BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift */,
+				093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
 				CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */,
@@ -356,6 +359,7 @@
 				09D59E1D2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */,
+				093EE63D2C32E5B900632B30 /* ManualParentSpanScenario.swift in Sources */,
 				01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */,
 				096EE5EF2B3C2B3E006059CE /* AutoInstrumentSwiftUIDeferredScenario.swift in Sources */,
 				CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNullNetworkCallbackScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNullNetworkCallbackScenario.swift
@@ -1,0 +1,31 @@
+//
+//  AutoInstrumentNullNetworkCallbackScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 02.07.24.
+//
+
+import Foundation
+
+@objcMembers
+class AutoInstrumentNullNetworkCallbackScenario: Scenario {
+
+    override func configure() {
+        super.configure()
+        config.autoInstrumentNetworkRequests = true
+        config.networkRequestCallback = nil
+    }
+
+    func query(url: URL) {
+        let task = URLSession.shared.dataTask(with: url) {(data, response, error) in
+        }
+        task.resume()
+
+    }
+
+    override func run() {
+        // Force the automatic spans to be sent in a separate trace that we will discard
+        waitForCurrentBatch()
+        query(url: URL(string: "https://bugsnag.com")!)
+    }
+}

--- a/features/fixtures/ios/Scenarios/ManualParentSpanScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualParentSpanScenario.swift
@@ -1,0 +1,26 @@
+//
+//  ManualParentSpanScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 01.07.24.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class ManualParentSpanScenario: Scenario {
+
+    override func configure() {
+        super.configure()
+        config.internal.autoTriggerExportOnBatchSize = 1;
+    }
+
+    override func run() {
+        let opts = BugsnagPerformanceSpanOptions()
+        opts.setParentContext(BugsnagPerformanceSpanContext(traceIdHi: 0x123456789abcdef0,
+                                                    traceIdLo: 0xfedcba9876543210,
+                                                    spanId: 0x23456789abcdef01))
+        let spanChild = BugsnagPerformance.startSpan(name: "SpanChild", options: opts)
+        spanChild.end()
+    }
+}


### PR DESCRIPTION
## Goal

If the user manually sets the network callback to nil, it could crash the app.

I've also added more logging to help diagnose a networking issue on a customer site.

## Design

Don't set a default implementation, and always check the callback pointer no matter what.

## Testing

New e2e test