### PR TITLE
Expose span.setAttribute

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -444,14 +444,14 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name, Bugsna
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *className, BugsnagPerformanceViewType viewType) noexcept {
     SpanOptions options;
     auto span = tracer_->startViewLoadSpan(viewType, className, options);
-    [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
+    [span setAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
     return span;
 }
 
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *className, BugsnagPerformanceViewType viewType, BugsnagPerformanceSpanOptions *optionsIn) noexcept {
     auto options = SpanOptions(optionsIn);
     auto span = tracer_->startViewLoadSpan(viewType, className, options);
-    [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
+    [span setAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
     return span;
 }
 
@@ -460,7 +460,7 @@ void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, Bug
     auto viewType = BugsnagPerformanceViewTypeUIKit;
     auto className = [NSString stringWithUTF8String:object_getClassName(controller)];
     auto span = tracer_->startViewLoadSpan(viewType, className, options);
-    [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
+    [span setAttributes:spanAttributesProvider_->viewLoadSpanAttributes(className, viewType)];
 
     std::lock_guard<std::mutex> guard(viewControllersToSpansMutex_);
     [viewControllersToSpans_ setObject:span forKey:controller];
@@ -469,7 +469,7 @@ void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, Bug
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadPhaseSpan(NSString *className, NSString *phase,
                                                                        BugsnagPerformanceSpanContext *parentContext) noexcept {
     auto span = tracer_->startViewLoadPhaseSpan(className, phase, parentContext);
-    [span addAttributes:spanAttributesProvider_->viewLoadPhaseSpanAttributes(className, phase)];
+    [span setAttributes:spanAttributesProvider_->viewLoadPhaseSpanAttributes(className, phase)];
     return span;
 }
 
@@ -513,7 +513,7 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
         options.makeCurrentContext = false;
         options.startTime = dateToAbsoluteTime(interval.startDate);
         span = tracer_->startNetworkSpan(name, options);
-        [span addAttributes:spanAttributesProvider_->networkSpanAttributes(info.url, task, metrics, errorFromGetRequest)];
+        [span setAttributes:spanAttributesProvider_->networkSpanAttributes(info.url, task, metrics, errorFromGetRequest)];
         [span endWithEndTime:interval.endDate];
     }
 }

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -25,9 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSpan:(std::shared_ptr<bugsnag::Span>)span NS_DESIGNATED_INITIALIZER;
 
-- (void)addAttribute:(NSString *)attributeName withValue:(id)value;
-
-- (void)addAttributes:(NSDictionary *)attributes;
+- (void)setAttributes:(NSDictionary *)attributes;
 
 - (BOOL)hasAttribute:(NSString *)attributeName withValue:(id)value;
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -194,7 +194,7 @@ AppStartupInstrumentation::beginAppStartSpan() noexcept {
     SpanOptions options;
     options.startTime = didStartProcessAtTime_;
     appStartSpan_ = tracer_->startAppStartSpan(name, options);
-    [appStartSpan_ addAttributes:spanAttributesProvider_->appStartSpanAttributes(firstViewName_, isColdLaunch_)];
+    [appStartSpan_ setAttributes:spanAttributesProvider_->appStartSpanAttributes(firstViewName_, isColdLaunch_)];
 }
 
 void
@@ -211,7 +211,7 @@ AppStartupInstrumentation::beginPreMainSpan() noexcept {
     options.startTime = didStartProcessAtTime_;
     options.parentContext = appStartSpan_;
     preMainSpan_ = tracer_->startAppStartSpan(name, options);
-    [preMainSpan_ addAttributes:spanAttributesProvider_->appStartPhaseSpanAttributes(@"App launching - pre main()")];
+    [preMainSpan_ setAttributes:spanAttributesProvider_->appStartPhaseSpanAttributes(@"App launching - pre main()")];
 }
 
 void
@@ -228,7 +228,7 @@ AppStartupInstrumentation::beginPostMainSpan() noexcept {
     options.startTime = didCallMainFunctionAtTime_;
     options.parentContext = appStartSpan_;
     postMainSpan_ = tracer_->startAppStartSpan(name, options);
-    [postMainSpan_ addAttributes:spanAttributesProvider_->appStartPhaseSpanAttributes(@"App launching - post main()")];
+    [postMainSpan_ setAttributes:spanAttributesProvider_->appStartPhaseSpanAttributes(@"App launching - post main()")];
 }
 
 void
@@ -245,7 +245,7 @@ AppStartupInstrumentation::beginUIInitSpan() noexcept {
     options.startTime = didFinishLaunchingAtTime_;
     options.parentContext = appStartSpan_;
     uiInitSpan_ = tracer_->startAppStartSpan(name, options);
-    [uiInitSpan_ addAttributes:spanAttributesProvider_->appStartPhaseSpanAttributes(@"UI init")];
+    [uiInitSpan_ setAttributes:spanAttributesProvider_->appStartPhaseSpanAttributes(@"UI init")];
 }
 
 #pragma mark -

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
@@ -97,7 +97,7 @@ API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0)) {
     BSGLogTrace(@"NetworkInstrumentation.URLSession:task:didFinishCollectingMetrics for %@: Ending span with time %@", request.URL, metrics.taskInterval.endDate);
 
     objc_setAssociatedObject(self, associatedNetworkSpanKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    [span addAttributes:self.spanAttributesProvider->networkSpanAttributes(nil, task, metrics, errorFromGetRequest)];
+    [span setAttributes:self.spanAttributesProvider->networkSpanAttributes(nil, task, metrics, errorFromGetRequest)];
     [span endWithEndTime:metrics.taskInterval.endDate];
 }
 
@@ -199,7 +199,7 @@ void NetworkInstrumentation::endEarlySpansPhase() noexcept {
             BSGLogTrace(@"NetworkInstrumentation::endEarlySpansPhase: info.url is nil, so we will end on destroy");
             [span endOnDestroy];
         } else {
-            [span addAttributes:spanAttributesProvider_->networkSpanUrlAttributes(info.url, nil)];
+            [span setAttributes:spanAttributesProvider_->networkSpanUrlAttributes(info.url, nil)];
         }
     }
 }
@@ -260,7 +260,7 @@ void NetworkInstrumentation::NSURLSessionTask_resume(NSURLSessionTask *task) noe
             BSGLogTrace(@"NetworkInstrumentation::NSURLSessionTask_resume: info.url is nil, so we will end on destroy");
             [span endOnDestroy];
         } else {
-            [span addAttributes:spanAttributesProvider_->networkSpanUrlAttributes(info.url, errorFromGetRequest)];
+            [span setAttributes:spanAttributesProvider_->networkSpanUrlAttributes(info.url, errorFromGetRequest)];
         }
         if (span != nil) {
             objc_setAssociatedObject(task, associatedNetworkSpanKey, span,

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -146,7 +146,7 @@ ViewLoadInstrumentation::onLoadView(UIViewController *viewController) noexcept {
     auto name = nameForViewController(viewController);
     SpanOptions options;
     auto span = tracer_->startViewLoadSpan(viewType, name, options);
-    [span addAttributes:spanAttributesProvider_->viewLoadSpanAttributes(name, viewType)];
+    [span setAttributes:spanAttributesProvider_->viewLoadSpanAttributes(name, viewType)];
 
     if (isEarlySpanPhase_) {
         markEarlySpan(span);
@@ -221,7 +221,7 @@ void ViewLoadInstrumentation::adjustSpanIfPreloaded(BugsnagPerformanceSpan *span
         auto className = NSStringFromClass([viewController class]);
         [span updateName: [NSString stringWithFormat:@"%@ (pre-loaded)", span.name]];
         [span updateStartTime: viewWillAppearStartTime];
-        [span addAttributes:spanAttributesProvider_->preloadedViewLoadSpanAttributes(className, viewType)];
+        [span setAttributes:spanAttributesProvider_->preloadedViewLoadSpanAttributes(className, viewType)];
         instrumentationState.isMarkedAsPreloaded = true;
     }
 }
@@ -322,7 +322,7 @@ ViewLoadInstrumentation::startViewLoadPhaseSpan(UIViewController *viewController
     }
     auto name = nameForViewController(viewController);
     auto span = tracer_->startViewLoadPhaseSpan(name, phase, getOverallSpan(viewController));
-    [span addAttributes:spanAttributesProvider_->viewLoadPhaseSpanAttributes(name, phase)];
+    [span setAttributes:spanAttributesProvider_->viewLoadPhaseSpanAttributes(name, phase)];
 
     if (isEarlySpanPhase_) {
         markEarlySpan(span);

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -165,13 +165,15 @@ OtlpTraceEncoding::encode(NSDictionary *attributes) noexcept {
         id value = attributes[key];
         if ([value isKindOfClass:[NSString class]]) {
             [result addObject:@{@"key": key, @"value": @{@"stringValue": value}}];
+            continue;
         }
         if ([value isKindOfClass:[NSNumber class]]) {
             auto typeId = CFGetTypeID((__bridge CFTypeRef)value);
             if (typeId == CFBooleanGetTypeID()) {
                 [result addObject:@{@"key": key, @"value": @{@"boolValue": value}}];
+                continue;
             }
-            else if (typeId == CFNumberGetTypeID()) {
+            if (typeId == CFNumberGetTypeID()) {
                 auto type = CFNumberGetType((__bridge CFNumberRef)value);
                 switch (type) {
                     case kCFNumberSInt8Type:
@@ -181,7 +183,7 @@ OtlpTraceEncoding::encode(NSDictionary *attributes) noexcept {
                     case kCFNumberShortType:
                     case kCFNumberIntType:
                         [result addObject:@{@"key": key, @"value": @{@"intValue": [value stringValue]}}];
-                        break;
+                        continue;
                         
                     case kCFNumberLongType:
                     case kCFNumberCFIndexType:
@@ -191,7 +193,7 @@ OtlpTraceEncoding::encode(NSDictionary *attributes) noexcept {
                         // "JSON value will be a decimal string. Either numbers or strings are accepted."
                         // https://developers.google.com/protocol-buffers/docs/proto3#json
                         [result addObject:@{@"key": key, @"value": @{@"intValue": [value stringValue]}}];
-                        break;
+                        continue;
                         
                     case kCFNumberFloat32Type:
                     case kCFNumberFloat64Type:
@@ -199,12 +201,13 @@ OtlpTraceEncoding::encode(NSDictionary *attributes) noexcept {
                     case kCFNumberDoubleType:
                     case kCFNumberCGFloatType:
                         [result addObject:@{@"key": key, @"value": @{@"doubleValue": value}}];
-                        break;
+                        continue;
                         
                     default: break;
                 }
             }
         }
+        BSGLogError(@"Could not encode attribute %@ because it is of an unknown type %@", key, NSStringFromClass([value class]));
     }
     return result;
 }

--- a/Sources/BugsnagPerformance/Private/Span.h
+++ b/Sources/BugsnagPerformance/Private/Span.h
@@ -61,16 +61,16 @@ public:
         }
     }
 
-    void addAttribute(NSString *attributeName, id value) noexcept {
-        data_->addAttribute(attributeName, value);
+    void setAttribute(NSString *attributeName, id value) noexcept {
+        data_->setAttribute(attributeName, value);
     }
 
-    void addAttributes(NSDictionary *attributes) noexcept {
+    void setAttributes(NSDictionary *attributes) noexcept {
         // This doesn't have to be thread safe because this method is never called
         // after the span is started.
         auto data = data_;
         if (!isEnded_ && data != nullptr) {
-            data->addAttributes(attributes);
+            data->setAttributes(attributes);
         }
     }
 

--- a/Sources/BugsnagPerformance/Private/SpanData.h
+++ b/Sources/BugsnagPerformance/Private/SpanData.h
@@ -29,9 +29,9 @@ public:
     
     SpanData(const SpanData&) = delete;
 
-    void addAttribute(NSString *attributeName, id value) noexcept;
+    void setAttribute(NSString *attributeName, id value) noexcept;
 
-    void addAttributes(NSDictionary *attributes) noexcept;
+    void setAttributes(NSDictionary *attributes) noexcept;
 
     bool hasAttribute(NSString *attributeName, id value) noexcept;
 

--- a/Sources/BugsnagPerformance/Private/SpanData.mm
+++ b/Sources/BugsnagPerformance/Private/SpanData.mm
@@ -31,13 +31,17 @@ SpanData::SpanData(NSString *name,
 }
 
 void
-SpanData::addAttribute(NSString *attributeName, id value) noexcept {
+SpanData::setAttribute(NSString *attributeName, id value) noexcept {
     std::lock_guard<std::mutex> guard(mutex_);
-    this->attributes[attributeName] = value;
+    if(value == nil) {
+        [this->attributes removeObjectForKey:attributeName];
+    } else {
+        this->attributes[attributeName] = value;
+    }
 }
 
 void
-SpanData::addAttributes(NSDictionary *dictionary) noexcept {
+SpanData::setAttributes(NSDictionary *dictionary) noexcept {
     std::lock_guard<std::mutex> guard(mutex_);
     [this->attributes addEntriesFromDictionary:dictionary];
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -95,7 +95,7 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
         BSGLogTrace(@"Tracer::startSpan: Making current context");
         spanStackingHandler_->push(span);
     }
-    [span addAttributes:SpanAttributes::get()];
+    [span setAttributes:SpanAttributes::get()];
     potentiallyOpenSpans_->add(span);
     onSpanStarted_();
     return span;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -85,12 +85,12 @@ using namespace bugsnag;
     return !self.span->isEnded();
 }
 
-- (void)addAttribute:(NSString *)attributeName withValue:(id)value {
-    self.span->addAttribute(attributeName, value);
+- (void)setAttribute:(NSString *)attributeName withValue:(id)value {
+    self.span->setAttribute(attributeName, value);
 }
 
-- (void)addAttributes:(NSDictionary *)attributes {
-    self.span->addAttributes(attributes);
+- (void)setAttributes:(NSDictionary *)attributes {
+    self.span->setAttributes(attributes);
 }
 
 - (BOOL)hasAttribute:(NSString *)attributeName withValue:(id)value {

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpan.h
@@ -28,6 +28,8 @@ OBJC_EXPORT
 
 - (void)endWithEndTime:(NSDate *)endTime NS_SWIFT_NAME(end(endTime:));
 
+- (void)setAttribute:(NSString *)attributeName withValue:(_Nullable id)value;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
@@ -211,7 +211,7 @@ static BugsnagPerformanceSpan *createSpan(std::shared_ptr<SpanStackingHandler> h
 - (void)testHasSpanWithAttributeShouldReturnTrueWhenThereIsOneSpanWithTheAttribute {
     auto handler = std::make_shared<SpanStackingHandler>();
     BugsnagPerformanceSpan *span = createSpan(handler);
-    [span addAttributes:@{@"testAttribute": @"testValue"}];
+    [span setAttributes:@{@"testAttribute": @"testValue"}];
     handler->push(span);
     XCTAssertTrue(handler->hasSpanWithAttribute(@"testAttribute", @"testValue"));
     
@@ -222,7 +222,7 @@ static BugsnagPerformanceSpan *createSpan(std::shared_ptr<SpanStackingHandler> h
     BugsnagPerformanceSpan *span1 = createSpan(handler);
     BugsnagPerformanceSpan *span2 = createSpan(handler);
     BugsnagPerformanceSpan *span3 = createSpan(handler);
-    [span2 addAttributes:@{@"testAttribute": @"testValue"}];
+    [span2 setAttributes:@{@"testAttribute": @"testValue"}];
     handler->push(span1);
     handler->push(span2);
     handler->push(span3);
@@ -234,7 +234,7 @@ static BugsnagPerformanceSpan *createSpan(std::shared_ptr<SpanStackingHandler> h
     BugsnagPerformanceSpan *span1 = createSpan(handler);
     BugsnagPerformanceSpan *span2 = createSpan(handler);
     BugsnagPerformanceSpan *span3 = createSpan(handler);
-    [span2 addAttributes:@{@"otherTestAttribute": @"testValue"}];
+    [span2 setAttributes:@{@"otherTestAttribute": @"testValue"}];
     handler->push(span1);
     handler->push(span2);
     handler->push(span3);
@@ -246,7 +246,7 @@ static BugsnagPerformanceSpan *createSpan(std::shared_ptr<SpanStackingHandler> h
     BugsnagPerformanceSpan *span1 = createSpan(handler);
     BugsnagPerformanceSpan *span2 = createSpan(handler);
     BugsnagPerformanceSpan *span3 = createSpan(handler);
-    [span2 addAttributes:@{@"testAttribute": @"otherTestValue"}];
+    [span2 setAttributes:@{@"testAttribute": @"otherTestValue"}];
     handler->push(span1);
     handler->push(span2);
     handler->push(span3);
@@ -258,7 +258,7 @@ static BugsnagPerformanceSpan *createSpan(std::shared_ptr<SpanStackingHandler> h
     BugsnagPerformanceSpan *span1 = createSpan(handler);
     BugsnagPerformanceSpan *span2 = createSpan(handler);
     BugsnagPerformanceSpan *span3 = createSpan(handler);
-    [span2 addAttributes:@{@"testAttribute": @"testValue"}];
+    [span2 setAttributes:@{@"testAttribute": @"testValue"}];
     handler->push(span1);
     handler->push(span2);
     handler->push(span3);

--- a/Tests/BugsnagPerformanceTests/SpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanTests.mm
@@ -140,12 +140,42 @@ static std::shared_ptr<Span> spanWithStartTime(CFAbsoluteTime startTime, OnSpanE
     XCTAssertEqual(spanData->endTime, endTime);
 }
 
+- (void)testAddRemoveAttributes {
+    auto span = spanWithStartTime(0, ^(std::shared_ptr<SpanData>) {});
+
+    XCTAssertNil(span->getAttribute(@"a"));
+    span->setAttribute(@"a", @(1));
+    XCTAssertEqualObjects(@(1), span->getAttribute(@"a"));
+
+    XCTAssertNil(span->getAttribute(@"b"));
+    span->setAttribute(@"b", @(2));
+    XCTAssertEqualObjects(@(1), span->getAttribute(@"a"));
+    XCTAssertEqualObjects(@(2), span->getAttribute(@"b"));
+
+    span->setAttribute(@"a", @(2));
+    XCTAssertEqualObjects(@(2), span->getAttribute(@"a"));
+    XCTAssertEqualObjects(@(2), span->getAttribute(@"b"));
+
+    span->setAttribute(@"a", nil);
+    XCTAssertNil(span->getAttribute(@"a"));
+    XCTAssertEqualObjects(@(2), span->getAttribute(@"b"));
+
+    span->setAttribute(@"a", @(100));
+    XCTAssertEqualObjects(@(100), span->getAttribute(@"a"));
+    XCTAssertEqualObjects(@(2), span->getAttribute(@"b"));
+
+    span->setAttribute(@"a", nil);
+    span->setAttribute(@"b", nil);
+    XCTAssertNil(span->getAttribute(@"a"));
+    XCTAssertNil(span->getAttribute(@"b"));
+}
+
 - (void)testMultithreadedAttributesAccess {
     auto span = spanWithStartTime(0, ^(std::shared_ptr<SpanData>) {});
 
     [NSThread detachNewThreadWithBlock:^{
         for (int i = 0; i < 10000000; i++) {
-            span->addAttributes(@{@"a": @(i)});
+            span->setAttributes(@{@"a": @(i)});
         }
     }];
 

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -295,3 +295,13 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "10.0"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
+  Scenario: Set attributes in a span
+    Given I run "SetAttributesScenario"
+    And I wait for 1 span
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * a span string attribute "a" equals "xyz"
+    * every span bool attribute "b" does not exist
+    * every span bool attribute "x" does not exist

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0921F02E2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */; };
 		09301DC12B63A65A000A7C12 /* ComplexViewScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */; };
 		093EE63D2C32E5B900632B30 /* ManualParentSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */; };
+		094F41E62C4A84D6008162A4 /* SetAttributesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */; };
 		09637A3C2B0607F300F4F776 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A3B2B0607F300F4F776 /* Logging.swift */; };
 		09637A3F2B06082200F4F776 /* Logging.m in Sources */ = {isa = PBXBuildFile; fileRef = 09637A3E2B06082200F4F776 /* Logging.m */; };
 		09637A412B060E7C00F4F776 /* CommandReaderThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09637A402B060E7C00F4F776 /* CommandReaderThread.swift */; };
@@ -91,6 +92,7 @@
 		0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkCallbackScenario.swift; sourceTree = "<group>"; };
 		09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplexViewScenario.swift; sourceTree = "<group>"; };
 		093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualParentSpanScenario.swift; sourceTree = "<group>"; };
+		094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAttributesScenario.swift; sourceTree = "<group>"; };
 		09637A3B2B0607F300F4F776 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		09637A3D2B06082200F4F776 /* Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Logging.h; sourceTree = "<group>"; };
 		09637A3E2B06082200F4F776 /* Logging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Logging.m; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
+				094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */,
 				09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */,
 			);
 			path = Scenarios;
@@ -398,6 +401,7 @@
 				CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,
 				01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */,
+				094F41E62C4A84D6008162A4 /* SetAttributesScenario.swift in Sources */,
 				09637A412B060E7C00F4F776 /* CommandReaderThread.swift in Sources */,
 				CBC90CE029CDD02800280884 /* FirstClassYesScenario.swift in Sources */,
 				09F025072BA08804007D9F73 /* ObjCURLSession.m in Sources */,

--- a/features/fixtures/ios/Scenarios/SetAttributesScenario.swift
+++ b/features/fixtures/ios/Scenarios/SetAttributesScenario.swift
@@ -1,0 +1,21 @@
+//
+//  SetAttributesScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 19.07.24.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class SetAttributesScenario: Scenario {
+    
+    override func run() {
+        let span = BugsnagPerformance.startSpan(name: "MySpan")
+        span.setAttribute("a", withValue: "xyz")
+        span.setAttribute("b", withValue: "abc")
+        span.setAttribute("b", withValue: nil)
+        span.setAttribute("x", withValue: [])
+        span.end()
+    }
+}


### PR DESCRIPTION
## Goal

Renamed span.addAtribute to setAttribute and exposed it in the public headers.

Setting an attribute to nil now erases that attribute.

Setting an invalid attribute type now prints an error message when encoding.

## Testing

Added new unit tests and e2e tests.
