### PR TITLE
All e2e tests now filter out the same admin URLs by default

### DIFF
--- a/features/fixtures/ios/Fixture/FixtureConfig.swift
+++ b/features/fixtures/ios/Fixture/FixtureConfig.swift
@@ -8,23 +8,44 @@
 import Foundation
 
 class FixtureConfig {
+    // Base MazeRunner URL
     let mazeRunnerURL: URL
+
+    // Admin URLs we normally don't want to capture
     let docsURL: URL
     let tracesURL: URL
     let commandURL: URL
     let metricsURL: URL
-    let reflectURL: URL
     let notifyURL: URL
     let sessionsURL: URL
 
+    // URLs explicitly used in tests
+    let reflectURL: URL
+
+    // Convenience URL sets
+    let adminMazeRunnerURLs: [URL]
+    let allMazeRunnerURLs: [URL]
+
     init(mazeRunnerBaseAddress: URL) {
         mazeRunnerURL = mazeRunnerBaseAddress
+
         docsURL = mazeRunnerBaseAddress.appendingPathComponent("docs")
         tracesURL = mazeRunnerBaseAddress.appendingPathComponent("traces")
         commandURL = mazeRunnerBaseAddress.appendingPathComponent("command")
         metricsURL = mazeRunnerBaseAddress.appendingPathComponent("metrics")
         notifyURL = mazeRunnerBaseAddress.appendingPathComponent("notify")
         sessionsURL = mazeRunnerBaseAddress.appendingPathComponent("sessions")
+
         reflectURL = mazeRunnerBaseAddress.appendingPathComponent("reflect")
+
+        adminMazeRunnerURLs = [
+            docsURL,
+            tracesURL,
+            commandURL,
+            metricsURL,
+            notifyURL,
+            sessionsURL,
+        ]
+        allMazeRunnerURLs = [mazeRunnerURL]
     }
 }

--- a/features/fixtures/ios/Scenarios/AutoInstrumentAVAssetScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentAVAssetScenario.swift
@@ -14,17 +14,6 @@ class AutoInstrumentAVAssetScenario: Scenario, AVAssetDownloadDelegate {
     override func configure() {
         super.configure()
         config.autoInstrumentNetworkRequests = true
-        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
-            super.ignoreInternalRequests(info: info)
-            let testUrl = info.url
-            if (testUrl == nil) {
-                return info
-            }
-            if (self.isMazeRunnerAdministrationURL(url: testUrl!)) {
-                info.url = nil
-            }
-            return info
-        }
     }
 
     func query(string: String) {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkBadAddressScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkBadAddressScenario.swift
@@ -13,17 +13,6 @@ class AutoInstrumentNetworkBadAddressScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentNetworkRequests = true
-        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
-            super.ignoreInternalRequests(info: info)
-            let testUrl = info.url
-            if (testUrl == nil) {
-                return info
-            }
-            if (self.isMazeRunnerAdministrationURL(url: testUrl!)) {
-                info.url = nil
-            }
-            return info
-        }
     }
 
     func query(string: String) {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkCallbackScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkCallbackScenario.swift
@@ -13,8 +13,8 @@ class AutoInstrumentNetworkCallbackScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentNetworkRequests = true
-        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
-            super.ignoreInternalRequests(info: info)
+        config.networkRequestCallback = { (origInfo: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+            let info = self.filterAdminMazeRunnerNetRequests(info: origInfo)
 
             let testUrl = info.url
             if (testUrl == nil) {
@@ -24,10 +24,7 @@ class AutoInstrumentNetworkCallbackScenario: Scenario {
             let url = testUrl!
             let urlString = url.absoluteString
 
-            if (urlString.starts(with:"http://bs-local.com")) {
-                info.url = nil
-            }
-            else if url.absoluteString == "https://google.com" {
+            if url.absoluteString == "https://google.com" {
                 info.url = nil
             } else if url.lastPathComponent == "changeme" {
                 info.url = URL(string:"changed", relativeTo:url.deletingLastPathComponent())

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkMultiple.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkMultiple.swift
@@ -13,17 +13,6 @@ class AutoInstrumentNetworkMultiple: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentNetworkRequests = true
-        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
-            super.ignoreInternalRequests(info: info)
-            let testUrl = info.url
-            if (testUrl == nil) {
-                return info
-            }
-            if (self.isMazeRunnerAdministrationURL(url: testUrl!)) {
-                info.url = nil
-            }
-            return info
-        }
     }
 
     func query(url: String) {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkNoParentScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkNoParentScenario.swift
@@ -13,17 +13,6 @@ class AutoInstrumentNetworkNoParentScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentNetworkRequests = true
-        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
-            super.ignoreInternalRequests(info: info)
-            let testUrl = info.url
-            if (testUrl == nil) {
-                return info
-            }
-            if (self.isMazeRunnerAdministrationURL(url: testUrl!)) {
-                info.url = nil
-            }
-            return info
-        }
     }
 
     func query(string: String) {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkNullURLScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkNullURLScenario.swift
@@ -16,17 +16,6 @@ class AutoInstrumentNetworkNullURLScenario: Scenario {
 
         super.configure()
         config.autoInstrumentNetworkRequests = true
-        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
-            super.ignoreInternalRequests(info: info)
-            let testUrl = info.url
-            if (testUrl == nil) {
-                return info
-            }
-            if (self.isMazeRunnerAdministrationURL(url: testUrl!)) {
-                info.url = nil
-            }
-            return info
-        }
     }
 
     func query(string: String) {

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkWithParentScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkWithParentScenario.swift
@@ -13,17 +13,6 @@ class AutoInstrumentNetworkWithParentScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentNetworkRequests = true
-        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
-            super.ignoreInternalRequests(info: info)
-            let testUrl = info.url
-            if (testUrl == nil) {
-                return info
-            }
-            if (self.isMazeRunnerAdministrationURL(url: testUrl!)) {
-                info.url = nil
-            }
-            return info
-        }
     }
 
     func query(string: String) {

--- a/features/fixtures/ios/Scenarios/ManualNetworkCallbackScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualNetworkCallbackScenario.swift
@@ -20,8 +20,8 @@ class ManualNetworkCallbackScenario: Scenario {
     override func configure() {
         super.configure()
         config.autoInstrumentNetworkRequests = false
-        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
-            super.ignoreInternalRequests(info: info)
+        config.networkRequestCallback = { (origInfo: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
+            let info = self.filterAdminMazeRunnerNetRequests(info: origInfo)
 
             let testUrl = info.url
             if (testUrl == nil) {
@@ -29,12 +29,8 @@ class ManualNetworkCallbackScenario: Scenario {
             }
 
             let url = testUrl!
-            let urlString = url.absoluteString
 
-            if (urlString.starts(with:"http://bs-local.com")) {
-                info.url = nil
-            }
-            else if url.absoluteString == "https://google.com" {
+            if url.absoluteString == "https://google.com" {
                 info.url = nil
             } else if url.lastPathComponent == "changeme" {
                 info.url = URL(string:"changed", relativeTo:url.deletingLastPathComponent())

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -33,23 +33,39 @@ class Scenario: NSObject {
         config.autoInstrumentNetworkRequests = false
         config.autoInstrumentViewControllers = false
         config.endpoint = fixtureConfig.tracesURL
-        config.networkRequestCallback = { (info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo in
-            self.ignoreInternalRequests(info: info)
+        config.networkRequestCallback = filterAdminMazeRunnerNetRequests
+    }
 
+    func urlHasAnyPrefixIn(url: URL, prefixes: [URL]) -> Bool {
+        for prefix in prefixes {
+            if url.absoluteString.hasPrefix(prefix.absoluteString) {
+                return true
+            }
+        }
+        return false
+    }
+
+    func filterNetRequestsContainingPrefixes(info: BugsnagPerformanceNetworkRequestInfo,
+                                             prefixes: [URL]) -> BugsnagPerformanceNetworkRequestInfo {
+        if info.url == nil {
             return info
-        }
+         }
+
+        if urlHasAnyPrefixIn(url: info.url!, prefixes: prefixes) {
+             info.url = nil
+         }
+        return info
     }
-    
-    func ignoreInternalRequests(info: BugsnagPerformanceNetworkRequestInfo) {
-        if (info.url == nil) {
-            return
-        }
-        let urlString = info.url!.absoluteString
-        if (urlString.hasSuffix("/metrics") || urlString.contains("/command")) {
-            info.url = nil
-        }
+
+    func filterAllMazeRunnerNetRequests(info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo {
+        return filterNetRequestsContainingPrefixes(info: info, prefixes: fixtureConfig.allMazeRunnerURLs)
     }
-    
+
+    func filterAdminMazeRunnerNetRequests(info: BugsnagPerformanceNetworkRequestInfo) -> BugsnagPerformanceNetworkRequestInfo {
+        // Everything except reflectURL
+        return filterNetRequestsContainingPrefixes(info: info, prefixes: fixtureConfig.adminMazeRunnerURLs)
+    }
+
     func clearPersistentData() {
         logDebug("Scenario.clearPersistentData()")
         UserDefaults.standard.removePersistentDomain(
@@ -89,20 +105,6 @@ class Scenario: NSObject {
     func run() {
         logError("Scenario.run() has not been overridden!")
         fatalError("To be implemented by subclass")
-    }
-    
-    func isMazeRunnerAdministrationURL(url: URL) -> Bool {
-        if url.absoluteString.hasPrefix(fixtureConfig.tracesURL.absoluteString) ||
-            url.absoluteString.hasPrefix(fixtureConfig.commandURL.absoluteString) ||
-            url.absoluteString.hasPrefix(fixtureConfig.metricsURL.absoluteString) {
-            return true
-        }
-
-        if url.absoluteString.hasPrefix(fixtureConfig.reflectURL.absoluteString) {
-            return false // reflectURL is fair game!
-        }
-
-        return false
     }
 
     func enterBackground(forSeconds seconds: Int) {


### PR DESCRIPTION
The e2e tests were getting messy because filtering for mazerunner admin URLs had evolved over time, differently for different tests.

All e2e tests now filter ALL mazerunner URLs by default, and all mazerunner URLs are now defined in one place only.
