### PR TITLE
Add autoreleasepools at top level calls

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
@@ -24,49 +24,57 @@ BugsnagPerformanceLibrary &BugsnagPerformanceLibrary::sharedInstance() noexcept 
 }
 
 void BugsnagPerformanceLibrary::calledAsEarlyAsPossible() noexcept {
-    BSGLogDebug(@"BugsnagPerformanceLibrary::calledAsEarlyAsPossible");
-    auto instance = sharedInstance();
-    auto config = [BSGEarlyConfiguration new];
-    instance.earlyConfigure(config);
-    instance.earlySetup();
+    @autoreleasepool {
+        BSGLogDebug(@"BugsnagPerformanceLibrary::calledAsEarlyAsPossible");
+        auto instance = sharedInstance();
+        auto config = [BSGEarlyConfiguration new];
+        instance.earlyConfigure(config);
+        instance.earlySetup();
+    }
 }
 
 void BugsnagPerformanceLibrary::calledRightBeforeMain() noexcept {
-    BSGLogDebug(@"BugsnagPerformanceLibrary::calledRightBeforeMain");
-    sharedInstance().bugsnagPerformanceImpl_->willCallMainFunction();
+    @autoreleasepool {
+        BSGLogDebug(@"BugsnagPerformanceLibrary::calledRightBeforeMain");
+        sharedInstance().bugsnagPerformanceImpl_->willCallMainFunction();
+    }
 }
 
 void BugsnagPerformanceLibrary::configureLibrary(BugsnagPerformanceConfiguration *config) noexcept {
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: apiKey = %@", config.apiKey);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: endpoint = %@", config.endpoint);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: autoInstrumentAppStarts = %d", config.autoInstrumentAppStarts);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: autoInstrumentViewControllers = %d", config.autoInstrumentViewControllers);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: autoInstrumentNetworkRequests = %d", config.autoInstrumentNetworkRequests);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: appVersion = %@", config.appVersion);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: bundleVersion = %@", config.bundleVersion);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: releaseStage = %@", config.releaseStage);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: enabledReleaseStages = %@", config.enabledReleaseStages);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: tracePropagationUrls = %@", config.tracePropagationUrls);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: clearPersistenceOnStart = %d", config.internal.clearPersistenceOnStart);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: autoTriggerExportOnBatchSize = %llu", config.internal.autoTriggerExportOnBatchSize);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: performWorkInterval = %f", config.internal.performWorkInterval);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: maxRetryAge = %f", config.internal.maxRetryAge);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: probabilityValueExpiresAfterSeconds = %f", config.internal.probabilityValueExpiresAfterSeconds);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: probabilityRequestsPauseForSeconds = %f", config.internal.probabilityRequestsPauseForSeconds);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: initialSamplingProbability = %f", config.internal.initialSamplingProbability);
-    BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: maxPackageContentLength = %llu", config.internal.maxPackageContentLength);
+    @autoreleasepool {
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: apiKey = %@", config.apiKey);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: endpoint = %@", config.endpoint);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: autoInstrumentAppStarts = %d", config.autoInstrumentAppStarts);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: autoInstrumentViewControllers = %d", config.autoInstrumentViewControllers);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: autoInstrumentNetworkRequests = %d", config.autoInstrumentNetworkRequests);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: appVersion = %@", config.appVersion);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: bundleVersion = %@", config.bundleVersion);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: releaseStage = %@", config.releaseStage);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: enabledReleaseStages = %@", config.enabledReleaseStages);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: tracePropagationUrls = %@", config.tracePropagationUrls);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: clearPersistenceOnStart = %d", config.internal.clearPersistenceOnStart);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: autoTriggerExportOnBatchSize = %llu", config.internal.autoTriggerExportOnBatchSize);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: performWorkInterval = %f", config.internal.performWorkInterval);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: maxRetryAge = %f", config.internal.maxRetryAge);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: probabilityValueExpiresAfterSeconds = %f", config.internal.probabilityValueExpiresAfterSeconds);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: probabilityRequestsPauseForSeconds = %f", config.internal.probabilityRequestsPauseForSeconds);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: initialSamplingProbability = %f", config.internal.initialSamplingProbability);
+        BSGLogDebug(@"BugsnagPerformanceLibrary::configureLibrary: maxPackageContentLength = %llu", config.internal.maxPackageContentLength);
 
-    NSError *__autoreleasing error = nil;
-    if (![config validate:&error]) {
-        BSGLogError(@"Configuration validation failed with error: %@", error);
+        NSError *__autoreleasing error = nil;
+        if (![config validate:&error]) {
+            BSGLogError(@"Configuration validation failed with error: %@", error);
+        }
+
+        sharedInstance().configure(config);
     }
-
-    sharedInstance().configure(config);
 }
 
 void BugsnagPerformanceLibrary::startLibrary() noexcept {
-    BSGLogDebug(@"BugsnagPerformanceLibrary::startLibrary");
-    sharedInstance().start();
+    @autoreleasepool {
+        BSGLogDebug(@"BugsnagPerformanceLibrary::startLibrary");
+        sharedInstance().start();
+    }
 }
 
 BugsnagPerformanceLibrary::BugsnagPerformanceLibrary()

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -80,7 +80,9 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
         firstClass = defaultFirstClass;
     }
     auto spanId = IdGenerator::generateSpanId();
-    __block BugsnagPerformanceSpan *span = [[BugsnagPerformanceSpan alloc] initWithSpan:std::make_unique<Span>(name,
+    __block __weak BugsnagPerformanceSpan *blockSpan = nil;
+    BugsnagPerformanceSpan *span = nil;
+    blockSpan = span = [[BugsnagPerformanceSpan alloc] initWithSpan:std::make_unique<Span>(name,
                                                               traceId,
                                                               spanId,
                                                               parentSpan.spanId,
@@ -88,17 +90,18 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
                                                               firstClass,
                                        ^void(std::shared_ptr<SpanData> spanData) {
         BSGLogTrace(@"Tracer::startSpan: OnEnd callback: for span %@", spanData->name);
+        BugsnagPerformanceSpan *localSpan = blockSpan;
         blockThis->spanStackingHandler_->didEnd(spanData->spanId);
         if (!blockThis->sampler_->sampled(*spanData)) {
             BSGLogTrace(@"Tracer::startSpan: OnEnd callback: span %@ sampling returned false. Dropping...", spanData->name);
-            [span abortUnconditionally];
+            [localSpan abortUnconditionally];
             return;
         }
         CFAbsoluteTime callbacksStartTime = CFAbsoluteTimeGetCurrent();
         for (BugsnagPerformanceSpanEndCallback callback: blockThis->onSpanEndCallbacks_) {
             BOOL shouldDiscardSpan = false;
             @try {
-                shouldDiscardSpan = !callback(span);
+                shouldDiscardSpan = !callback(localSpan);
             } @catch(NSException *e) {
                 BSGLogError(@"Span OnEnd callback threw exception %@", e);
                 // We don't know whether they wanted to discard the span or not, so keep it.
@@ -106,13 +109,13 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
             }
             if(shouldDiscardSpan) {
                 BSGLogDebug(@"Tracer::startSpan: span %@ OnEnd callback returned false. Dropping...", spanData->name);
-                [span abortUnconditionally];
+                [localSpan abortUnconditionally];
                 return;
             }
         }
         CFAbsoluteTime callbacksEndTime = CFAbsoluteTimeGetCurrent();
         BSGLogDebug(@"Tracer::startSpan: OnEnd callback: Adding span %@ to batch", spanData->name);
-        [span setAttribute:@"bugsnag.span.callbacks_duration" withValue:@(intervalToNanoseconds(callbacksEndTime - callbacksStartTime))];
+        [localSpan setAttribute:@"bugsnag.span.callbacks_duration" withValue:@(intervalToNanoseconds(callbacksEndTime - callbacksStartTime))];
         blockThis->batch_->add(spanData);
     })];
     if (options.makeCurrentContext) {

--- a/Sources/BugsnagPerformance/Private/Worker.mm
+++ b/Sources/BugsnagPerformance/Private/Worker.mm
@@ -56,30 +56,32 @@
 }
 
 - (void) run {
-    // Start off asleep
-    [self sleep];
-    if (self.shouldEnd) {
-        return;
-    }
+    @autoreleasepool {
+        // Start off asleep
+        [self sleep];
+        if (self.shouldEnd) {
+            return;
+        }
 
-    [self performInitialWork];
+        [self performInitialWork];
 
-    if (self.initialRecurringWorkDelay > 0) {
-        [NSThread sleepForTimeInterval:self.initialRecurringWorkDelay];
-    }
+        if (self.initialRecurringWorkDelay > 0) {
+            [NSThread sleepForTimeInterval:self.initialRecurringWorkDelay];
+        }
 
-    for (;;) {
-        @autoreleasepool {
-            if (self.shouldEnd) {
-                break;
+        for (;;) {
+            @autoreleasepool {
+                if (self.shouldEnd) {
+                    break;
+                }
+
+                while ([self performRecurringWork]) {
+                    // Keep working until no work gets done
+                }
+
+                // Once there's no work getting done, go to sleep.
+                [self sleep];
             }
-
-            while ([self performRecurringWork]) {
-                // Keep working until no work gets done
-            }
-
-            // Once there's no work getting done, go to sleep.
-            [self sleep];
         }
     }
 }

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -601,7 +601,6 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
 
-  @skip # Skip Pending PLAT-12526
   Scenario: Automatically start a network span triggered by AVAssetDownloadURLSession (must not crash)
     Given I run "AutoInstrumentAVAssetScenario"
     And I wait for 2 seconds

--- a/features/fixtures/ios/Scenarios/AutoInstrumentAppStartsScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentAppStartsScenario.swift
@@ -15,11 +15,6 @@ class AutoInstrumentAppStartsScenario: Scenario {
         config.autoInstrumentAppStarts = true
     }
 
-    override func startBugsnag() {
-        BugsnagPerformance.startViewLoadSpan(name: "AutoInstrumentAppStartsScenarioView", viewType: .uiKit)
-        super.startBugsnag()
-    }
-
     override func run() {
     }
 }

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkCallbackScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkCallbackScenario.swift
@@ -22,7 +22,6 @@ class AutoInstrumentNetworkCallbackScenario: Scenario {
             }
 
             let url = testUrl!
-            let urlString = url.absoluteString
 
             if url.absoluteString == "https://google.com" {
                 info.url = nil


### PR DESCRIPTION
Many of the top-level calls don't have autoreleasepools, and are leaking. Although not many things are leaking, they're still leaking.

This PR adds autoreleasepools to the top-level calls, and also defensively to Worker so that it doesn't retain things for too long.

Tracer was causing a strong recursive retain of the spans being created, which has now been fixed.
