### PR TITLE
[Plat-12551] Call OnSpanEnd callbacks for early spans on library start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* OnEnd span callbacks are now called on early spans (spans that ended before library start) once the library is started.
+  [298](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/298)
+
 ## 1.7.0 (2024-08-05)
 
 ### Enhancements

--- a/Sources/BugsnagPerformance/Private/PhasedStartup.h
+++ b/Sources/BugsnagPerformance/Private/PhasedStartup.h
@@ -17,22 +17,58 @@ namespace bugsnag {
 
 /* Phased library startup protocols and interfaces.
  *
- * Library startup occurs in four phases, where each component is called in-order using
- * the API of the current phase.
+ * Library startup occurs in multiple phases, where each component is called in-order using
+ * the API of the currently running phase.
  *
  * The APIs for each phase are:
  * - earlyConfigure(): Called as early as possible upon library init, using Info.plist as a source.
  * - earlySetup(): Called immediately after earlyConfigure().
  * - configure(): Called via [BugsnagPerformance startWithConfiguration:]
- * - start(): Called immediately after configure().
+ * - preStartSetup(): Called immediately after configure().
+ * - start(): Called immediately after preStartSetup().
  */
 class PhasedStartup {
 public:
+    /**
+     * Perform "early" configuration. This is called before main(), using configuration data
+     * pulled from the environment (Info.plist).
+     *
+     * It's called automatically by BugsnagPerformanceLibrary, and does not require any user runtime actions.
+     */
     virtual void earlyConfigure(BSGEarlyConfiguration *config) noexcept = 0;
+
+    /**
+     * Perform "early" setup. This is called before main(), and gives each component an
+     * opportunity to perform any setup in response to the early configuration.
+     *
+     * It's split into a separate step so that any cross-component calls will always be
+     * made to an already-configured object.
+     */
     virtual void earlySetup() noexcept = 0;
+
+    /**
+     * Perform user configuration. This is called as a consequence of the user calling [BugsnagPerformance start],
+     * and performs configuration according to what the user provided.
+     */
     virtual void configure(BugsnagPerformanceConfiguration *config) noexcept = 0;
+
+    /**
+     * Perform pre-start setup. Like earlySetup(), this step gives each component an
+     * opportunity to perform any required setup in response to the configuration.
+     *
+     * It's split into a separate step so that any cross-component calls will always be
+     * made to an already-configured object.
+     */
     virtual void preStartSetup() noexcept = 0;
+
+    /**
+     * Start this fully configured and set up component.
+     *
+     * This step is for actions that aren't part of the setup, but rather for "running" the object.
+     * This is typically for things such as starting threads and queues, patching into system callbacks, etc.
+     */
     virtual void start() noexcept = 0;
+
     virtual ~PhasedStartup() {}
 };
 
@@ -40,14 +76,44 @@ public:
 
 @protocol BSGPhasedStartup
 
+/**
+ * Perform "early" configuration. This is called before main(), using configuration data
+ * pulled from the environment (Info.plist).
+ *
+ * It's called automatically by BugsnagPerformanceLibrary, and does not require any user runtime actions.
+ */
 - (void)earlyConfigure:(BSGEarlyConfiguration *)config;
 
+/**
+ * Perform "early" setup. This is called before main(), and gives each component an
+ * opportunity to perform any setup in response to the early configuration.
+ *
+ * It's split into a separate step so that any cross-component calls will always be
+ * made to an already-configured object.
+ */
 - (void)earlySetup;
 
+/**
+ * Perform user configuration. This is called as a consequence of the user calling [BugsnagPerformance start],
+ * and performs configuration according to what the user provided.
+ */
 - (void)configure:(BugsnagPerformanceConfiguration *)config;
 
+/**
+ * Perform pre-start setup. Like earlySetup(), this step gives each component an
+ * opportunity to perform any required setup in response to the configuration.
+ *
+ * It's split into a separate step so that any cross-component calls will always be
+ * made to an already-configured object.
+ */
 - (void)preStartSetup;
 
+/**
+ * Start this fully configured and set up component.
+ *
+ * This step is for actions that aren't part of the setup, but rather for "running" the object.
+ * This is typically for things such as starting threads and queues, patching into system callbacks, etc.
+ */
 - (void)start;
 
 @end

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -621,6 +621,27 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
 
+  Scenario: Make sure OnSpanEnd callbacks also get called for early spans.
+    Given I run "EarlySpanOnEndScenario"
+    And I wait for exactly 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "parentSpanId" does not exist
+    * a span field "name" equals "[HTTP/GET]"
+    * a span string attribute "http.flavor" exists
+    * a span string attribute "http.method" equals "GET"
+    * a span integer attribute "http.status_code" is greater than 0
+    * a span integer attribute "http.response_content_length" is greater than 0
+    * a span string attribute "net.host.connection.type" equals "wifi"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.cocoaperformance"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
   Scenario: ComplexViewScenario
     Given I run "ComplexViewScenario"
     And I wait for 27 spans

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		09D59E172BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D59E162BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift */; };
 		09D59E1D2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */; };
 		09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */; };
+		09DC622A2C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */; };
 		09F025072BA08804007D9F73 /* ObjCURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F025062BA08804007D9F73 /* ObjCURLSession.m */; };
 		09F025092BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */; };
 		09F025152BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */; };
@@ -114,6 +115,7 @@
 		09D59E162BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkTracePropagationScenario.swift; sourceTree = "<group>"; };
 		09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkTracePropagationScenario.swift; sourceTree = "<group>"; };
 		09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkCallbackScenario.swift; sourceTree = "<group>"; };
+		09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarlySpanOnEndScenario.swift; sourceTree = "<group>"; };
 		09F025052BA08804007D9F73 /* ObjCURLSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCURLSession.h; sourceTree = "<group>"; };
 		09F025062BA08804007D9F73 /* ObjCURLSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCURLSession.m; sourceTree = "<group>"; };
 		09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkNullURLScenario.swift; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
 				094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */,
 				09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */,
+				09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -425,6 +428,7 @@
 				098C3B502C53CEC0006F9886 /* ErrorGenerator.m in Sources */,
 				0921F02E2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift in Sources */,
 				01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */,
+				09DC622A2C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift in Sources */,
 				CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/features/fixtures/ios/Scenarios/EarlySpanOnEndScenario.swift
+++ b/features/fixtures/ios/Scenarios/EarlySpanOnEndScenario.swift
@@ -1,0 +1,34 @@
+//
+//  EarlySpanOnEndScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 15.08.24.
+//
+
+import Foundation
+
+@objcMembers
+class EarlySpanOnEndScenario: Scenario {
+
+    override func configure() {
+        // Early network span
+        query(string: "test")
+
+        super.configure()
+        config.autoInstrumentAppStarts = true
+        config.autoInstrumentNetworkRequests = true
+        config.add { span in
+            // We've turned on app start spans, but they'll get filtered
+            // out here because they don't contain "HTTP" in their names.
+            return span.name.contains("HTTP")
+        }
+    }
+
+    func query(string: String) {
+        let url = URL(string: string, relativeTo: fixtureConfig.reflectURL)!
+        URLSession.shared.dataTask(with: url).resume()
+    }
+
+    override func run() {
+    }
+}


### PR DESCRIPTION
## Goal

Spans ended before the library was started can't call the OnSpanEnd callbacks because they haven't been configured yet.

On library start, explicitly call the OnSpanEnd callbacks for all spans ended before the library started.

## Testing

Added e2e test
