### PR TITLE
Sampling probability configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Changelog
 
 * `service.name` can now be set in the configuration.
   [299](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/299)
+  
+* A fixed `samplingProbability` can now be set in the configuration.
+  [300](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/300)
 
 ## 1.7.0 (2024-08-05)
 

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.h
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.h
@@ -21,7 +21,7 @@ public:
     /**
      * Build a package suitable for upload to the backend server.
      */
-    static std::unique_ptr<OtlpPackage> buildUploadPackage(const std::vector<std::shared_ptr<SpanData>> &spans, NSDictionary *resourceAttributes) noexcept;
+    static std::unique_ptr<OtlpPackage> buildUploadPackage(const std::vector<std::shared_ptr<SpanData>> &spans, NSDictionary *resourceAttributes, bool includeSamplingHeader) noexcept;
 
     static std::unique_ptr<OtlpPackage> buildPValueRequestPackage() noexcept;
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -58,6 +58,7 @@ static NSString *defaultEndpoint = @"https://otlp.bugsnag.com/v1/traces";
     auto autoInstrumentAppStarts = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"autoInstrumentAppStarts"]);
     auto autoInstrumentViewControllers = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"autoInstrumentViewControllers"]);
     auto autoInstrumentNetworkRequests = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"autoInstrumentNetworkRequests"]);
+    auto samplingProbability = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"samplingProbability"]);
     auto configuration = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:apiKey];
     if (appVersion) {
         configuration.appVersion = appVersion;
@@ -83,6 +84,9 @@ static NSString *defaultEndpoint = @"https://otlp.bugsnag.com/v1/traces";
     }
     if (autoInstrumentNetworkRequests != nil) {
         configuration.autoInstrumentNetworkRequests = [autoInstrumentNetworkRequests boolValue];
+    }
+    if (samplingProbability != nil) {
+        configuration.samplingProbability = samplingProbability;
     }
     return configuration;
 }

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -59,6 +59,11 @@ OBJC_EXPORT
  */
 @property (copy, nullable, nonatomic) NSString *serviceName;
 
+/**
+ *  Fixed sampling probability
+ */
+@property (nonatomic, nullable) NSNumber *samplingProbability;
+
 @property (nullable, nonatomic) BugsnagPerformanceViewControllerInstrumentationCallback viewControllerInstrumentationCallback;
 
 @end

--- a/features/default/configuration.feature
+++ b/features/default/configuration.feature
@@ -25,3 +25,31 @@ Feature: Configuration overrides
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "42.0"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
+  Scenario: Fixed sampling probability
+    Given I set the sampling probability for the next traces to "0"
+    And I enter unmanaged traces mode
+    And I run "FixedSamplingProbabilityScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
+    * the trace "Bugsnag-Span-Sampling" header is not present
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "FixedSamplingProbabilitySpan1"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    Then I discard the oldest trace
+    Then I set the sampling probability for the next traces to "0"
+    And I invoke "step2"
+    And I wait for 1 span
+    * the trace "Bugsnag-Span-Sampling" header is not present
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "FixedSamplingProbabilitySpan2"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"

--- a/features/default/configuration.feature
+++ b/features/default/configuration.feature
@@ -29,7 +29,7 @@ Feature: Configuration overrides
   Scenario: Setting fixed sampling probability of 1 with dynamic probability of 0 should send all spans
     Given I set the sampling probability for the next traces to "0"
     And I enter unmanaged traces mode
-    And I run "FixedSamplingProbabilityScenario"
+    And I run "FixedSamplingProbabilityOneScenario"
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
@@ -53,3 +53,9 @@ Feature: Configuration overrides
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+
+  Scenario: Setting fixed sampling probability of 0 with dynamic probability of 1 should send no spans
+    Given I set the sampling probability for the next traces to "0"
+    And I enter unmanaged traces mode
+    And I run "FixedSamplingProbabilityZeroScenario"
+    And I should receive no traces

--- a/features/default/configuration.feature
+++ b/features/default/configuration.feature
@@ -26,7 +26,7 @@ Feature: Configuration overrides
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
 
-  Scenario: Fixed sampling probability
+  Scenario: Setting fixed sampling probability of 1 with dynamic probability of 0 should send all spans
     Given I set the sampling probability for the next traces to "0"
     And I enter unmanaged traces mode
     And I run "FixedSamplingProbabilityScenario"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -53,7 +53,8 @@
 		9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */; };
 		967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */; };
 		96D528CC2C72B14300FEA2E2 /* AppDataOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */; };
-		96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityScenario.swift */; };
+		96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */; };
+		96D528D02C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */; };
 		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
@@ -126,7 +127,8 @@
 		9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNavigationViewLoadScenario.swift; sourceTree = "<group>"; };
 		967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseStageNotEnabledScenario.swift; sourceTree = "<group>"; };
 		96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataOverrideScenario.swift; sourceTree = "<group>"; };
-		96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityScenario.swift; sourceTree = "<group>"; };
+		96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityOneScenario.swift; sourceTree = "<group>"; };
+		96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityZeroScenario.swift; sourceTree = "<group>"; };
 		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackSetToNilScenario.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
@@ -253,6 +255,8 @@
 				09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */,
 				CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */,
 				CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */,
+				96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */,
+				96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */,
 				CBC90C4129C466BD00280884 /* ForceUBSan.h */,
 				CBC90C4229C466BD00280884 /* ForceUBSan.m */,
 				CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */,
@@ -278,7 +282,6 @@
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
 				094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */,
 				09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */,
-				96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -380,6 +383,7 @@
 				09F025092BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift in Sources */,
 				0185C47228F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift in Sources */,
 				09D59E172BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift in Sources */,
+				96D528D02C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift in Sources */,
 				09D59E1D2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */,
@@ -410,7 +414,7 @@
 				01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */,
 				09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */,
 				09301DC12B63A65A000A7C12 /* ComplexViewScenario.swift in Sources */,
-				96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityScenario.swift in Sources */,
+				96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift in Sources */,
 				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,
 				967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */,
 				9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */,

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */; };
 		967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */; };
 		96D528CC2C72B14300FEA2E2 /* AppDataOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */; };
+		96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityScenario.swift */; };
 		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
@@ -125,6 +126,7 @@
 		9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNavigationViewLoadScenario.swift; sourceTree = "<group>"; };
 		967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseStageNotEnabledScenario.swift; sourceTree = "<group>"; };
 		96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataOverrideScenario.swift; sourceTree = "<group>"; };
+		96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityScenario.swift; sourceTree = "<group>"; };
 		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackSetToNilScenario.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
 				094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */,
 				09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */,
+				96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -407,6 +410,7 @@
 				01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */,
 				09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */,
 				09301DC12B63A65A000A7C12 /* ComplexViewScenario.swift in Sources */,
+				96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityScenario.swift in Sources */,
 				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,
 				967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */,
 				9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/FixedSamplingProbabilityOneScenario.swift
+++ b/features/fixtures/ios/Scenarios/FixedSamplingProbabilityOneScenario.swift
@@ -8,7 +8,7 @@
 import BugsnagPerformance
 
 @objcMembers
-class FixedSamplingProbabilityScenario: Scenario {
+class FixedSamplingProbabilityOneScenario: Scenario {
     
     override func configure() {
         super.configure()

--- a/features/fixtures/ios/Scenarios/FixedSamplingProbabilityScenario.swift
+++ b/features/fixtures/ios/Scenarios/FixedSamplingProbabilityScenario.swift
@@ -1,0 +1,25 @@
+//
+//  ServiceNameScenario.swift
+//  Fixture
+//
+//  Created by Robert B on 20/08/2024.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class FixedSamplingProbabilityScenario: Scenario {
+    
+    override func configure() {
+        super.configure()
+        config.samplingProbability = 1.0
+    }
+    
+    override func run() {
+        BugsnagPerformance.startSpan(name: "FixedSamplingProbabilitySpan1").end()
+    }
+    
+    func step2() {
+        BugsnagPerformance.startSpan(name: "FixedSamplingProbabilitySpan2").end()
+    }
+}

--- a/features/fixtures/ios/Scenarios/FixedSamplingProbabilityZeroScenario.swift
+++ b/features/fixtures/ios/Scenarios/FixedSamplingProbabilityZeroScenario.swift
@@ -1,0 +1,21 @@
+//
+//  FixedSamplingProbabilityZeroScenario.swift
+//  Fixture
+//
+//  Created by Robert B on 23/08/2024.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class FixedSamplingProbabilityZeroScenario: Scenario {
+    
+    override func configure() {
+        super.configure()
+        config.samplingProbability = 0.0
+    }
+    
+    override func run() {
+        BugsnagPerformance.startSpan(name: "FixedSamplingProbabilitySpan1").end()
+    }
+}


### PR DESCRIPTION
## Goal

To support non-BugSnag trace endpoints, we should provide the client RUM SDKs with a samplingProbability configuration that can be set by the developer to provide a fixed p-value for sampling.

## Design



When sampling probability is set it:
- disables the initial and periodic p-value requests being sent
- is used in preference to any persisted p-value or any value received in response headers
- disables the setting of the Bugsnag-Span-Sampling header, but keep the bugsnag.sampling.p attribute for possible future use

## Changeset

Added `samplingProbability` option to `BugsnagPerformanceConfiguration`

## Testing

E2E and Unit tests