### PR TITLE
Upload only the XCframework product without excess directories

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
           - make build_xcframework
         plugins:
           - artifacts#v1.9.3:
-              upload: "build/xcframeworks/products/BugsnagPerformance.xcframework"
+              upload: "BugsnagPerformance.xcframework"
               compressed: xcframework.zip
 
       - label: "Carthage"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,8 +15,7 @@ steps:
           - make build_xcframework
         plugins:
           - artifacts#v1.9.3:
-              upload: "BugsnagPerformance.xcframework"
-              compressed: xcframework.zip
+              upload: "BugsnagPerformance.xcframework.zip"
 
       - label: "Carthage"
         commands:

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -134,7 +134,7 @@ build_frameworks() {
         fixup_xcframework $framework
         pushd "${PRODUCTS_DIR}"
         zip --symlinks -rq "${framework}.xcframework.zip" "${framework}.xcframework"
-        cp "${framework}.xcframework" "${PROJECT_DIR}/${framework}.xcframework}"
+        cp -r "${framework}.xcframework" "${PROJECT_DIR}/${framework}.xcframework}"
         popd
     done
 }

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -134,7 +134,7 @@ build_frameworks() {
         fixup_xcframework $framework
         pushd "${PRODUCTS_DIR}"
         zip --symlinks -rq "${framework}.xcframework.zip" "${framework}.xcframework"
-        cp -r "${framework}.xcframework" "${PROJECT_DIR}/${framework}.xcframework}"
+        cp -r "${framework}.xcframework" "${PROJECT_DIR}/${framework}.xcframework"
         popd
     done
 }
@@ -147,7 +147,3 @@ build_frameworks
 
 echo
 echo "** build-frameworks.sh: script completed successfully **"
-
-echo "ROOT"
-pwd
-ls $PROJECT_DIR

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -134,6 +134,7 @@ build_frameworks() {
         fixup_xcframework $framework
         pushd "${PRODUCTS_DIR}"
         zip --symlinks -rq "${framework}.xcframework.zip" "${framework}.xcframework"
+        cp "${framework}.xcframework" "${PROJECT_DIR}/${framework}.xcframework}"
         popd
     done
 }

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -134,7 +134,7 @@ build_frameworks() {
         fixup_xcframework $framework
         pushd "${PRODUCTS_DIR}"
         zip --symlinks -rq "${framework}.xcframework.zip" "${framework}.xcframework"
-        cp -r "${framework}.xcframework" "${PROJECT_DIR}/${framework}.xcframework"
+        cp -r "${framework}.xcframework.zip" "${PROJECT_DIR}/${framework}.xcframework.zip"
         popd
     done
 }

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -135,8 +135,6 @@ build_frameworks() {
         pushd "${PRODUCTS_DIR}"
         zip --symlinks -rq "${framework}.xcframework.zip" "${framework}.xcframework"
         cp -r "${framework}.xcframework" "${PROJECT_DIR}/${framework}.xcframework}"
-        echo "HERE"
-        ls .
         popd
     done
 }
@@ -149,3 +147,7 @@ build_frameworks
 
 echo
 echo "** build-frameworks.sh: script completed successfully **"
+
+echo "ROOT"
+pwd
+ls $PROJECT_DIR

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -135,6 +135,8 @@ build_frameworks() {
         pushd "${PRODUCTS_DIR}"
         zip --symlinks -rq "${framework}.xcframework.zip" "${framework}.xcframework"
         cp -r "${framework}.xcframework" "${PROJECT_DIR}/${framework}.xcframework}"
+        echo "HERE"
+        ls .
         popd
     done
 }


### PR DESCRIPTION
## Goal

Pretty much does as described, copies the XCframework products up to the top level once built and zips them there, rather than the whole directory structure.

@kstenerud I'd appreciate you checking the zip file on the build step, just to make sure everything is there.