### PR TITLE
[PLAT-12452] Enforce immutability on closed spans

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) double samplingProbability;
 @property (nonatomic) BSGFirstClass firstClass;
 @property (nonatomic) SpanKind kind;
+@property (nonatomic,readwrite) BOOL isMutable;
 
 
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
@@ -25,7 +25,7 @@ public:
     void earlyConfigure(BSGEarlyConfiguration *) noexcept {}
     void earlySetup() noexcept;
     void configure(BugsnagPerformanceConfiguration *config) noexcept;
-    void preStartSetup() noexcept;
+    void preStartSetup() noexcept {}
     void start() noexcept {}
 
     void didStartViewLoadSpan(NSString *name) noexcept;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -78,10 +78,6 @@ void AppStartupInstrumentation::configure(BugsnagPerformanceConfiguration *confi
     }
 }
 
-void AppStartupInstrumentation::preStartSetup() noexcept {
-    // TODO
-}
-
 void AppStartupInstrumentation::willCallMainFunction() noexcept {
     std::lock_guard<std::mutex> guard(mutex_);
     if (!isEnabled_) {

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
@@ -158,12 +158,6 @@ void NetworkInstrumentation::configure(BugsnagPerformanceConfiguration *config) 
 
 void NetworkInstrumentation::preStartSetup() noexcept {
     [delegate_ preStartSetup];
-
-    if (!isEnabled_) {
-        return;
-    }
-
-    // TODO
 }
 
 void NetworkInstrumentation::start() noexcept {

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -38,7 +38,7 @@ public:
     void earlyConfigure(BSGEarlyConfiguration *config) noexcept;
     void earlySetup() noexcept;
     void configure(BugsnagPerformanceConfiguration *config) noexcept;
-    void preStartSetup() noexcept;
+    void preStartSetup() noexcept {};
     void start() noexcept {}
     
 private:

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.mm
@@ -111,13 +111,6 @@ ViewLoadInstrumentation::configure(BugsnagPerformanceConfiguration *config) noex
     endEarlySpanPhase();
 }
 
-void ViewLoadInstrumentation::preStartSetup() noexcept {
-    if (!isEnabled_) {
-        return;
-    }
-    // TODO
-}
-
 BugsnagPerformanceSpan *ViewLoadInstrumentation::getOverallSpan(UIViewController *viewController) noexcept {
     if (viewController != nil) {
         return objc_getAssociatedObject(viewController, &kAssociatedViewLoadSpan);

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -91,5 +91,6 @@ private:
     BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
     void markPrewarmSpan(BugsnagPerformanceSpan *span) noexcept;
     void onSpanClosed(BugsnagPerformanceSpan *span);
+    void reprocessEarlySpans(void);
 };
 }

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -692,3 +692,31 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.cocoaperformance"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
+  Scenario: ModifyEarlySpansScenario
+    Given I run "ModifyEarlySpansScenario"
+    And I wait for exactly 5 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:5"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "[AppStart/iOSCold]"
+    * a span field "name" equals "[AppStartPhase/App launching - pre main()]"
+    * a span field "name" equals "[AppStartPhase/App launching - post main()]"
+    * a span field "name" equals "[AppStartPhase/UI init]"
+    * a span field "name" equals "[HTTP/GET]"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "bugsnag.app_start.type" equals "cold"
+    * a span string attribute "bugsnag.phase" equals "App launching - pre main()"
+    * a span string attribute "bugsnag.phase" equals "App launching - post main()"
+    * a span string attribute "bugsnag.phase" equals "UI init"
+    * a span string attribute "bugsnag.span.category" equals "app_start"
+    * a span string attribute "bugsnag.span.category" equals "app_start_phase"
+    * every span bool attribute "bugsnag.span.first_class" does not exist
+    * every span string attribute "modifiedOnEnd" equals "yes"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.cocoaperformance"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		09D59E1D2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */; };
 		09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */; };
 		09DC622A2C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */; };
+		09E9BDAF2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E9BDAE2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift */; };
 		09F025072BA08804007D9F73 /* ObjCURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F025062BA08804007D9F73 /* ObjCURLSession.m */; };
 		09F025092BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */; };
 		09F025152BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */; };
@@ -119,6 +120,7 @@
 		09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkTracePropagationScenario.swift; sourceTree = "<group>"; };
 		09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkCallbackScenario.swift; sourceTree = "<group>"; };
 		09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarlySpanOnEndScenario.swift; sourceTree = "<group>"; };
+		09E9BDAE2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyEarlySpansScenario.swift; sourceTree = "<group>"; };
 		09F025052BA08804007D9F73 /* ObjCURLSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCURLSession.h; sourceTree = "<group>"; };
 		09F025062BA08804007D9F73 /* ObjCURLSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCURLSession.m; sourceTree = "<group>"; };
 		09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkNullURLScenario.swift; sourceTree = "<group>"; };
@@ -255,6 +257,7 @@
 				CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */,
 				CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */,
 				09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */,
+				09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */,
 				CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */,
 				CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */,
 				96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */,
@@ -273,6 +276,7 @@
 				098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */,
 				01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */,
 				CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */,
+				09E9BDAE2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift */,
 				09F025052BA08804007D9F73 /* ObjCURLSession.h */,
 				09F025062BA08804007D9F73 /* ObjCURLSession.m */,
 				098C3B2C2C523EC5006F9886 /* OnEndCallbackScenario.swift */,
@@ -284,7 +288,6 @@
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
 				094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */,
 				09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */,
-				09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -402,6 +405,7 @@
 				96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */,
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
+				09E9BDAF2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift in Sources */,
 				099331FC2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift in Sources */,
 				097FFC0B2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift in Sources */,
 				01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/ModifyEarlySpansScenario.swift
+++ b/features/fixtures/ios/Scenarios/ModifyEarlySpansScenario.swift
@@ -1,0 +1,32 @@
+//
+//  ModifyEarlySpansScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 29.08.24.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class ModifyEarlySpansScenario: Scenario {
+    
+    override func configure() {
+        super.configure()
+        config.autoInstrumentAppStarts = true
+        config.autoInstrumentNetworkRequests = true
+        config.add(onSpanEndCallback: { (span: BugsnagPerformanceSpan) -> Bool in
+            span.setAttribute("modifiedOnEnd", withValue: "yes")
+            return true
+        })
+
+        query(string: "?status=200")
+    }
+
+    func query(string: String) {
+        let url = URL(string: string, relativeTo: fixtureConfig.reflectURL)!
+        URLSession.shared.dataTask(with: url).resume()
+    }
+
+    override func run() {
+    }
+}


### PR DESCRIPTION
## Goal

Spans shouldn't be modified after they have ended or been aborted.

## Design

Disallow span mutations after they have been closed, and issue error messages when an attempt is made.

Mutability is temporarily re-enabled for early spans that ended before the library started so that the onSpanEnd callbacks can be run.

## Testing

Added new e2e test and unit tests.
