### PR TITLE
Updated default url

### DIFF
--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -12,15 +12,13 @@
 
 using namespace bugsnag;
 
-static NSString *defaultEndpoint = @"https://otlp.bugsnag.com/v1/traces";
-
 @implementation BugsnagPerformanceConfiguration
 
 - (instancetype)initWithApiKey:(NSString *)apiKey {
     if ((self = [super init])) {
         _internal = [BSGInternalConfiguration new];
         _apiKey = [apiKey copy];
-        _endpoint = nsurlWithString(defaultEndpoint, nil);
+        _endpoint = nsurlWithString([NSString stringWithFormat: @"https://%@.otlp.bugsnag.com/v1/traces", apiKey], nil);
         _autoInstrumentAppStarts = YES;
         _autoInstrumentViewControllers = YES;
         _autoInstrumentNetworkRequests = YES;

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
@@ -180,4 +180,9 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
 }
 
+- (void)testShouldSetIncludeApiKeyInTheDefaultEndpoint {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
+    XCTAssertEqualObjects(config.endpoint.absoluteString, @"https://0123456789abcdef0123456789abcdef.otlp.bugsnag.com/v1/traces");
+}
+
 @end


### PR DESCRIPTION
## Goal

Our SaaS span endpoint now supports the format <project_api_key>.otlp.bugsnag.com.

## Changeset

Changed default endpoint in `BugsnagPerfromanceConfiguration`.

## Testing

Unit tests