### PR TITLE
[PLAT-12631] Prevent .xcprivacy files from being marked 'compile' in podspec

### DIFF
--- a/BugsnagPerformance.podspec.json
+++ b/BugsnagPerformance.podspec.json
@@ -18,7 +18,7 @@
     "ios": "13.0"
   },
   "requires_arc": true,
-  "source_files": "Sources/BugsnagPerformance/**/*",
+  "source_files": "Sources/BugsnagPerformance/{**/,}*.{m,h,mm,c,swift}",
   "resource_bundles": {
       "BugsnagPerformance": ["Sources/BugsnagPerformance/resources/PrivacyInfo.xcprivacy"]
   },

--- a/BugsnagPerformanceSwift.podspec.json
+++ b/BugsnagPerformanceSwift.podspec.json
@@ -13,13 +13,13 @@
   "swift_version": "4.2",
   "source": {
     "git": "https://github.com/bugsnag/bugsnag-cocoa-performance.git",
-    "tag": "v1.5.0"
+    "tag": "v1.8.0"
   },
   "platforms": {
     "ios": "13.0"
   },
   "requires_arc": true,
-  "source_files": "Sources/BugsnagPerformanceSwift/**/*",
+  "source_files": "Sources/BugsnagPerformanceSwift/{**/,}*.{m,h,mm,c,swift}",
   "frameworks": [
     "SwiftUI"
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Stop podspec from trying to compile xcprivacy files (which generates warnings).
+  [311](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/311)
+
 * Early spans (ended before Bugsnag starts) now get their sampling probability value properly updated.
   [310](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/310)
 


### PR DESCRIPTION
## Goal

When using `**/*` as the glob specifier for source files, the `xcprivacy` file also gets sucked in and generates warnings. Use a more specific glob specifier so that non-compiled files don't get sucked in.

There was also one version reference that didn't get updated with the last PR. After this, it will be updated via the Makefile command.
