### PR TITLE
[PLAT-12703] Add configurable size limits to span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Added configurable span attribute limits for string and array types.
+  [314](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/314)
+
 ## 1.8.1 (2024-09-03)
 
 ### Bug fixes

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -25,6 +25,7 @@
 #import "Instrumentation/Instrumentation.h"
 #import "ResourceAttributes.h"
 #import "NetworkHeaderInjector.h"
+#import "OtlpTraceEncoding.h"
 
 #import <mutex>
 
@@ -87,6 +88,7 @@ private:
     std::shared_ptr<PersistentDeviceID> deviceID_;
     std::shared_ptr<ResourceAttributes> resourceAttributes_;
     BugsnagPerformanceNetworkRequestCallback networkRequestCallback_;
+    OtlpTraceEncoding traceEncoding_;
 
     BugsnagPerformanceConfiguration *configuration_;
     std::shared_ptr<OtlpUploader> uploader_;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -46,10 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) SpanKind kind;
 @property (nonatomic,readwrite) BOOL isMutable;
 
-
-
 @property(nonatomic) uint64_t startClock;
-
 
 @property(atomic) SpanState state;
 

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -11,6 +11,8 @@
 #import "Utils.h"
 #import "Gzip.h"
 
+static const NSUInteger maxAttributeKeyLength = 128;
+
 using namespace bugsnag;
 
 static NSString * EncodeSpanId(SpanId const &spanId) {
@@ -211,60 +213,81 @@ NSArray<NSDictionary *> * OtlpTraceEncoding::encode(NSArray *arrayAttribute) noe
     return result;
 }
 
+void OtlpTraceEncoding::encodeStringAttribute(NSMutableArray *destination, NSString *key, NSString *value) {
+    if (value.length > attributeStringValueLimit_) {
+        uint64_t truncatedCharCount = (uint64_t)value.length - attributeStringValueLimit_;
+        value = [value substringToIndex:attributeStringValueLimit_];
+        value = [NSString stringWithFormat:@"%@*** %llu CHARS TRUNCATED", value, truncatedCharCount];
+    }
+    [destination addObject:@{@"key": key, @"value": @{@"stringValue": value}}];
+}
+
+void OtlpTraceEncoding::encodeArrayAttribute(NSMutableArray *destination, NSString *key, NSArray *value) {
+    if (value.count > attributeArrayLengthLimit_) {
+        value = [value subarrayWithRange:NSMakeRange(0, attributeArrayLengthLimit_)];
+    }
+    [destination addObject:@{@"key": key, @"value": @{@"arrayValue": @{@"values": encode(value)}}}];
+}
+
+void OtlpTraceEncoding::encodeNumberAttribute(NSMutableArray *destination, NSString *key, NSNumber *value) {
+    auto typeId = CFGetTypeID((__bridge CFTypeRef)value);
+    if (typeId == CFBooleanGetTypeID()) {
+        [destination addObject:@{@"key": key, @"value": @{@"boolValue": value}}];
+        return;
+    }
+    if (typeId == CFNumberGetTypeID()) {
+        auto type = CFNumberGetType((__bridge CFNumberRef)value);
+        switch (type) {
+            case kCFNumberSInt8Type:
+            case kCFNumberSInt16Type:
+            case kCFNumberSInt32Type:
+            case kCFNumberCharType:
+            case kCFNumberShortType:
+            case kCFNumberIntType:
+                [destination addObject:@{@"key": key, @"value": @{@"intValue": [value stringValue]}}];
+                return;
+
+            case kCFNumberLongType:
+            case kCFNumberCFIndexType:
+            case kCFNumberNSIntegerType:
+            case kCFNumberSInt64Type:
+            case kCFNumberLongLongType:
+                // "JSON value will be a decimal string. Either numbers or strings are accepted."
+                // https://developers.google.com/protocol-buffers/docs/proto3#json
+                [destination addObject:@{@"key": key, @"value": @{@"intValue": [value stringValue]}}];
+                return;
+
+            case kCFNumberFloat32Type:
+            case kCFNumberFloat64Type:
+            case kCFNumberFloatType:
+            case kCFNumberDoubleType:
+            case kCFNumberCGFloatType:
+                [destination addObject:@{@"key": key, @"value": @{@"doubleValue": value}}];
+                return;
+        }
+    }
+}
+
 NSArray<NSDictionary *> *
 OtlpTraceEncoding::encode(NSDictionary *attributes) noexcept {
     auto result = [NSMutableArray array];
     for (NSString *key in attributes) {
+        if (key.length > maxAttributeKeyLength) {
+            BSGLogError(@"Could not encode attribute %@ because the key is too long", key);
+            continue;
+        }
         id value = attributes[key];
         if ([value isKindOfClass:[NSString class]]) {
-            [result addObject:@{@"key": key, @"value": @{@"stringValue": value}}];
+            encodeStringAttribute(result, key, value);
             continue;
-        }
-        if ([value isKindOfClass:[NSArray class]]) {
-            [result addObject:@{@"key": key, @"value": @{@"arrayValue": @{@"values": encode((NSArray *)value)}}}];
+        } else if ([value isKindOfClass:[NSArray class]]) {
+            encodeArrayAttribute(result, key, value);
             continue;
+        } else if ([value isKindOfClass:[NSNumber class]]) {
+            encodeNumberAttribute(result, key, value);
+        } else {
+            BSGLogError(@"Could not encode attribute %@ because it is of an unknown type %@", key, NSStringFromClass([value class]));
         }
-        if ([value isKindOfClass:[NSNumber class]]) {
-            auto typeId = CFGetTypeID((__bridge CFTypeRef)value);
-            if (typeId == CFBooleanGetTypeID()) {
-                [result addObject:@{@"key": key, @"value": @{@"boolValue": value}}];
-                continue;
-            }
-            if (typeId == CFNumberGetTypeID()) {
-                auto type = CFNumberGetType((__bridge CFNumberRef)value);
-                switch (type) {
-                    case kCFNumberSInt8Type:
-                    case kCFNumberSInt16Type:
-                    case kCFNumberSInt32Type:
-                    case kCFNumberCharType:
-                    case kCFNumberShortType:
-                    case kCFNumberIntType:
-                        [result addObject:@{@"key": key, @"value": @{@"intValue": [value stringValue]}}];
-                        continue;
-                        
-                    case kCFNumberLongType:
-                    case kCFNumberCFIndexType:
-                    case kCFNumberNSIntegerType:
-                    case kCFNumberSInt64Type:
-                    case kCFNumberLongLongType:
-                        // "JSON value will be a decimal string. Either numbers or strings are accepted."
-                        // https://developers.google.com/protocol-buffers/docs/proto3#json
-                        [result addObject:@{@"key": key, @"value": @{@"intValue": [value stringValue]}}];
-                        continue;
-                        
-                    case kCFNumberFloat32Type:
-                    case kCFNumberFloat64Type:
-                    case kCFNumberFloatType:
-                    case kCFNumberDoubleType:
-                    case kCFNumberCGFloatType:
-                        [result addObject:@{@"key": key, @"value": @{@"doubleValue": value}}];
-                        continue;
-                        
-                    default: break;
-                }
-            }
-        }
-        BSGLogError(@"Could not encode attribute %@ because it is of an unknown type %@", key, NSStringFromClass([value class]));
     }
     return result;
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -12,6 +12,14 @@
 
 using namespace bugsnag;
 
+#define MIN_ATTRIBUTE_ARRAY_LENGTH_LIMIT 1
+#define MAX_ATTRIBUTE_ARRAY_LENGTH_LIMIT 10000
+#define DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT 1000
+
+#define MIN_ATTRIBUTE_STRING_VALUE_LIMIT 1
+#define MAX_ATTRIBUTE_STRING_VALUE_LIMIT 10000
+#define DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT 1024
+
 @implementation BugsnagPerformanceConfiguration
 
 - (instancetype)initWithApiKey:(NSString *)apiKey {
@@ -23,6 +31,8 @@ using namespace bugsnag;
         _autoInstrumentViewControllers = YES;
         _autoInstrumentNetworkRequests = YES;
         _onSpanEndCallbacks = [NSMutableArray array];
+        _attributeArrayLengthLimit = DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT;
+        _attributeStringValueLimit = DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT;
 #if defined(DEBUG) && DEBUG
         _releaseStage = @"development";
 #else
@@ -30,6 +40,30 @@ using namespace bugsnag;
 #endif
     }
     return self;
+}
+
+static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInteger max, NSUInteger def) {
+    if(value < min) {
+        return def;
+    }
+    if(value > max) {
+        return max;
+    }
+    return value;
+}
+
+- (void) setAttributeArrayLengthLimit:(NSUInteger)limit {
+    _attributeArrayLengthLimit = minMaxDefault(limit,
+                                               MIN_ATTRIBUTE_ARRAY_LENGTH_LIMIT,
+                                               MAX_ATTRIBUTE_ARRAY_LENGTH_LIMIT,
+                                               DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT);
+}
+
+- (void) setAttributeStringValueLimit:(NSUInteger)limit {
+    _attributeStringValueLimit = minMaxDefault(limit,
+                                               MIN_ATTRIBUTE_STRING_VALUE_LIMIT,
+                                               MAX_ATTRIBUTE_STRING_VALUE_LIMIT,
+                                               DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT);
 }
 
 + (instancetype)loadConfig {

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -66,6 +66,23 @@ OBJC_EXPORT
 
 @property (nullable, nonatomic) BugsnagPerformanceViewControllerInstrumentationCallback viewControllerInstrumentationCallback;
 
+/**
+ * Maximum length of attribute string values in characters. Any characters in excess of
+ * this are discarded, and a warning message will be appended to the string value.
+ *
+ * Default: 1024
+ * Range: 1 - 10000
+ */
+@property (nonatomic) NSUInteger attributeStringValueLimit;
+
+/**
+ * Maximum number of elements in an array. Any elements in excess of this are discarded.
+ *
+ * Default: 1000
+ * Range: 1 - 10000
+ */
+@property (nonatomic) NSUInteger attributeArrayLengthLimit;
+
 @end
 
 @interface BugsnagPerformanceConfiguration (/* App metadata */)

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
@@ -185,4 +185,32 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertEqualObjects(config.endpoint.absoluteString, @"https://0123456789abcdef0123456789abcdef.otlp.bugsnag.com/v1/traces");
 }
 
+- (void)testLimits {
+#define MIN_ATTRIBUTE_COUNT_LIMIT (uint64_t)1
+#define MAX_ATTRIBUTE_COUNT_LIMIT (uint64_t)500
+#define DEFAULT_ATTRIBUTE_COUNT_LIMIT (uint64_t)100
+
+#define MIN_ATTRIBUTE_ARRAY_LENGTH_LIMIT (uint64_t)1
+#define MAX_ATTRIBUTE_ARRAY_LENGTH_LIMIT (uint64_t)10000
+#define DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT (uint64_t)1000
+
+#define MIN_ATTRIBUTE_STRING_VALUE_LIMIT (uint64_t)1
+#define MAX_ATTRIBUTE_STRING_VALUE_LIMIT (uint64_t)10000
+#define DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT (uint64_t)1024
+
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
+    XCTAssertEqual(config.attributeArrayLengthLimit, DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT);
+    XCTAssertEqual(config.attributeStringValueLimit, DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT);
+
+    config.attributeArrayLengthLimit = MAX_ATTRIBUTE_ARRAY_LENGTH_LIMIT + 1;
+    config.attributeStringValueLimit = MAX_ATTRIBUTE_STRING_VALUE_LIMIT + 1;
+    XCTAssertEqual(config.attributeArrayLengthLimit, MAX_ATTRIBUTE_ARRAY_LENGTH_LIMIT);
+    XCTAssertEqual(config.attributeStringValueLimit, MAX_ATTRIBUTE_STRING_VALUE_LIMIT);
+
+    config.attributeArrayLengthLimit = 0;
+    config.attributeStringValueLimit = 0;
+    XCTAssertEqual(config.attributeArrayLengthLimit, DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT);
+    XCTAssertEqual(config.attributeStringValueLimit, DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT);
+}
+
 @end

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -313,6 +313,18 @@ Feature: Manual creation of spans
     * a span array attribute "c" contains the value true at index 2
     * a span array attribute "c" contains the float value 1.5 at index 3
 
+  Scenario: Set attributes in a span with limits set
+    Given I run "SetAttributesWithLimitsScenario"
+    And I wait for 1 span
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * a span string attribute "a" equals "1234567890*** 1 CHARS TRUNCATED"
+    * a span array attribute "b" contains the integer value 1 at index 0
+    * a span array attribute "b" contains the integer value 2 at index 1
+    * a span array attribute "b" contains the integer value 3 at index 2
+    * a span array attribute "b" contains no value at index 3
+
   Scenario: Set OnEnd
     Given I run "OnEndCallbackScenario"
     And I wait for exactly 1 span

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		09D59E1D2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */; };
 		09DA59A52A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */; };
 		09DC622A2C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */; };
+		09E0455F2C94662B003882D3 /* SetAttributesWithLimitsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E0455E2C94662B003882D3 /* SetAttributesWithLimitsScenario.swift */; };
 		09E9BDAF2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E9BDAE2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift */; };
 		09F025072BA08804007D9F73 /* ObjCURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F025062BA08804007D9F73 /* ObjCURLSession.m */; };
 		09F025092BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */; };
@@ -120,6 +121,7 @@
 		09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkTracePropagationScenario.swift; sourceTree = "<group>"; };
 		09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkCallbackScenario.swift; sourceTree = "<group>"; };
 		09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarlySpanOnEndScenario.swift; sourceTree = "<group>"; };
+		09E0455E2C94662B003882D3 /* SetAttributesWithLimitsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAttributesWithLimitsScenario.swift; sourceTree = "<group>"; };
 		09E9BDAE2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyEarlySpansScenario.swift; sourceTree = "<group>"; };
 		09F025052BA08804007D9F73 /* ObjCURLSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCURLSession.h; sourceTree = "<group>"; };
 		09F025062BA08804007D9F73 /* ObjCURLSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCURLSession.m; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
 				094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */,
+				09E0455E2C94662B003882D3 /* SetAttributesWithLimitsScenario.swift */,
 				09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */,
 			);
 			path = Scenarios;
@@ -401,6 +404,7 @@
 				09637A3C2B0607F300F4F776 /* Logging.swift in Sources */,
 				9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */,
 				01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */,
+				09E0455F2C94662B003882D3 /* SetAttributesWithLimitsScenario.swift in Sources */,
 				01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */,
 				96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */,
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/SetAttributesWithLimitsScenario.swift
+++ b/features/fixtures/ios/Scenarios/SetAttributesWithLimitsScenario.swift
@@ -1,0 +1,25 @@
+//
+//  SetAttributesWithLimitsScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 13.09.24.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class SetAttributesWithLimitsScenario: Scenario {
+
+    override func configure() {
+        super.configure()
+        config.attributeStringValueLimit = 10
+        config.attributeArrayLengthLimit = 3
+    }
+
+    override func run() {
+        let span = BugsnagPerformance.startSpan(name: "MySpan")
+        span.setAttribute("a", withValue: "12345678901")
+        span.setAttribute("b", withValue: [1, 2, 3, 4])
+        span.end()
+    }
+}

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -198,6 +198,11 @@ Then('a span array attribute {string} contains the value false at index {int}') 
   Maze.check.true(value == false)
 end
 
+Then('a span array attribute {string} contains no value at index {int}') do |attribute, index|
+  array = get_array_attribute_contents(attribute)
+  Maze.check.true(array.length() <= index)
+end
+
 def get_array_value_at_index(attribute, index, type)
   array = get_array_attribute_contents(attribute)
   Maze.check.true(array.length() > index)


### PR DESCRIPTION
## Goal

Adds configurable size limits to string and array span attribute values.

These can be configured:

- `attributeStringValueLimit`
- `attributeArrayLengthLimit`

## Testing

Added unit tests and e2e test.
