### PR TITLE
[PLAT-12705] Add missing / misnamed fields to plist configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ Changelog
 
 ### Bug fixes
 
-* Make sure no early network spans escape when automatic span capture is disabled.
+* Make sure that no early network spans escape when automatic network span capture is disabled.
   [317](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/317)
+
+* Add missing / misnamed fields to plist configuration.
+  [316](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/316)
 
 ## 1.8.1 (2024-09-03)
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -96,13 +96,17 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
     auto bundleVersion = getSharedConfigValue(@"bundleVersion");
     auto releaseStage = getSharedConfigValue(@"releaseStage");
     auto enabledReleaseStages = getSharedConfigArray(@"enabledReleaseStages");
-    
-    auto serviceName = BSGDynamicCast<NSString>(bugsnagPerformanceConfiguration[@"service.name"]);
+
+    auto serviceName = BSGDynamicCast<NSString>(bugsnagPerformanceConfiguration[@"serviceName"]);
     auto endpoint = BSGDynamicCast<NSString>(bugsnagPerformanceConfiguration[@"endpoint"]);
+    auto tracePropagationUrls = BSGDynamicCast<NSArray<NSString *>>(bugsnagPerformanceConfiguration[@"tracePropagationUrls"]);
     auto autoInstrumentAppStarts = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"autoInstrumentAppStarts"]);
     auto autoInstrumentViewControllers = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"autoInstrumentViewControllers"]);
     auto autoInstrumentNetworkRequests = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"autoInstrumentNetworkRequests"]);
     auto samplingProbability = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"samplingProbability"]);
+    auto attributeArrayLengthLimit = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"attributeArrayLengthLimit"]);
+    auto attributeStringValueLimit = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"attributeStringValueLimit"]);
+    auto attributeCountLimit = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"attributeCountLimit"]);
     auto configuration = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:apiKey];
     if (appVersion) {
         configuration.appVersion = appVersion;
@@ -114,6 +118,16 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
         configuration.releaseStage = releaseStage;
     }
     configuration.enabledReleaseStages = [NSSet setWithArray: enabledReleaseStages ?: @[]];
+    if (tracePropagationUrls) {
+        NSMutableSet<NSRegularExpression *> *exprs = [NSMutableSet setWithCapacity:tracePropagationUrls.count];
+        for (NSString *pattern: tracePropagationUrls) {
+            NSRegularExpression *expr = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:nil];
+            if (expr != nil) {
+                [exprs addObject:expr];
+            }
+        }
+        [configuration setTracePropagationUrls:exprs];
+    }
     if (serviceName) {
         configuration.serviceName = serviceName;
     }
@@ -131,6 +145,15 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
     }
     if (samplingProbability != nil) {
         configuration.samplingProbability = samplingProbability;
+    }
+    if (attributeArrayLengthLimit != nil) {
+        configuration.attributeArrayLengthLimit = attributeArrayLengthLimit.unsignedLongValue;
+    }
+    if (attributeStringValueLimit != nil) {
+        configuration.attributeStringValueLimit = attributeStringValueLimit.unsignedLongValue;
+    }
+    if (attributeCountLimit != nil) {
+        configuration.attributeCountLimit = attributeCountLimit.unsignedLongValue;
     }
     return configuration;
 }

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
@@ -22,8 +22,10 @@ static NSString *const performanceBundleVersion = @"PerformanceBundleVersion";
 static NSString *const performanceReleaseStage = @"PerformanceReleaseStage";
 static NSString *const performanceReleaseStage1 = @"PerformanceEnabledReleaseStage1";
 static NSString *const performanceReleaseStage2 = @"PerformanceEnabledReleaseStage2";
+static NSString *const performanceServiceName = @"PerformanceServiceName";
 static NSString *const performanceEndpoint = @"PerformanceEndpoint";
 static NSArray *const performanceEnabledReleaseStages = @[performanceReleaseStage1, performanceReleaseStage2];
+static NSArray *const performanceTracePropagationUrls = @[@"https://my.company.com/.*", @"https://somewhere.com/[0-9]+/abc/*"];
 
 static NSString *const bugsnagApiKey = @"PerfromanceApiKey";
 static NSString *const bugsnagAppVersion = @"PerfromanceAppVersion";
@@ -88,6 +90,14 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertFalse([config shouldSendReports]);
 }
 
+- (void)assertConfig:(BugsnagPerformanceConfiguration *)config tracePropagationUrlsAre:(NSArray<NSString *> *) regexStrings {
+    XCTAssertEqual(config.tracePropagationUrls.count, regexStrings.count);
+    for(NSString *regexString: regexStrings) {
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexString options:0 error:nil];
+        XCTAssertTrue([config.tracePropagationUrls containsObject:regex]);
+    }
+}
+
 - (void)testLoadConfigLoadsWhenAllValuesAreInPerformanceDictionary {
     auto config = [BugsnagPerformanceConfiguration loadConfigWithInfoDictionary:@{
         @"bugsnag": @{
@@ -97,7 +107,12 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
                 @"bundleVersion": performanceBundleVersion,
                 @"releaseStage": performanceReleaseStage,
                 @"enabledReleaseStages": performanceEnabledReleaseStages,
+                @"serviceName": performanceServiceName,
                 @"endpoint": performanceEndpoint,
+                @"attributeArrayLengthLimit": @100,
+                @"attributeStringValueLimit": @200,
+                @"attributeCountLimit": @50,
+                @"tracePropagationUrls": performanceTracePropagationUrls,
                 @"autoInstrumentAppStarts": @(NO),
                 @"autoInstrumentViewControllers": @(NO),
                 @"autoInstrumentNetworkRequests": @(YES),
@@ -112,6 +127,10 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertTrue([config.enabledReleaseStages containsObject:performanceReleaseStage1]);
     XCTAssertTrue([config.enabledReleaseStages containsObject:performanceReleaseStage2]);
     XCTAssertEqualObjects([config.endpoint description], performanceEndpoint);
+    XCTAssertEqual(config.attributeArrayLengthLimit, (NSUInteger)100);
+    XCTAssertEqual(config.attributeStringValueLimit, (NSUInteger)200);
+    XCTAssertEqual(config.attributeCountLimit, (NSUInteger)50);
+    [self assertConfig:config tracePropagationUrlsAre:performanceTracePropagationUrls];
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
@@ -131,7 +150,12 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
                 @"bundleVersion": performanceBundleVersion,
                 @"releaseStage": performanceReleaseStage,
                 @"enabledReleaseStages": performanceEnabledReleaseStages,
+                @"serviceName": performanceServiceName,
                 @"endpoint": performanceEndpoint,
+                @"attributeArrayLengthLimit": @100,
+                @"attributeStringValueLimit": @200,
+                @"attributeCountLimit": @50,
+                @"tracePropagationUrls": performanceTracePropagationUrls,
                 @"autoInstrumentAppStarts": @(NO),
                 @"autoInstrumentViewControllers": @(NO),
                 @"autoInstrumentNetworkRequests": @(YES),
@@ -145,7 +169,12 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertEqual(config.enabledReleaseStages.count, performanceEnabledReleaseStages.count);
     XCTAssertTrue([config.enabledReleaseStages containsObject:performanceReleaseStage1]);
     XCTAssertTrue([config.enabledReleaseStages containsObject:performanceReleaseStage2]);
+    XCTAssertEqualObjects(config.serviceName, performanceServiceName);
     XCTAssertEqualObjects([config.endpoint description], performanceEndpoint);
+    XCTAssertEqual(config.attributeArrayLengthLimit, (NSUInteger)100);
+    XCTAssertEqual(config.attributeStringValueLimit, (NSUInteger)200);
+    XCTAssertEqual(config.attributeCountLimit, (NSUInteger)50);
+    [self assertConfig:config tracePropagationUrlsAre:performanceTracePropagationUrls];
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);


### PR DESCRIPTION
## Goal

These were missed in an earlier PR.

## Testing

Updated unit tests to check for them.
