### PR TITLE
[PLAT-12731] Make sure that no early network spans escape when automatic network span capture is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog
 * Added configurable span attribute limits for string and array types.
   [314](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/314)
 
+### Bug fixes
+
+* Make sure no early network spans escape when automatic span capture is disabled.
+  [317](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/317)
+
 ## 1.8.1 (2024-09-03)
 
 ### Bug fixes

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
@@ -189,6 +189,13 @@ void NetworkInstrumentation::endEarlySpansPhase() noexcept {
     isEarlySpansPhase_ = false;
     auto spans = earlySpans_;
     earlySpans_ = nil;
+
+    if (!isEnabled_) {
+        for (BugsnagPerformanceSpan *span: spans) {
+            [span abortUnconditionally];
+        }
+    }
+
     for (BugsnagPerformanceSpan *span: spans) {
         auto info = [BugsnagPerformanceNetworkRequestInfo new];
         NSString *urlString = [span getAttribute:spanAttributesProvider_->httpUrlAttributeKey()];

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -621,6 +621,33 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
 
+  Scenario: Capture automatic network span before configuration
+    Given I run "AutoInstrumentNetworkPreStartScenario"
+    And I wait for 2 seconds
+    And I wait for exactly 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "parentSpanId" does not exist
+    * a span field "name" equals "[HTTP/GET]"
+    * a span string attribute "http.flavor" exists
+    * a span string attribute "http.url" matches the regex "http://.*:9[0-9]{3}/reflect\?status=200"
+    * a span string attribute "http.method" equals "GET"
+    * a span integer attribute "http.status_code" is greater than 0
+    * a span integer attribute "http.response_content_length" is greater than 0
+    * a span string attribute "net.host.connection.type" equals "wifi"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.cocoaperformance"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]\.[0-9]\.[0-9]"
+
+  Scenario: Capture automatic network span before configuration (disabled)
+    Given I run "AutoInstrumentNetworkPreStartDisabledScenario"
+    And I should receive no traces
+
   Scenario: Make sure OnSpanEnd callbacks also get called for early spans.
     Given I run "EarlySpanOnEndScenario"
     And I wait for exactly 1 span

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */; };
 		01FE4DC528E1AF9600D1F239 /* Scenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC428E1AF9600D1F239 /* Scenario.swift */; };
 		01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FE4DC628E1D5A400D1F239 /* Fixture.swift */; };
+		091B95722CA179AC007DC8A9 /* AutoInstrumentNetworkPreStartScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 091B95712CA179AC007DC8A9 /* AutoInstrumentNetworkPreStartScenario.swift */; };
+		091B95742CA18F66007DC8A9 /* AutoInstrumentNetworkPreStartDisabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 091B95732CA18F66007DC8A9 /* AutoInstrumentNetworkPreStartDisabledScenario.swift */; };
 		0921F02E2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */; };
 		09301DC12B63A65A000A7C12 /* ComplexViewScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */; };
 		093EE63D2C32E5B900632B30 /* ManualParentSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */; };
@@ -99,6 +101,8 @@
 		01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanScenario.swift; sourceTree = "<group>"; };
 		01FE4DC428E1AF9600D1F239 /* Scenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scenario.swift; sourceTree = "<group>"; };
 		01FE4DC628E1D5A400D1F239 /* Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
+		091B95712CA179AC007DC8A9 /* AutoInstrumentNetworkPreStartScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkPreStartScenario.swift; sourceTree = "<group>"; };
+		091B95732CA18F66007DC8A9 /* AutoInstrumentNetworkPreStartDisabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkPreStartDisabledScenario.swift; sourceTree = "<group>"; };
 		0921F02D2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkCallbackScenario.swift; sourceTree = "<group>"; };
 		09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplexViewScenario.swift; sourceTree = "<group>"; };
 		093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualParentSpanScenario.swift; sourceTree = "<group>"; };
@@ -248,6 +252,7 @@
 				CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */,
 				CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */,
 				09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */,
+				091B95712CA179AC007DC8A9 /* AutoInstrumentNetworkPreStartScenario.swift */,
 				09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
 				097FFC0A2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift */,
@@ -290,10 +295,11 @@
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
+				09E045602C98649D003882D3 /* SetAttributeCountLimitScenario.swift */,
 				094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */,
 				09E0455E2C94662B003882D3 /* SetAttributesWithLimitsScenario.swift */,
 				09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */,
-				09E045602C98649D003882D3 /* SetAttributeCountLimitScenario.swift */,
+				091B95732CA18F66007DC8A9 /* AutoInstrumentNetworkPreStartDisabledScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -423,6 +429,7 @@
 				CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */,
 				09637A3F2B06082200F4F776 /* Logging.m in Sources */,
 				CB3477182901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift in Sources */,
+				091B95742CA18F66007DC8A9 /* AutoInstrumentNetworkPreStartDisabledScenario.swift in Sources */,
 				CBE6B66B28FD66B400D1CF78 /* ManualNetworkSpanScenario.swift in Sources */,
 				098C3B2D2C523EC5006F9886 /* OnEndCallbackScenario.swift in Sources */,
 				098808E02B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift in Sources */,
@@ -438,6 +445,7 @@
 				CB2B8A9F2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift in Sources */,
 				09F025152BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift in Sources */,
 				CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */,
+				091B95722CA179AC007DC8A9 /* AutoInstrumentNetworkPreStartScenario.swift in Sources */,
 				098C3B522C53CECF006F9886 /* SwiftErrorGenerator.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,
 				01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkPreStartDisabledScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkPreStartDisabledScenario.swift
@@ -1,0 +1,34 @@
+//
+//  AutoInstrumentNetworkPreStartDisabledScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 23.09.24.
+//
+
+import Foundation
+
+@objcMembers
+class AutoInstrumentNetworkPreStartDisabledScenario: Scenario {
+    
+    override func configure() {
+        super.configure()
+        config.autoInstrumentNetworkRequests = false
+    }
+    
+    override func startBugsnag() {
+        query(string: "?status=200")
+        
+        // Wait for the query to finish before starting bugsnag
+        Thread.sleep(forTimeInterval: 2.0)
+        
+        super.startBugsnag()
+    }
+    
+    func query(string: String) {
+        let url = URL(string: string, relativeTo: fixtureConfig.reflectURL)!
+        URLSession.shared.dataTask(with: url).resume()
+    }
+    
+    override func run() {
+    }
+}

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkPreStartScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkPreStartScenario.swift
@@ -1,0 +1,34 @@
+//
+//  AutoInstrumentNetworkPreStartScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 23.09.24.
+//
+
+import Foundation
+
+@objcMembers
+class AutoInstrumentNetworkPreStartScenario: Scenario {
+    
+    override func configure() {
+        super.configure()
+        config.autoInstrumentNetworkRequests = true
+    }
+    
+    override func startBugsnag() {
+        query(string: "?status=200")
+        
+        // Wait for the query to finish before starting bugsnag
+        Thread.sleep(forTimeInterval: 2.0)
+        
+        super.startBugsnag()
+    }
+    
+    func query(string: String) {
+        let url = URL(string: string, relativeTo: fixtureConfig.reflectURL)!
+        URLSession.shared.dataTask(with: url).resume()
+    }
+    
+    override func run() {
+    }
+}

--- a/features/swizzling_disabled/automatic_spans.feature
+++ b/features/swizzling_disabled/automatic_spans.feature
@@ -28,3 +28,11 @@ Feature: Automatic instrumentation spans
   Scenario: Don't send an auto network span that failed to send with swizzling disabled
     Given I run "AutoInstrumentNetworkBadAddressScenario"
     And I should receive no traces
+
+  Scenario: Don't send early network spans with swizzling disabled
+    Given I run "AutoInstrumentNetworkPreStartScenario"
+    And I should receive no traces
+
+  Scenario: Capture automatic network span before configuration (disabled)
+    Given I run "AutoInstrumentNetworkPreStartDisabledScenario"
+    And I should receive no traces


### PR DESCRIPTION
## Goal

There was still a potential for early network spans to leak through even when disabled via configuration. This PR closes that hole.

## Testing

Added new e2e tests.
