### PR TITLE
Rendering metrics on first class spans only

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -72,7 +72,14 @@
 		8A80DA912966CEB30035BDA9 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A80DA80296588840035BDA9 /* ConfigurationTests.swift */; };
 		960EECF12B23DF9B009FAA11 /* BugsnagPerformanceTrackedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960EECED2B237561009FAA11 /* BugsnagPerformanceTrackedViewController.swift */; };
 		960EECF32B24CA24009FAA11 /* BugsnagPerformanceTrackedViewContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 960EECF22B24C89A009FAA11 /* BugsnagPerformanceTrackedViewContainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		962D7B342C7DEDD0004330E4 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 962D7B332C7DEDD0004330E4 /* QuartzCore.framework */; };
 		962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F80F129DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift */; };
+		966634D12C8909BB004A934D /* FrameMetricsCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 966634D02C8909BB004A934D /* FrameMetricsCollector.h */; };
+		966634D32C8909D9004A934D /* FrameMetricsCollector.mm in Sources */ = {isa = PBXBuildFile; fileRef = 966634D22C8909D9004A934D /* FrameMetricsCollector.mm */; };
+		966634D52C8A3647004A934D /* FrameMetricsSnapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 966634D42C8A3640004A934D /* FrameMetricsSnapshot.h */; };
+		966634D72C8A365B004A934D /* FrameMetricsSnapshot.mm in Sources */ = {isa = PBXBuildFile; fileRef = 966634D62C8A365B004A934D /* FrameMetricsSnapshot.mm */; };
+		966634DA2C8A39B1004A934D /* FrozenFrameData.h in Headers */ = {isa = PBXBuildFile; fileRef = 966634D92C8A39B1004A934D /* FrozenFrameData.h */; };
+		966634DC2C8A39C1004A934D /* FrozenFrameData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 966634DB2C8A39C1004A934D /* FrozenFrameData.mm */; };
 		966DD5012A211D7F002030B2 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		966DD5022A211D7F002030B2 /* BugsnagPerformance.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		967F6F1829C3783B0054EED8 /* BugsnagPerformanceConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */; };
@@ -306,7 +313,14 @@
 		8A80DA872966CE940035BDA9 /* BugsnagPerformance-iOSTestsSwift.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagPerformance-iOSTestsSwift.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		960EECED2B237561009FAA11 /* BugsnagPerformanceTrackedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugsnagPerformanceTrackedViewController.swift; sourceTree = "<group>"; };
 		960EECF22B24C89A009FAA11 /* BugsnagPerformanceTrackedViewContainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceTrackedViewContainer.h; sourceTree = "<group>"; };
+		962D7B332C7DEDD0004330E4 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
 		962F80F129DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMicrobenchmarkTests.swift; sourceTree = "<group>"; };
+		966634D02C8909BB004A934D /* FrameMetricsCollector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameMetricsCollector.h; sourceTree = "<group>"; };
+		966634D22C8909D9004A934D /* FrameMetricsCollector.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FrameMetricsCollector.mm; sourceTree = "<group>"; };
+		966634D42C8A3640004A934D /* FrameMetricsSnapshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameMetricsSnapshot.h; sourceTree = "<group>"; };
+		966634D62C8A365B004A934D /* FrameMetricsSnapshot.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FrameMetricsSnapshot.mm; sourceTree = "<group>"; };
+		966634D92C8A39B1004A934D /* FrozenFrameData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrozenFrameData.h; sourceTree = "<group>"; };
+		966634DB2C8A39C1004A934D /* FrozenFrameData.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FrozenFrameData.mm; sourceTree = "<group>"; };
 		967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
 		96D415F029E6ADC500AEE435 /* BugsnagPerformanceTestsApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BugsnagPerformanceTestsApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		96D415F229E6ADC500AEE435 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -431,6 +445,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				962D7B342C7DEDD0004330E4 /* QuartzCore.framework in Frameworks */,
 				96D4160A29F05FA900AEE435 /* CoreTelephony.framework in Frameworks */,
 				01A414D42913CAE7003152A4 /* SystemConfiguration.framework in Frameworks */,
 				CBF7C5E4297A964900D47719 /* libz.tbd in Frameworks */,
@@ -518,6 +533,7 @@
 		0122C21F29019770002D243C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				966634D82C8A3939004A934D /* FrameRateMetrics */,
 				CB572EA829BB783200FD7A2A /* AppStateTracker.h */,
 				CB572EA929BB783200FD7A2A /* AppStateTracker.m */,
 				CBE8EA1C294B5E1500702950 /* Batch.h */,
@@ -610,6 +626,7 @@
 		0122C25629019904002D243C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				962D7B332C7DEDD0004330E4 /* QuartzCore.framework */,
 				96D4160929F05FA900AEE435 /* CoreTelephony.framework */,
 				CBF7C5E3297A963A00D47719 /* libz.tbd */,
 				01A414D32913CAE7003152A4 /* SystemConfiguration.framework */,
@@ -715,6 +732,19 @@
 			path = BugsnagPerformanceTestsSwift;
 			sourceTree = "<group>";
 		};
+		966634D82C8A3939004A934D /* FrameRateMetrics */ = {
+			isa = PBXGroup;
+			children = (
+				966634D02C8909BB004A934D /* FrameMetricsCollector.h */,
+				966634D22C8909D9004A934D /* FrameMetricsCollector.mm */,
+				966634D42C8A3640004A934D /* FrameMetricsSnapshot.h */,
+				966634D62C8A365B004A934D /* FrameMetricsSnapshot.mm */,
+				966634D92C8A39B1004A934D /* FrozenFrameData.h */,
+				966634DB2C8A39C1004A934D /* FrozenFrameData.mm */,
+			);
+			path = FrameRateMetrics;
+			sourceTree = "<group>";
+		};
 		96D415F129E6ADC500AEE435 /* BugsnagPerformanceTestsApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -784,6 +814,7 @@
 			files = (
 				CB04969729150D860097E526 /* OtlpPackage.h in Headers */,
 				960EECF32B24CA24009FAA11 /* BugsnagPerformanceTrackedViewContainer.h in Headers */,
+				966634D52C8A3647004A934D /* FrameMetricsSnapshot.h in Headers */,
 				CB34772029068C350033759C /* BSGURLSessionPerformanceProxy.h in Headers */,
 				0122C24C29019770002D243C /* NetworkInstrumentation.h in Headers */,
 				CB7FD930299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h in Headers */,
@@ -807,6 +838,7 @@
 				0921F02B2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h in Headers */,
 				0122C24A29019770002D243C /* AppStartupInstrumentation.h in Headers */,
 				CB04969B2915194E0097E526 /* OtlpUploader.h in Headers */,
+				966634D12C8909BB004A934D /* FrameMetricsCollector.h in Headers */,
 				0122C25029019770002D243C /* BugsnagPerformanceSpan+Private.h in Headers */,
 				09D59E1A2BDFE0D900199E1B /* NetworkHeaderInjector.h in Headers */,
 				0122C23F29019770002D243C /* OtlpTraceEncoding.h in Headers */,
@@ -828,6 +860,7 @@
 				CBEBE59329F2783C00BF0B4F /* Swizzle.h in Headers */,
 				CBEC51BC296D9EEE009C0CE3 /* PersistentState.h in Headers */,
 				0122C23829019770002D243C /* BugsnagPerformanceSpan.h in Headers */,
+				966634DA2C8A39B1004A934D /* FrozenFrameData.h in Headers */,
 				CB0AD76A296573FC002A3FB6 /* BugsnagPerformanceErrors.h in Headers */,
 				0122C23B29019770002D243C /* BugsnagPerformance.h in Headers */,
 				0122C24B29019770002D243C /* ViewLoadInstrumentation.h in Headers */,
@@ -1170,11 +1203,13 @@
 				CB04969829150D860097E526 /* OtlpPackage.mm in Sources */,
 				0122C23D29019770002D243C /* BugsnagPerformance.mm in Sources */,
 				CBEC51D72976BCAD009C0CE3 /* Filesystem.mm in Sources */,
+				966634D32C8909D9004A934D /* FrameMetricsCollector.mm in Sources */,
 				CB7FD932299D2F7700499E13 /* BugsnagPerformanceSpanOptions.m in Sources */,
 				CBEC51BD296D9EEE009C0CE3 /* PersistentState.mm in Sources */,
 				CBEC51B9296D8386009C0CE3 /* Persistence.mm in Sources */,
 				CB572EAB29BB783200FD7A2A /* AppStateTracker.m in Sources */,
 				CBE8EA17294B528100702950 /* BugsnagPerformanceImpl.mm in Sources */,
+				966634DC2C8A39C1004A934D /* FrozenFrameData.mm in Sources */,
 				0122C23E29019770002D243C /* BugsnagPerformanceSpan.mm in Sources */,
 				0987F27A2C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm in Sources */,
 				CBEC51DD2976F1F9009C0CE3 /* RetryQueue.mm in Sources */,
@@ -1204,6 +1239,7 @@
 				CBE0872929F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm in Sources */,
 				CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */,
 				0921F02C2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m in Sources */,
+				966634D72C8A365B004A934D /* FrameMetricsSnapshot.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 Changelog
 =========
 
-## 1.9.0 (2024-09-25)
+## TBD
 
 ### Enhancements
 
 * Added rendering metrics to first class spans.
   [319](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/319)
+
+## 1.9.0 (2024-09-25)
+
+### Enhancements
 
 * Added configurable limit to number of span attributes per span.
   [315](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/315)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Enhancements
 
+* Added rendering metrics to first class spans.
+  [319](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/319)
+
 * Added configurable limit to number of span attributes per span.
   [315](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/315)
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -26,6 +26,7 @@
 #import "ResourceAttributes.h"
 #import "NetworkHeaderInjector.h"
 #import "OtlpTraceEncoding.h"
+#import "FrameRateMetrics/FrameMetricsCollector.h"
 
 #import <mutex>
 
@@ -79,6 +80,7 @@ private:
     std::shared_ptr<SpanAttributesProvider> spanAttributesProvider_;
     std::shared_ptr<class Sampler> sampler_;
     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector_;
+    FrameMetricsCollector *frameMetricsCollector_;
     std::shared_ptr<Tracer> tracer_;
     std::unique_ptr<RetryQueue> retryQueue_;
     AppStateTracker *appStateTracker_;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -47,7 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) SpanKind kind;
 @property (nonatomic,readwrite) BOOL isMutable;
 @property (nonatomic,readonly) NSUInteger attributeCountLimit;
-@property (nonatomic,readwrite) BOOL shouldInstrumentRendering;
+@property (nonatomic,readwrite) BOOL wasStartOrEndTimeProvided;
+@property (nonatomic) BSGInstrumentRendering instrumentRendering;
 @property (nonatomic, strong) FrameMetricsSnapshot *startFramerateSnapshot;
 @property (nonatomic, strong) FrameMetricsSnapshot *endFramerateSnapshot;
 
@@ -64,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
                    startTime:(CFAbsoluteTime) startTime
                   firstClass:(BSGFirstClass) firstClass
          attributeCountLimit:(NSUInteger)attributeCountLimit
-   shouldInstrumentRendering:(BOOL)shouldInstrumentRendering
+         instrumentRendering:(BSGInstrumentRendering)instrumentRendering
                 onSpanClosed:(OnSpanClosed) onSpanEnded NS_DESIGNATED_INITIALIZER;
 
 - (void)internalSetAttribute:(NSString *)attributeName withValue:(_Nullable id)value;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -10,6 +10,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 #import "BugsnagPerformanceSpanContext+Private.h"
 #import "SpanKind.h"
+#import "FrameRateMetrics/FrameMetricsSnapshot.h"
 
 #import <memory>
 
@@ -46,6 +47,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) SpanKind kind;
 @property (nonatomic,readwrite) BOOL isMutable;
 @property (nonatomic,readonly) NSUInteger attributeCountLimit;
+@property (nonatomic,readwrite) BOOL wasEndedWithEndTime;
+@property (nonatomic, strong) FrameMetricsSnapshot *startFramerateSnapshot;
+@property (nonatomic, strong) FrameMetricsSnapshot *endFramerateSnapshot;
+
+
 
 @property(nonatomic) uint64_t startClock;
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) SpanKind kind;
 @property (nonatomic,readwrite) BOOL isMutable;
 @property (nonatomic,readonly) NSUInteger attributeCountLimit;
-@property (nonatomic,readwrite) BOOL wasEndedWithEndTime;
+@property (nonatomic,readwrite) BOOL shouldInstrumentRendering;
 @property (nonatomic, strong) FrameMetricsSnapshot *startFramerateSnapshot;
 @property (nonatomic, strong) FrameMetricsSnapshot *endFramerateSnapshot;
 
@@ -64,6 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
                    startTime:(CFAbsoluteTime) startTime
                   firstClass:(BSGFirstClass) firstClass
          attributeCountLimit:(NSUInteger)attributeCountLimit
+   shouldInstrumentRendering:(BOOL)shouldInstrumentRendering
                 onSpanClosed:(OnSpanClosed) onSpanEnded NS_DESIGNATED_INITIALIZER;
 
 - (void)internalSetAttribute:(NSString *)attributeName withValue:(_Nullable id)value;

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.h
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.h
@@ -1,0 +1,20 @@
+//
+//  FrameMetricsCollector.h
+//  BugsnagPerformance
+//
+//  Created by Robert B on 23/08/2024.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#pragma once
+#import "../PhasedStartup.h"
+#import "FrameMetricsSnapshot.h"
+
+@interface FrameMetricsCollector: NSObject<BSGPhasedStartup>
+
+- (void)onAppEnteredBackground;
+- (void)onAppEnteredForeground;
+- (FrameMetricsSnapshot *)currentSnapshot;
+
+@end
+

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
@@ -1,0 +1,127 @@
+//
+//  FrameMetricsCollector.mm
+//  BugsnagPerformance
+//
+//  Created by Robert B on 23/08/2024.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+
+#import "BugsnagPerformance/BugsnagPerformanceConfiguration.h"
+#import "../EarlyConfiguration.h"
+#import "FrameMetricsCollector.h"
+#import "FrozenFrameData.h"
+
+static const CGFloat kFrozenFrameThreshold = 0.7;
+static const CGFloat kSlowFrameRatioThreshold = 1.3;
+
+@interface FrameMetricsCollector ()
+
+@property(nonatomic, readwrite) uint64_t totalFrames;
+@property(nonatomic, readwrite) uint64_t totalSlowFrames;
+@property(nonatomic, readwrite) uint64_t totalFrozenFrames;
+
+@property(nonatomic) NSTimeInterval lastFrameTimestamp;
+@property(nonatomic) NSTimeInterval nextFrameTargetTimestamp;
+@property(nonatomic) NSTimeInterval frameTimestampAdjustment;
+
+@property(nonatomic, readwrite) Boolean isInForeground;
+@property(nonatomic, readwrite) Boolean justEnteredForeground;
+@property(nonatomic, strong) FrozenFrameData *lastFrozenFrame;
+
+@end
+
+@implementation FrameMetricsCollector
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _totalFrames = 0;
+        _totalSlowFrames = 0;
+        _totalFrozenFrames = 0;
+        _isInForeground = true;
+        _justEnteredForeground = true;
+        _lastFrozenFrame = [FrozenFrameData root];
+        _frameTimestampAdjustment = [NSDate date].timeIntervalSinceReferenceDate - CACurrentMediaTime();
+    }
+    return self;
+}
+
+- (void)onAppEnteredBackground {
+    self.isInForeground = false;
+}
+
+- (void)onAppEnteredForeground {
+    self.isInForeground = true;
+    self.justEnteredForeground = true;
+    self.frameTimestampAdjustment = [NSDate date].timeIntervalSinceReferenceDate - CACurrentMediaTime();
+}
+
+- (FrameMetricsSnapshot *)currentSnapshot {
+    @synchronized (self) {
+        auto snapshot = [FrameMetricsSnapshot new];
+        snapshot.totalFrames = self.totalFrames;
+        snapshot.totalSlowFrames = self.totalSlowFrames;
+        snapshot.totalFrozenFrames = self.totalFrozenFrames;
+        snapshot.lastFrozenFrame = self.lastFrozenFrame;
+        return snapshot;
+    }
+}
+
+#pragma mark BSGPhasedStartup
+
+- (void)earlyConfigure:(BSGEarlyConfiguration *)config {}
+
+- (void)earlySetup {}
+
+- (void)configure:(BugsnagPerformanceConfiguration *)config {}
+
+- (void)start {
+    CADisplayLink *displayLink = [CADisplayLink displayLinkWithTarget:self
+                                                             selector:@selector(didRenderFrame:)];
+    [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+}
+
+- (void)preStartSetup {}
+
+#pragma mark Private
+
+- (void)didRenderFrame:(CADisplayLink *)sender {
+    @synchronized (self) {
+        if (!self.isInForeground) {
+            return;
+        }
+        auto lastFrameTimestamp = self.lastFrameTimestamp;
+        auto currentFrameTargetTimestamp = self.nextFrameTargetTimestamp;
+        auto currentFrameTimestamp = sender.timestamp;
+        
+        self.lastFrameTimestamp = currentFrameTimestamp;
+        self.nextFrameTargetTimestamp = sender.targetTimestamp;
+        
+        if (self.justEnteredForeground) {
+            self.justEnteredForeground = false;
+            return;
+        }
+        
+        self.totalFrames++;
+        
+        auto renderDuration = currentFrameTimestamp - lastFrameTimestamp;
+        if (renderDuration >= kFrozenFrameThreshold) {
+            self.totalFrozenFrames++;
+            FrozenFrameData *frameData = [[FrozenFrameData alloc] initWithStartTime:lastFrameTimestamp + self.frameTimestampAdjustment
+                                                                            endTime:currentFrameTimestamp + self.frameTimestampAdjustment];
+            self.lastFrozenFrame.next = frameData;
+            self.lastFrozenFrame = frameData;
+        } else {
+            auto expectedRenderDuration = currentFrameTargetTimestamp - lastFrameTimestamp;
+            if (renderDuration >= expectedRenderDuration * kSlowFrameRatioThreshold) {
+                self.totalSlowFrames++;
+            }
+        }
+    }
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
@@ -29,6 +29,7 @@ static const CGFloat kSlowFrameRatioThreshold = 1.3;
 
 @property(nonatomic, readwrite) Boolean isInForeground;
 @property(nonatomic, readwrite) Boolean justEnteredForeground;
+@property(nonatomic, readwrite) Boolean autoInstrumentRendering;
 @property(nonatomic, strong) FrozenFrameData *lastFrozenFrame;
 
 @end
@@ -46,6 +47,7 @@ static const CGFloat kSlowFrameRatioThreshold = 1.3;
         _justEnteredForeground = true;
         _lastFrozenFrame = [FrozenFrameData root];
         _frameTimestampAdjustment = [NSDate date].timeIntervalSinceReferenceDate - CACurrentMediaTime();
+        _autoInstrumentRendering = true;
     }
     return self;
 }
@@ -77,9 +79,14 @@ static const CGFloat kSlowFrameRatioThreshold = 1.3;
 
 - (void)earlySetup {}
 
-- (void)configure:(BugsnagPerformanceConfiguration *)config {}
+- (void)configure:(BugsnagPerformanceConfiguration *)config {
+    self.autoInstrumentRendering = config.autoInstrumentRendering;
+}
 
 - (void)start {
+    if (!self.autoInstrumentRendering) {
+        return;
+    }
     CADisplayLink *displayLink = [CADisplayLink displayLinkWithTarget:self
                                                              selector:@selector(didRenderFrame:)];
     [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsSnapshot.h
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsSnapshot.h
@@ -1,0 +1,25 @@
+//
+//  FrameMetricsSnapshot.h
+//  BugsnagPerformance
+//
+//  Created by Robert B on 23/08/2024.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#pragma once
+#import "../PhasedStartup.h"
+#import "FrozenFrameData.h"
+
+@interface FrameMetricsSnapshot: NSObject
+
+@property(nonatomic, readwrite) uint64_t totalFrames;
+@property(nonatomic, readwrite) uint64_t totalSlowFrames;
+@property(nonatomic, readwrite) uint64_t totalFrozenFrames;
+
+@property(nonatomic, strong) FrozenFrameData *firstFrozenFrame;
+@property(nonatomic, strong) FrozenFrameData *lastFrozenFrame;
+
++ (FrameMetricsSnapshot *)mergeWithStart:(FrameMetricsSnapshot *)startSnapshot end:(FrameMetricsSnapshot *)endSnapshot;
+
+@end
+

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsSnapshot.mm
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsSnapshot.mm
@@ -1,0 +1,24 @@
+//
+//  FrameMetricsSnapshot.mm
+//  BugsnagPerformance
+//
+//  Created by Robert B on 23/08/2024.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "FrameMetricsSnapshot.h"
+
+@implementation FrameMetricsSnapshot
+
++ (FrameMetricsSnapshot *)mergeWithStart:(FrameMetricsSnapshot *)startSnapshot end:(FrameMetricsSnapshot *)endSnapshot {
+    auto result = [FrameMetricsSnapshot new];
+    result.totalFrames = endSnapshot.totalFrames - startSnapshot.totalFrames;
+    result.totalSlowFrames = endSnapshot.totalSlowFrames - startSnapshot.totalSlowFrames;
+    result.totalFrozenFrames = endSnapshot.totalFrozenFrames - startSnapshot.totalFrozenFrames;
+    result.firstFrozenFrame = startSnapshot.lastFrozenFrame.next;
+    result.lastFrozenFrame = endSnapshot.lastFrozenFrame;
+    return result;
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrozenFrameData.h
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrozenFrameData.h
@@ -1,0 +1,22 @@
+//
+//  FrozenFrameData.h
+//  BugsnagPerformance
+//
+//  Created by Robert B on 05/09/2024.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#pragma once
+#import "../PhasedStartup.h"
+
+@interface FrozenFrameData: NSObject
+
+@property(nonatomic, readonly) NSTimeInterval startTime;
+@property(nonatomic, readonly) NSTimeInterval endTime;
+@property(nonatomic, strong) FrozenFrameData *next;
+
+- (instancetype)initWithStartTime:(NSTimeInterval)startTime endTime:(NSTimeInterval)endTime;
+
++ (FrozenFrameData *)root;
+
+@end

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrozenFrameData.mm
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrozenFrameData.mm
@@ -1,0 +1,33 @@
+//
+//  FrozenFrameData.mm
+//  BugsnagPerformance
+//
+//  Created by Robert B on 05/09/2024.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "FrozenFrameData.h"
+
+@interface FrozenFrameData ()
+
+@property(nonatomic, readwrite) NSTimeInterval startTime;
+@property(nonatomic, readwrite) NSTimeInterval endTime;
+
+@end
+
+@implementation FrozenFrameData
+
++ (FrozenFrameData *)root {
+    return [[FrozenFrameData alloc] initWithStartTime:0 endTime:0];
+}
+
+- (instancetype)initWithStartTime:(NSTimeInterval)startTime endTime:(NSTimeInterval)endTime {
+    if ((self = [super init])) {
+        _startTime = startTime;
+        _endTime = endTime;
+    }
+    return self;
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -17,18 +17,21 @@ public:
     SpanOptions(BugsnagPerformanceSpanContext *parentContext,
                 CFAbsoluteTime startTime,
                 bool makeCurrentContext,
-                BSGFirstClass firstClass)
+                BSGFirstClass firstClass,
+                bool instrumentRendering)
     : parentContext(parentContext)
     , startTime(startTime)
     , makeCurrentContext(makeCurrentContext)
     , firstClass(firstClass)
+    , instrumentRendering(instrumentRendering)
     {}
     
     SpanOptions(BugsnagPerformanceSpanOptions *options)
     : SpanOptions(options.parentContext,
                   dateToAbsoluteTime(options.startTime),
                   options.makeCurrentContext,
-                  options.firstClass)
+                  options.firstClass,
+                  options.instrumentRendering)
     {}
     
     SpanOptions()
@@ -36,13 +39,15 @@ public:
     : SpanOptions(nil,
                   CFABSOLUTETIME_INVALID,
                   true,
-                  BSGFirstClassUnset)
+                  BSGFirstClassUnset,
+                  true)
     {}
     
     BugsnagPerformanceSpanContext *parentContext{nil};
     CFAbsoluteTime startTime{CFABSOLUTETIME_INVALID};
     bool makeCurrentContext{false};
     BSGFirstClass firstClass{BSGFirstClassUnset};
+    bool instrumentRendering{true};
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -18,7 +18,7 @@ public:
                 CFAbsoluteTime startTime,
                 bool makeCurrentContext,
                 BSGFirstClass firstClass,
-                bool instrumentRendering)
+                BSGInstrumentRendering instrumentRendering)
     : parentContext(parentContext)
     , startTime(startTime)
     , makeCurrentContext(makeCurrentContext)
@@ -40,14 +40,14 @@ public:
                   CFABSOLUTETIME_INVALID,
                   true,
                   BSGFirstClassUnset,
-                  true)
+                  BSGInstrumentRenderingUnset)
     {}
     
     BugsnagPerformanceSpanContext *parentContext{nil};
     CFAbsoluteTime startTime{CFABSOLUTETIME_INVALID};
     bool makeCurrentContext{false};
     BSGFirstClass firstClass{BSGFirstClassUnset};
-    bool instrumentRendering{true};
+    BSGInstrumentRendering instrumentRendering{BSGInstrumentRenderingUnset};
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -40,6 +40,7 @@ public:
     void configure(BugsnagPerformanceConfiguration *config) noexcept {
         onSpanEndCallbacks_ = config.onSpanEndCallbacks;
         attributeCountLimit_ = config.attributeCountLimit;
+        autoInstrumentRendering_ = config.autoInstrumentRendering;
     };
     void preStartSetup() noexcept;
     void start() noexcept {}
@@ -80,6 +81,7 @@ private:
     FrameMetricsCollector *frameMetricsCollector_;
 
     std::atomic<bool> willDiscardPrewarmSpans_{false};
+    std::atomic<bool> autoInstrumentRendering_{true};
     std::mutex prewarmSpansMutex_;
     NSMutableArray<BugsnagPerformanceSpan *> *prewarmSpans_;
     NSArray<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks_;

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -16,6 +16,7 @@
 #import "SpanAttributesProvider.h"
 #import "SpanStackingHandler.h"
 #import "WeakSpansList.h"
+#import "FrameRateMetrics/FrameMetricsCollector.h"
 
 #import <memory>
 
@@ -30,6 +31,7 @@ public:
     Tracer(std::shared_ptr<SpanStackingHandler> spanContextStack,
            std::shared_ptr<Sampler> sampler,
            std::shared_ptr<Batch> batch,
+           FrameMetricsCollector *frameMetricsCollector,
            void (^onSpanStarted)()) noexcept;
     ~Tracer() {};
 
@@ -75,6 +77,7 @@ private:
     Tracer() = delete;
     std::shared_ptr<Sampler> sampler_;
     std::shared_ptr<SpanStackingHandler> spanStackingHandler_;
+    FrameMetricsCollector *frameMetricsCollector_;
 
     std::atomic<bool> willDiscardPrewarmSpans_{false};
     std::mutex prewarmSpansMutex_;
@@ -91,8 +94,10 @@ private:
     std::function<void(NSString *)> onViewLoadSpanStarted_{ [](NSString *){} };
 
     BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
+    BugsnagPerformanceSpan *startFrozenFrameSpan(NSTimeInterval startTime, BugsnagPerformanceSpanContext *parentContext) noexcept;
     void markPrewarmSpan(BugsnagPerformanceSpan *span) noexcept;
     void onSpanClosed(BugsnagPerformanceSpan *span);
     void reprocessEarlySpans(void);
+    void processFrameMetrics(BugsnagPerformanceSpan *span) noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -94,7 +94,7 @@ private:
     std::function<void(NSString *)> onViewLoadSpanStarted_{ [](NSString *){} };
 
     BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
-    BugsnagPerformanceSpan *startFrozenFrameSpan(NSTimeInterval startTime, BugsnagPerformanceSpanContext *parentContext) noexcept;
+    void createFrozenFrameSpan(NSTimeInterval startTime, NSTimeInterval endTime, BugsnagPerformanceSpanContext *parentContext) noexcept;
     void markPrewarmSpan(BugsnagPerformanceSpan *span) noexcept;
     void onSpanClosed(BugsnagPerformanceSpan *span);
     void reprocessEarlySpans(void);

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -101,5 +101,6 @@ private:
     void onSpanClosed(BugsnagPerformanceSpan *span);
     void reprocessEarlySpans(void);
     void processFrameMetrics(BugsnagPerformanceSpan *span) noexcept;
+    bool shouldInstrumentRendering(BugsnagPerformanceSpan *span) noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -214,8 +214,7 @@ void Tracer::processFrameMetrics(BugsnagPerformanceSpan *span) noexcept {
     
     auto frozenFrame = mergedSnapshot.firstFrozenFrame;
     while (frozenFrame != nil) {
-        auto frozenFrameSpan = startFrozenFrameSpan(frozenFrame.startTime, span);
-        [frozenFrameSpan endWithAbsoluteTime:frozenFrame.endTime];
+        createFrozenFrameSpan(frozenFrame.startTime, frozenFrame.endTime, span);
         frozenFrame = frozenFrame != mergedSnapshot.lastFrozenFrame ? frozenFrame.next : nil;
     }
 }
@@ -287,14 +286,16 @@ void Tracer::markPrewarmSpan(BugsnagPerformanceSpan *span) noexcept {
     }
 }
 
-BugsnagPerformanceSpan *
-Tracer::startFrozenFrameSpan(NSTimeInterval startTime, 
-                             BugsnagPerformanceSpanContext *parentContext) noexcept {
+void
+Tracer::createFrozenFrameSpan(NSTimeInterval startTime,
+                              NSTimeInterval endTime,
+                              BugsnagPerformanceSpanContext *parentContext) noexcept {
     SpanOptions options;
     options.startTime = startTime;
     options.parentContext = parentContext;
     options.makeCurrentContext = false;
-    return startSpan(@"FrozenFrame", options, BSGFirstClassNo);
+    auto span = startSpan(@"FrozenFrame", options, BSGFirstClassNo);
+    [span endWithAbsoluteTime:endTime];
 }
 
 void

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -34,6 +34,7 @@ using namespace bugsnag;
         _autoInstrumentAppStarts = YES;
         _autoInstrumentViewControllers = YES;
         _autoInstrumentNetworkRequests = YES;
+        _autoInstrumentRendering = YES;
         _onSpanEndCallbacks = [NSMutableArray array];
         _attributeArrayLengthLimit = DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT;
         _attributeStringValueLimit = DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT;
@@ -103,6 +104,7 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
     auto autoInstrumentAppStarts = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"autoInstrumentAppStarts"]);
     auto autoInstrumentViewControllers = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"autoInstrumentViewControllers"]);
     auto autoInstrumentNetworkRequests = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"autoInstrumentNetworkRequests"]);
+    auto autoInstrumentRendering = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"autoInstrumentRendering"]);
     auto samplingProbability = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"samplingProbability"]);
     auto attributeArrayLengthLimit = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"attributeArrayLengthLimit"]);
     auto attributeStringValueLimit = BSGDynamicCast<NSNumber>(bugsnagPerformanceConfiguration[@"attributeStringValueLimit"]);
@@ -142,6 +144,9 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
     }
     if (autoInstrumentNetworkRequests != nil) {
         configuration.autoInstrumentNetworkRequests = [autoInstrumentNetworkRequests boolValue];
+    }
+    if (autoInstrumentRendering != nil) {
+        configuration.autoInstrumentRendering = [autoInstrumentRendering boolValue];
     }
     if (samplingProbability != nil) {
         configuration.samplingProbability = samplingProbability;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -34,7 +34,7 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
                    startTime:(CFAbsoluteTime) startAbsTime
                   firstClass:(BSGFirstClass) firstClass
          attributeCountLimit:(NSUInteger)attributeCountLimit
-   shouldInstrumentRendering:(BOOL)shouldInstrumentRendering
+         instrumentRendering:(BSGInstrumentRendering)instrumentRendering
                 onSpanClosed:(OnSpanClosed) onSpanClosed {
     if ((self = [super initWithTraceId:traceId spanId:spanId])) {
         _startClock = currentMonotonicClockNsecIfUnset(startAbsTime);
@@ -55,7 +55,8 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
             _attributes[@"bugsnag.span.first_class"] = @(firstClass == BSGFirstClassYes);
         }
         _attributes[@"bugsnag.sampling.p"] = @(1.0);
-        _shouldInstrumentRendering = shouldInstrumentRendering;
+        _instrumentRendering = instrumentRendering;
+        _wasStartOrEndTimeProvided = isCFAbsoluteTimeValid(startAbsTime);
     }
     return self;
 }
@@ -111,7 +112,7 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
 }
 
 - (void)endWithEndTime:(NSDate *)endTime {
-    self.shouldInstrumentRendering &= endTime == nil;
+    self.wasStartOrEndTimeProvided |= endTime != nil;
     [self endWithAbsoluteTime:(dateToAbsoluteTime(endTime))];
 }
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -109,6 +109,7 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
 }
 
 - (void)endWithEndTime:(NSDate *)endTime {
+    self.wasEndedWithEndTime = endTime != nil;
     [self endWithAbsoluteTime:(dateToAbsoluteTime(endTime))];
 }
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -34,6 +34,7 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
                    startTime:(CFAbsoluteTime) startAbsTime
                   firstClass:(BSGFirstClass) firstClass
          attributeCountLimit:(NSUInteger)attributeCountLimit
+   shouldInstrumentRendering:(BOOL)shouldInstrumentRendering
                 onSpanClosed:(OnSpanClosed) onSpanClosed {
     if ((self = [super initWithTraceId:traceId spanId:spanId])) {
         _startClock = currentMonotonicClockNsecIfUnset(startAbsTime);
@@ -54,6 +55,7 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
             _attributes[@"bugsnag.span.first_class"] = @(firstClass == BSGFirstClassYes);
         }
         _attributes[@"bugsnag.sampling.p"] = @(1.0);
+        _shouldInstrumentRendering = shouldInstrumentRendering;
     }
     return self;
 }
@@ -109,7 +111,7 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
 }
 
 - (void)endWithEndTime:(NSDate *)endTime {
-    self.wasEndedWithEndTime = endTime != nil;
+    self.shouldInstrumentRendering &= endTime == nil;
     [self endWithAbsoluteTime:(dateToAbsoluteTime(endTime))];
 }
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -15,7 +15,7 @@
 @property(nonatomic,strong) BugsnagPerformanceSpanContext *parentContext_;
 @property(nonatomic) BOOL makeCurrentContext_;
 @property(nonatomic) BSGFirstClass firstClass_;
-@property(nonatomic) BOOL instrumentRendering_;
+@property(nonatomic) BSGInstrumentRendering instrumentRendering_;
 @end
 
 @implementation BugsnagPerformanceSpanOptions
@@ -24,6 +24,7 @@
 @synthesize parentContext_ = _parentContext;
 @synthesize makeCurrentContext_ = _makeCurrentContext;
 @synthesize firstClass_ = _firstClass;
+@synthesize instrumentRendering_ = _instrumentRendering;
 
 - (instancetype)init {
     // These defaults must match the defaults in SpanOptions.h
@@ -31,14 +32,14 @@
                      parentContext:nil
                 makeCurrentContext:true
                         firstClass:BSGFirstClassUnset
-               instrumentRendering:true];
+               instrumentRendering:BSGInstrumentRenderingUnset];
 }
 
 - (instancetype)initWithStartTime:(NSDate *)startTime
                     parentContext:(BugsnagPerformanceSpanContext *)parentContext
                makeCurrentContext:(BOOL)makeCurrentContext
                        firstClass:(BSGFirstClass)firstClass
-              instrumentRendering:(BOOL)instrumentRendering {
+              instrumentRendering:(BSGInstrumentRendering)instrumentRendering {
     if ((self = [super init])) {
         _startTime = startTime;
         _parentContext = parentContext;
@@ -69,6 +70,11 @@
     return _firstClass;
 }
 
+- (BSGInstrumentRendering)instrumentRendering {
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+    return _instrumentRendering;
+}
+
 - (instancetype)setStartTime:(NSDate *)startTime {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     _startTime = startTime;
@@ -93,7 +99,7 @@
     return self;
 }
 
-- (instancetype _Nonnull)setInstrumentRendering:(BOOL)instrumentRendering {
+- (instancetype _Nonnull)setInstrumentRendering:(BSGInstrumentRendering)instrumentRendering {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     _instrumentRendering = instrumentRendering;
     return self;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -15,6 +15,7 @@
 @property(nonatomic,strong) BugsnagPerformanceSpanContext *parentContext_;
 @property(nonatomic) BOOL makeCurrentContext_;
 @property(nonatomic) BSGFirstClass firstClass_;
+@property(nonatomic) BOOL instrumentRendering_;
 @end
 
 @implementation BugsnagPerformanceSpanOptions
@@ -29,18 +30,21 @@
     return [self initWithStartTime:nil
                      parentContext:nil
                 makeCurrentContext:true
-                        firstClass:BSGFirstClassUnset];
+                        firstClass:BSGFirstClassUnset
+               instrumentRendering:true];
 }
 
 - (instancetype)initWithStartTime:(NSDate *)startTime
                     parentContext:(BugsnagPerformanceSpanContext *)parentContext
                makeCurrentContext:(BOOL)makeCurrentContext
-                       firstClass:(BSGFirstClass)firstClass {
+                       firstClass:(BSGFirstClass)firstClass
+              instrumentRendering:(BOOL)instrumentRendering {
     if ((self = [super init])) {
         _startTime = startTime;
         _parentContext = parentContext;
         _makeCurrentContext = makeCurrentContext;
         _firstClass = firstClass;
+        _instrumentRendering = instrumentRendering;
     }
     return self;
 }
@@ -89,12 +93,19 @@
     return self;
 }
 
+- (instancetype _Nonnull)setInstrumentRendering:(BOOL)instrumentRendering {
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+    _instrumentRendering = instrumentRendering;
+    return self;
+}
+
 - (instancetype)clone {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     return [[BugsnagPerformanceSpanOptions alloc] initWithStartTime:_startTime
                                                       parentContext:_parentContext
                                                  makeCurrentContext:_makeCurrentContext
-                                                         firstClass:_firstClass];
+                                                         firstClass:_firstClass
+                                                instrumentRendering:_instrumentRendering];
 }
 
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -44,6 +44,8 @@ OBJC_EXPORT
 
 @property (nonatomic) BOOL autoInstrumentNetworkRequests;
 
+@property (nonatomic) BOOL autoInstrumentRendering;
+
 /**
  *  The version of the application
  */

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -30,11 +30,15 @@ OBJC_EXPORT
 // If true, this span will be considered "first class" on the dashboard.
 @property(nonatomic, readonly) BSGFirstClass firstClass;
 
+// If false, this span will not include frame rendering metrics
+@property(nonatomic, readonly) BOOL instrumentRendering;
+
 
 - (instancetype _Nonnull)setStartTime:(NSDate * _Nullable)startTime;
 - (instancetype _Nonnull)setParentContext:(BugsnagPerformanceSpanContext * _Nullable)parentContext;
 - (instancetype _Nonnull)setMakeCurrentContext:(BOOL)makeCurrentContext;
 - (instancetype _Nonnull)setFirstClass:(BSGFirstClass)firstClass;
+- (instancetype _Nonnull)setInstrumentRendering:(BOOL)instrumentRendering;
 
 - (instancetype _Nonnull)clone;
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -14,6 +14,12 @@ typedef NS_ENUM(uint8_t, BSGFirstClass) {
     BSGFirstClassUnset = 2,
 };
 
+typedef NS_ENUM(uint8_t, BSGInstrumentRendering) {
+    BSGInstrumentRenderingNo = 0,
+    BSGInstrumentRenderingYes = 1,
+    BSGInstrumentRenderingUnset = 2,
+};
+
 // Span options allow the user to affect how spans are created.
 OBJC_EXPORT
 @interface BugsnagPerformanceSpanOptions: NSObject
@@ -30,15 +36,14 @@ OBJC_EXPORT
 // If true, this span will be considered "first class" on the dashboard.
 @property(nonatomic, readonly) BSGFirstClass firstClass;
 
-// If false, this span will not include frame rendering metrics
-@property(nonatomic, readonly) BOOL instrumentRendering;
-
+// If true, this span will always include frame rendering metrics
+@property(nonatomic, readonly) BSGInstrumentRendering instrumentRendering;
 
 - (instancetype _Nonnull)setStartTime:(NSDate * _Nullable)startTime;
 - (instancetype _Nonnull)setParentContext:(BugsnagPerformanceSpanContext * _Nullable)parentContext;
 - (instancetype _Nonnull)setMakeCurrentContext:(BOOL)makeCurrentContext;
 - (instancetype _Nonnull)setFirstClass:(BSGFirstClass)firstClass;
-- (instancetype _Nonnull)setInstrumentRendering:(BOOL)instrumentRendering;
+- (instancetype _Nonnull)setInstrumentRendering:(BSGInstrumentRendering)instrumentRendering;
 
 - (instancetype _Nonnull)clone;
 

--- a/Tests/BugsnagPerformanceTests/BatchTests.mm
+++ b/Tests/BugsnagPerformanceTests/BatchTests.mm
@@ -26,7 +26,7 @@ static BugsnagPerformanceSpan *newSpanData() {
                                               startTime:0
                                              firstClass:BSGFirstClassUnset
                                     attributeCountLimit:128
-                              shouldInstrumentRendering:NO
+                                    instrumentRendering:BSGInstrumentRenderingNo
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
 }

--- a/Tests/BugsnagPerformanceTests/BatchTests.mm
+++ b/Tests/BugsnagPerformanceTests/BatchTests.mm
@@ -26,6 +26,7 @@ static BugsnagPerformanceSpan *newSpanData() {
                                               startTime:0
                                              firstClass:BSGFirstClassUnset
                                     attributeCountLimit:128
+                              shouldInstrumentRendering:NO
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
 }

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
@@ -116,6 +116,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
                 @"autoInstrumentAppStarts": @(NO),
                 @"autoInstrumentViewControllers": @(NO),
                 @"autoInstrumentNetworkRequests": @(YES),
+                @"autoInstrumentRendering": @(NO),
             }
         }
     }];
@@ -134,6 +135,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
+    XCTAssertFalse(config.autoInstrumentRendering);
 }
 
 - (void)testLoadConfigDoesntTakeValuesFromBugsnagWhenAllValuesAreInPerformanceDictionary {
@@ -159,6 +161,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
                 @"autoInstrumentAppStarts": @(NO),
                 @"autoInstrumentViewControllers": @(NO),
                 @"autoInstrumentNetworkRequests": @(YES),
+                @"autoInstrumentRendering": @(YES),
             }
         }
     }];
@@ -178,6 +181,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
+    XCTAssertTrue(config.autoInstrumentRendering);
 }
 
 - (void)testLoadConfigDoesTakeValuesFromBugsnagWhenSomeValuesAreMissingInPerformanceDictionary {
@@ -193,6 +197,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
                 @"autoInstrumentAppStarts": @(NO),
                 @"autoInstrumentViewControllers": @(NO),
                 @"autoInstrumentNetworkRequests": @(YES),
+                @"autoInstrumentRendering": @(YES),
             }
         }
     }];
@@ -207,6 +212,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
+    XCTAssertTrue(config.autoInstrumentRendering);
 }
 
 - (void)testShouldSetIncludeApiKeyInTheDefaultEndpoint {

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -184,7 +184,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                               startTime:startAbsTime
                                              firstClass:firstClass
                                     attributeCountLimit:128
-                              shouldInstrumentRendering:NO
+                                    instrumentRendering:BSGInstrumentRenderingNo
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {}];
 }
 

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -184,6 +184,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                               startTime:startAbsTime
                                              firstClass:firstClass
                                     attributeCountLimit:128
+                              shouldInstrumentRendering:NO
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {}];
 }
 

--- a/Tests/BugsnagPerformanceTests/SamplerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SamplerTests.mm
@@ -66,6 +66,7 @@ using namespace bugsnag;
                                                                           startTime:0
                                                                          firstClass:BSGFirstClassUnset
                                                                 attributeCountLimit:128
+                                                          shouldInstrumentRendering:NO
                                                                        onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
         }];
         if (sampler.sampled(span)) {

--- a/Tests/BugsnagPerformanceTests/SamplerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SamplerTests.mm
@@ -66,7 +66,7 @@ using namespace bugsnag;
                                                                           startTime:0
                                                                          firstClass:BSGFirstClassUnset
                                                                 attributeCountLimit:128
-                                                          shouldInstrumentRendering:NO
+                                                                instrumentRendering:BSGInstrumentRenderingNo
                                                                        onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
         }];
         if (sampler.sampled(span)) {

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -48,7 +48,7 @@ using namespace bugsnag;
                                                                       startTime:SpanOptions().startTime 
                                                                      firstClass:BSGFirstClassNo
                                                             attributeCountLimit:128
-                                                      shouldInstrumentRendering:NO
+                                                            instrumentRendering:BSGInstrumentRenderingNo
                                                                    onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
     BugsnagPerformanceSpanOptions *objcOptions = [BugsnagPerformanceSpanOptions new];

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -48,6 +48,7 @@ using namespace bugsnag;
                                                                       startTime:SpanOptions().startTime 
                                                                      firstClass:BSGFirstClassNo
                                                             attributeCountLimit:128
+                                                      shouldInstrumentRendering:NO
                                                                    onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
     BugsnagPerformanceSpanOptions *objcOptions = [BugsnagPerformanceSpanOptions new];

--- a/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
@@ -24,7 +24,7 @@ static BugsnagPerformanceSpan *createSpan(std::shared_ptr<SpanStackingHandler> h
                                               startTime:SpanOptions().startTime
                                              firstClass:BSGFirstClassNo
                                     attributeCountLimit:128
-                              shouldInstrumentRendering:NO
+                                    instrumentRendering:BSGInstrumentRenderingNo
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull span) {
         handler->onSpanClosed(span.spanId);
     }];

--- a/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
@@ -24,6 +24,7 @@ static BugsnagPerformanceSpan *createSpan(std::shared_ptr<SpanStackingHandler> h
                                               startTime:SpanOptions().startTime
                                              firstClass:BSGFirstClassNo
                                     attributeCountLimit:128
+                              shouldInstrumentRendering:NO
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull span) {
         handler->onSpanClosed(span.spanId);
     }];

--- a/Tests/BugsnagPerformanceTests/SpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanTests.mm
@@ -27,7 +27,7 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, OnSpa
                                               startTime:startTime
                                              firstClass:BSGFirstClassUnset
                                     attributeCountLimit:128
-                              shouldInstrumentRendering:NO
+                                    instrumentRendering:BSGInstrumentRenderingNo
                                            onSpanClosed:onEnded];
 }
 
@@ -277,7 +277,7 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, OnSpa
                                                    startTime:0
                                                   firstClass:BSGFirstClassUnset
                                          attributeCountLimit:5
-                                   shouldInstrumentRendering:YES
+                                         instrumentRendering:BSGInstrumentRenderingNo
                                                 onSpanClosed:^(BugsnagPerformanceSpan *) {}];
 
     // Note: "bugsnag.sampling.p" is automatically added.

--- a/Tests/BugsnagPerformanceTests/SpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanTests.mm
@@ -27,6 +27,7 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, OnSpa
                                               startTime:startTime
                                              firstClass:BSGFirstClassUnset
                                     attributeCountLimit:128
+                              shouldInstrumentRendering:NO
                                            onSpanClosed:onEnded];
 }
 
@@ -276,6 +277,7 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, OnSpa
                                                    startTime:0
                                                   firstClass:BSGFirstClassUnset
                                          attributeCountLimit:5
+                                   shouldInstrumentRendering:YES
                                                 onSpanClosed:^(BugsnagPerformanceSpan *) {}];
 
     // Note: "bugsnag.sampling.p" is automatically added.

--- a/Tests/BugsnagPerformanceTests/TracerTests.mm
+++ b/Tests/BugsnagPerformanceTests/TracerTests.mm
@@ -27,9 +27,10 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto config = newConfig();
     auto stackingHandler = std::make_shared<SpanStackingHandler>();
     auto sampler = std::make_shared<Sampler>();
+    auto frameMetricsCollector = [FrameMetricsCollector new];
     sampler->setProbability(1.0);
     auto batch = std::make_shared<Batch>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -51,7 +52,8 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto sampler = std::make_shared<Sampler>();
     sampler->setProbability(1.0);
     auto batch = std::make_shared<Batch>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, ^(){});
+    auto frameMetricsCollector = [FrameMetricsCollector new];
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -73,7 +75,8 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto sampler = std::make_shared<Sampler>();
     sampler->setProbability(1.0);
     auto batch = std::make_shared<Batch>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, ^(){});
+    auto frameMetricsCollector = [FrameMetricsCollector new];
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -95,7 +98,8 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto sampler = std::make_shared<Sampler>();
     sampler->setProbability(1.0);
     auto batch = std::make_shared<Batch>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, ^(){});
+    auto frameMetricsCollector = [FrameMetricsCollector new];
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);

--- a/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
+++ b/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
@@ -26,7 +26,7 @@ static BugsnagPerformanceSpan *createSpan() {
                                               startTime:SpanOptions().startTime 
                                              firstClass:BSGFirstClassNo
                                     attributeCountLimit:128
-                              shouldInstrumentRendering:NO
+                                    instrumentRendering:BSGInstrumentRenderingNo
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
 }

--- a/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
+++ b/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
@@ -26,6 +26,7 @@ static BugsnagPerformanceSpan *createSpan() {
                                               startTime:SpanOptions().startTime 
                                              firstClass:BSGFirstClassNo
                                     attributeCountLimit:128
+                              shouldInstrumentRendering:NO
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
 }

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -339,3 +339,55 @@ Feature: Manual creation of spans
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "MySpan"
+
+  Scenario: Frame metrics - no slow frames
+    Given I run "FrameMetricsNoSlowFramesScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "FrameMetricsNoSlowFramesScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * a span integer attribute "bugsnag.framerate.total_frames" is greater than 0
+    * a span integer attribute "bugsnag.framerate.slow_frames" equals 0
+    * a span integer attribute "bugsnag.framerate.frozen_frames" equals 0
+
+  Scenario: Frame metrics - slow frames
+    Given I run "FrameMetricsSlowFramesScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "FrameMetricsSlowFramesScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * a span integer attribute "bugsnag.framerate.total_frames" is greater than 0
+    * a span integer attribute "bugsnag.framerate.slow_frames" equals 3
+    * a span integer attribute "bugsnag.framerate.frozen_frames" equals 0
+
+  Scenario: Frame metrics - frozen frames
+    Given I run "FrameMetricsFronzenFramesScenario"
+    And I wait for 3 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:3"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "FrameMetricsFronzenFramesScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * a span integer attribute "bugsnag.framerate.total_frames" is greater than 4
+    * a span integer attribute "bugsnag.framerate.slow_frames" equals 2
+    * a span integer attribute "bugsnag.framerate.frozen_frames" equals 2
+    * the span named "FrameMetricsFronzenFramesScenario" is the parent of every span named "FrozenFrame"

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -353,9 +353,9 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" is true
-    * a span integer attribute "bugsnag.framerate.total_frames" is greater than 0
-    * a span integer attribute "bugsnag.framerate.slow_frames" equals 0
-    * a span integer attribute "bugsnag.framerate.frozen_frames" equals 0
+    * a span integer attribute "bugsnag.rendering.total_frames" is greater than 0
+    * a span integer attribute "bugsnag.rendering.slow_frames" equals 0
+    * a span integer attribute "bugsnag.rendering.frozen_frames" equals 0
 
   Scenario: Frame metrics - slow frames
     Given I run "FrameMetricsSlowFramesScenario"
@@ -370,9 +370,9 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" is true
-    * a span integer attribute "bugsnag.framerate.total_frames" is greater than 0
-    * a span integer attribute "bugsnag.framerate.slow_frames" equals 3
-    * a span integer attribute "bugsnag.framerate.frozen_frames" equals 0
+    * a span integer attribute "bugsnag.rendering.total_frames" is greater than 0
+    * a span integer attribute "bugsnag.rendering.slow_frames" equals 3
+    * a span integer attribute "bugsnag.rendering.frozen_frames" equals 0
 
   Scenario: Frame metrics - frozen frames
     Given I run "FrameMetricsFronzenFramesScenario"
@@ -387,9 +387,9 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * a span bool attribute "bugsnag.span.first_class" is true
-    * a span integer attribute "bugsnag.framerate.total_frames" is greater than 4
-    * a span integer attribute "bugsnag.framerate.slow_frames" equals 2
-    * a span integer attribute "bugsnag.framerate.frozen_frames" equals 2
+    * a span integer attribute "bugsnag.rendering.total_frames" is greater than 4
+    * a span integer attribute "bugsnag.rendering.slow_frames" equals 2
+    * a span integer attribute "bugsnag.rendering.frozen_frames" equals 2
     * the span named "FrameMetricsFronzenFramesScenario" is the parent of every span named "FrozenFrame"
 
   Scenario: Frame metrics - autoInstrumentRendering off
@@ -405,9 +405,9 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" is true
-    * every span integer attribute "bugsnag.framerate.total_frames" does not exist
-    * every span integer attribute "bugsnag.framerate.slow_frames" does not exist
-    * every span integer attribute "bugsnag.framerate.frozen_frames" does not exist
+    * every span integer attribute "bugsnag.rendering.total_frames" does not exist
+    * every span integer attribute "bugsnag.rendering.slow_frames" does not exist
+    * every span integer attribute "bugsnag.rendering.frozen_frames" does not exist
 
   Scenario: Frame metrics - span instrumentRendering off
     Given I run "FrameMetricsSpanInstrumentRenderingOffScenario"
@@ -422,6 +422,23 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" is true
-    * every span integer attribute "bugsnag.framerate.total_frames" does not exist
-    * every span integer attribute "bugsnag.framerate.slow_frames" does not exist
-    * every span integer attribute "bugsnag.framerate.frozen_frames" does not exist
+    * every span integer attribute "bugsnag.rendering.total_frames" does not exist
+    * every span integer attribute "bugsnag.rendering.slow_frames" does not exist
+    * every span integer attribute "bugsnag.rendering.frozen_frames" does not exist
+
+  Scenario: Frame metrics - non firstClass span with instrumentRendering off
+    Given I run "FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is false
+    * a span integer attribute "bugsnag.rendering.total_frames" is greater than 0
+    * a span integer attribute "bugsnag.rendering.slow_frames" equals 3
+    * a span integer attribute "bugsnag.rendering.frozen_frames" equals 0

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -391,3 +391,37 @@ Feature: Manual creation of spans
     * a span integer attribute "bugsnag.framerate.slow_frames" equals 2
     * a span integer attribute "bugsnag.framerate.frozen_frames" equals 2
     * the span named "FrameMetricsFronzenFramesScenario" is the parent of every span named "FrozenFrame"
+
+  Scenario: Frame metrics - autoInstrumentRendering off
+    Given I run "FrameMetricsAutoInstrumentRenderingOffScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "FrameMetricsAutoInstrumentRenderingOffScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span integer attribute "bugsnag.framerate.total_frames" does not exist
+    * every span integer attribute "bugsnag.framerate.slow_frames" does not exist
+    * every span integer attribute "bugsnag.framerate.frozen_frames" does not exist
+
+  Scenario: Frame metrics - span instrumentRendering off
+    Given I run "FrameMetricsSpanInstrumentRenderingOffScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "FrameMetricsSpanInstrumentRenderingOffScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span integer attribute "bugsnag.framerate.total_frames" does not exist
+    * every span integer attribute "bugsnag.framerate.slow_frames" does not exist
+    * every span integer attribute "bugsnag.framerate.frozen_frames" does not exist

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		96284DCE2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96284DCD2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift */; };
 		9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */; };
 		9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */; };
+		966634DE2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966634DD2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift */; };
+		966634E02C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966634DF2C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift */; };
+		966634E22C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966634E12C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift */; };
 		967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */; };
 		96D528CC2C72B14300FEA2E2 /* AppDataOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */; };
 		96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */; };
@@ -137,6 +140,9 @@
 		96284DCD2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentPreLoadedViewLoadScenario.swift; sourceTree = "<group>"; };
 		9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentTabViewLoadScenario.swift; sourceTree = "<group>"; };
 		9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNavigationViewLoadScenario.swift; sourceTree = "<group>"; };
+		966634DD2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsFronzenFramesScenario.swift; sourceTree = "<group>"; };
+		966634DF2C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsSlowFramesScenario.swift; sourceTree = "<group>"; };
+		966634E12C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsNoSlowFramesScenario.swift; sourceTree = "<group>"; };
 		967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseStageNotEnabledScenario.swift; sourceTree = "<group>"; };
 		96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataOverrideScenario.swift; sourceTree = "<group>"; };
 		96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityOneScenario.swift; sourceTree = "<group>"; };
@@ -273,6 +279,9 @@
 				96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */,
 				CBC90C4129C466BD00280884 /* ForceUBSan.h */,
 				CBC90C4229C466BD00280884 /* ForceUBSan.m */,
+				966634DD2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift */,
+				966634E12C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift */,
+				966634DF2C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift */,
 				CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */,
 				09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */,
 				96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */,
@@ -399,6 +408,7 @@
 				96D528CC2C72B14300FEA2E2 /* AppDataOverrideScenario.swift in Sources */,
 				09E045612C98649D003882D3 /* SetAttributeCountLimitScenario.swift in Sources */,
 				09637A432B0617FE00F4F776 /* MazeRunnerCommand.swift in Sources */,
+				966634E22C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift in Sources */,
 				09F025092BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift in Sources */,
 				0185C47228F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift in Sources */,
 				09D59E172BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift in Sources */,
@@ -419,6 +429,7 @@
 				96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */,
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
+				966634DE2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift in Sources */,
 				09E9BDAF2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift in Sources */,
 				099331FC2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift in Sources */,
 				097FFC0B2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift in Sources */,
@@ -442,6 +453,7 @@
 				9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */,
 				CBEC89452A4ED0590088A3CE /* MaxPayloadSizeScenario.swift in Sources */,
 				CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */,
+				966634E02C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift in Sources */,
 				CB2B8A9F2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift in Sources */,
 				09F025152BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift in Sources */,
 				CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */,

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		966634E02C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966634DF2C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift */; };
 		966634E22C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966634E12C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift */; };
 		967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */; };
+		9691A9DD2CA5E61500707CDF /* FrameMetricsAutoInstrumentRenderingOffScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9691A9DC2CA5E61500707CDF /* FrameMetricsAutoInstrumentRenderingOffScenario.swift */; };
+		9691A9DF2CA5E62800707CDF /* FrameMetricsSpanInstrumentRenderingOffScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9691A9DE2CA5E62800707CDF /* FrameMetricsSpanInstrumentRenderingOffScenario.swift */; };
 		96D528CC2C72B14300FEA2E2 /* AppDataOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */; };
 		96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */; };
 		96D528D02C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */; };
@@ -144,6 +146,8 @@
 		966634DF2C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsSlowFramesScenario.swift; sourceTree = "<group>"; };
 		966634E12C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsNoSlowFramesScenario.swift; sourceTree = "<group>"; };
 		967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseStageNotEnabledScenario.swift; sourceTree = "<group>"; };
+		9691A9DC2CA5E61500707CDF /* FrameMetricsAutoInstrumentRenderingOffScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsAutoInstrumentRenderingOffScenario.swift; sourceTree = "<group>"; };
+		9691A9DE2CA5E62800707CDF /* FrameMetricsSpanInstrumentRenderingOffScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsSpanInstrumentRenderingOffScenario.swift; sourceTree = "<group>"; };
 		96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataOverrideScenario.swift; sourceTree = "<group>"; };
 		96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityOneScenario.swift; sourceTree = "<group>"; };
 		96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityZeroScenario.swift; sourceTree = "<group>"; };
@@ -279,9 +283,11 @@
 				96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */,
 				CBC90C4129C466BD00280884 /* ForceUBSan.h */,
 				CBC90C4229C466BD00280884 /* ForceUBSan.m */,
+				9691A9DC2CA5E61500707CDF /* FrameMetricsAutoInstrumentRenderingOffScenario.swift */,
 				966634DD2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift */,
 				966634E12C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift */,
 				966634DF2C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift */,
+				9691A9DE2CA5E62800707CDF /* FrameMetricsSpanInstrumentRenderingOffScenario.swift */,
 				CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */,
 				09DA59A42A6E866B00A06EEE /* ManualNetworkCallbackScenario.swift */,
 				96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */,
@@ -409,6 +415,7 @@
 				09E045612C98649D003882D3 /* SetAttributeCountLimitScenario.swift in Sources */,
 				09637A432B0617FE00F4F776 /* MazeRunnerCommand.swift in Sources */,
 				966634E22C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift in Sources */,
+				9691A9DF2CA5E62800707CDF /* FrameMetricsSpanInstrumentRenderingOffScenario.swift in Sources */,
 				09F025092BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift in Sources */,
 				0185C47228F6C983006F9BDC /* AutoInstrumentViewLoadScenario.swift in Sources */,
 				09D59E172BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift in Sources */,
@@ -467,6 +474,7 @@
 				09F025072BA08804007D9F73 /* ObjCURLSession.m in Sources */,
 				CBC90CDE29CDCFF700280884 /* FirstClassNoScenario.swift in Sources */,
 				CBC90C4329C466BD00280884 /* ForceUBSan.m in Sources */,
+				9691A9DD2CA5E61500707CDF /* FrameMetricsAutoInstrumentRenderingOffScenario.swift in Sources */,
 				09637A452B0B883B00F4F776 /* FixtureConfig.swift in Sources */,
 				CBC90CE429D1BDE400280884 /* AutoInstrumentSubViewLoadScenario.swift in Sources */,
 				098C3B502C53CEC0006F9886 /* ErrorGenerator.m in Sources */,

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */; };
 		9691A9DD2CA5E61500707CDF /* FrameMetricsAutoInstrumentRenderingOffScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9691A9DC2CA5E61500707CDF /* FrameMetricsAutoInstrumentRenderingOffScenario.swift */; };
 		9691A9DF2CA5E62800707CDF /* FrameMetricsSpanInstrumentRenderingOffScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9691A9DE2CA5E62800707CDF /* FrameMetricsSpanInstrumentRenderingOffScenario.swift */; };
+		9691A9E12CA7588700707CDF /* FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9691A9E02CA7588700707CDF /* FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift */; };
 		96D528CC2C72B14300FEA2E2 /* AppDataOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */; };
 		96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */; };
 		96D528D02C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */; };
@@ -148,6 +149,7 @@
 		967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseStageNotEnabledScenario.swift; sourceTree = "<group>"; };
 		9691A9DC2CA5E61500707CDF /* FrameMetricsAutoInstrumentRenderingOffScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsAutoInstrumentRenderingOffScenario.swift; sourceTree = "<group>"; };
 		9691A9DE2CA5E62800707CDF /* FrameMetricsSpanInstrumentRenderingOffScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsSpanInstrumentRenderingOffScenario.swift; sourceTree = "<group>"; };
+		9691A9E02CA7588700707CDF /* FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift; sourceTree = "<group>"; };
 		96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataOverrideScenario.swift; sourceTree = "<group>"; };
 		96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityOneScenario.swift; sourceTree = "<group>"; };
 		96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityZeroScenario.swift; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 				CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */,
 				CBE0872A29F81BBB007455F2 /* AutoInstrumentNetworkNoParentScenario.swift */,
 				09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */,
+				091B95732CA18F66007DC8A9 /* AutoInstrumentNetworkPreStartDisabledScenario.swift */,
 				091B95712CA179AC007DC8A9 /* AutoInstrumentNetworkPreStartScenario.swift */,
 				09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
@@ -285,6 +288,7 @@
 				CBC90C4229C466BD00280884 /* ForceUBSan.m */,
 				9691A9DC2CA5E61500707CDF /* FrameMetricsAutoInstrumentRenderingOffScenario.swift */,
 				966634DD2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift */,
+				9691A9E02CA7588700707CDF /* FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift */,
 				966634E12C9DE648004A934D /* FrameMetricsNoSlowFramesScenario.swift */,
 				966634DF2C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift */,
 				9691A9DE2CA5E62800707CDF /* FrameMetricsSpanInstrumentRenderingOffScenario.swift */,
@@ -314,7 +318,6 @@
 				094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */,
 				09E0455E2C94662B003882D3 /* SetAttributesWithLimitsScenario.swift */,
 				09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */,
-				091B95732CA18F66007DC8A9 /* AutoInstrumentNetworkPreStartDisabledScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -445,6 +448,7 @@
 				0983A1792B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift in Sources */,
 				CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */,
 				CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */,
+				9691A9E12CA7588700707CDF /* FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift in Sources */,
 				09637A3F2B06082200F4F776 /* Logging.m in Sources */,
 				CB3477182901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift in Sources */,
 				091B95742CA18F66007DC8A9 /* AutoInstrumentNetworkPreStartDisabledScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/FrameMetricsAutoInstrumentRenderingOffScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsAutoInstrumentRenderingOffScenario.swift
@@ -1,23 +1,23 @@
 //
-//  FrameMetricsSlowFramesScenario.swift
+//  FrameMetricsAutoInstrumentRenderingOffScenario.swift
 //  Fixture
 //
-//  Created by Robert B on 20/09/2024.
+//  Created by Robert B on 26/09/2024.
 //
 
 import Bugsnag
 import BugsnagPerformance
 
 @objcMembers
-class FrameMetricsSlowFramesScenario: Scenario {
+class FrameMetricsAutoInstrumentRenderingOffScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.autoInstrumentRendering = false
     }
     
     override func run() {
-        let span = BugsnagPerformance.startSpan(name: "FrameMetricsSlowFramesScenario")
+        let span = BugsnagPerformance.startSpan(name: "FrameMetricsAutoInstrumentRenderingOffScenario")
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             Thread.sleep(forTimeInterval: 0.3)

--- a/features/fixtures/ios/Scenarios/FrameMetricsFronzenFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsFronzenFramesScenario.swift
@@ -1,0 +1,37 @@
+//
+//  FrameMetricsFronzenFramesScenario.swift
+//  Fixture
+//
+//  Created by Robert B on 20/09/2024.
+//
+
+import Bugsnag
+import BugsnagPerformance
+
+@objcMembers
+class FrameMetricsFronzenFramesScenario: Scenario {
+    
+    override func configure() {
+        super.configure()
+        config.internal.autoTriggerExportOnBatchSize = 3
+    }
+    
+    override func run() {
+        let span = BugsnagPerformance.startSpan(name: "FrameMetricsFronzenFramesScenario")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            Thread.sleep(forTimeInterval: 0.3)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                Thread.sleep(forTimeInterval: 0.8)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                    Thread.sleep(forTimeInterval: 0.4)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                        Thread.sleep(forTimeInterval: 1.0)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                            span.end()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/features/fixtures/ios/Scenarios/FrameMetricsFronzenFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsFronzenFramesScenario.swift
@@ -13,6 +13,7 @@ class FrameMetricsFronzenFramesScenario: Scenario {
     
     override func configure() {
         super.configure()
+        config.autoInstrumentRendering = true
         config.internal.autoTriggerExportOnBatchSize = 3
     }
     

--- a/features/fixtures/ios/Scenarios/FrameMetricsNoSlowFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsNoSlowFramesScenario.swift
@@ -1,0 +1,21 @@
+//
+//  FrameMetricsNoSlowFramesScenario.swift
+//  Fixture
+//
+//  Created by Robert B on 20/09/2024.
+//
+
+import Bugsnag
+import BugsnagPerformance
+
+@objcMembers
+class FrameMetricsNoSlowFramesScenario: Scenario {
+    
+    override func run() {
+        let span = BugsnagPerformance.startSpan(name: "FrameMetricsNoSlowFramesScenario")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            span.end()
+        }
+    }
+}

--- a/features/fixtures/ios/Scenarios/FrameMetricsNoSlowFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsNoSlowFramesScenario.swift
@@ -11,6 +11,11 @@ import BugsnagPerformance
 @objcMembers
 class FrameMetricsNoSlowFramesScenario: Scenario {
     
+    override func configure() {
+        super.configure()
+        config.autoInstrumentRendering = true
+    }
+    
     override func run() {
         let span = BugsnagPerformance.startSpan(name: "FrameMetricsNoSlowFramesScenario")
         

--- a/features/fixtures/ios/Scenarios/FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift
@@ -1,15 +1,15 @@
 //
-//  FrameMetricsSpanInstrumentRenderingOffScenario.swift
+//  FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift
 //  Fixture
 //
-//  Created by Robert B on 26/09/2024.
+//  Created by Robert B on 27/09/2024.
 //
 
 import Bugsnag
 import BugsnagPerformance
 
 @objcMembers
-class FrameMetricsSpanInstrumentRenderingOffScenario: Scenario {
+class FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario: Scenario {
     
     override func configure() {
         super.configure()
@@ -18,8 +18,9 @@ class FrameMetricsSpanInstrumentRenderingOffScenario: Scenario {
     
     override func run() {
         let options = BugsnagPerformanceSpanOptions()
-        options.setInstrumentRendering(.no)
-        let span = BugsnagPerformance.startSpan(name: "FrameMetricsSpanInstrumentRenderingOffScenario", options: options)
+        options.setInstrumentRendering(.yes)
+        options.setFirstClass(.no)
+        let span = BugsnagPerformance.startSpan(name: "FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario", options: options)
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             Thread.sleep(forTimeInterval: 0.3)

--- a/features/fixtures/ios/Scenarios/FrameMetricsSlowFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsSlowFramesScenario.swift
@@ -1,0 +1,30 @@
+//
+//  FrameMetricsSlowFramesScenario.swift
+//  Fixture
+//
+//  Created by Robert B on 20/09/2024.
+//
+
+import Bugsnag
+import BugsnagPerformance
+
+@objcMembers
+class FrameMetricsSlowFramesScenario: Scenario {
+    
+    override func run() {
+        let span = BugsnagPerformance.startSpan(name: "FrameMetricsSlowFramesScenario")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            Thread.sleep(forTimeInterval: 0.3)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                Thread.sleep(forTimeInterval: 0.5)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    Thread.sleep(forTimeInterval: 0.2)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        span.end()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/features/fixtures/ios/Scenarios/FrameMetricsSpanInstrumentRenderingOffScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsSpanInstrumentRenderingOffScenario.swift
@@ -1,15 +1,15 @@
 //
-//  FrameMetricsSlowFramesScenario.swift
+//  FrameMetricsSpanInstrumentRenderingOffScenario.swift
 //  Fixture
 //
-//  Created by Robert B on 20/09/2024.
+//  Created by Robert B on 26/09/2024.
 //
 
 import Bugsnag
 import BugsnagPerformance
 
 @objcMembers
-class FrameMetricsSlowFramesScenario: Scenario {
+class FrameMetricsSpanInstrumentRenderingOffScenario: Scenario {
     
     override func configure() {
         super.configure()
@@ -17,7 +17,9 @@ class FrameMetricsSlowFramesScenario: Scenario {
     }
     
     override func run() {
-        let span = BugsnagPerformance.startSpan(name: "FrameMetricsSlowFramesScenario")
+        let options = BugsnagPerformanceSpanOptions()
+        options.setInstrumentRendering(false)
+        let span = BugsnagPerformance.startSpan(name: "FrameMetricsSpanInstrumentRenderingOffScenario", options: options)
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             Thread.sleep(forTimeInterval: 0.3)

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -32,6 +32,7 @@ class Scenario: NSObject {
         config.autoInstrumentAppStarts = false
         config.autoInstrumentNetworkRequests = false
         config.autoInstrumentViewControllers = false
+        config.autoInstrumentRendering = false
         config.endpoint = fixtureConfig.tracesURL
         config.networkRequestCallback = filterAdminMazeRunnerNetRequests
     }

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -173,6 +173,20 @@ Then('a span integer attribute {string} is greater than {int}') do |attribute, e
   Maze.check.false(attribute_values.empty?)
 end
 
+Then('a span integer attribute {string} equals {int}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') } }.compact
+  attribute_values = selected_attributes.map { |a| a['value']['intValue'].to_i == expected }
+  Maze.check.false(attribute_values.empty?)
+end
+
+Then('a span integer attribute {string} is less than {int}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') } }.compact
+  attribute_values = selected_attributes.map { |a| a['value']['intValue'].to_i < expected }
+  Maze.check.false(attribute_values.empty?)
+end
+
 Then('a span array attribute {string} contains the string value {string} at index {int}') do |attribute, expected, index|
   value = get_array_value_at_index(attribute, index, 'stringValue')
   Maze.check.true(value == expected)
@@ -273,4 +287,15 @@ Then('a span double attribute {string} equals {float}') do |attribute, value|
   selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('doubleValue') } }.compact
   selected_attributes = selected_attributes.map { |a| a['value']['doubleValue'] == value }
   Maze.check.false(selected_attributes.empty?)
+end
+
+Then('the span named {string} is the parent of every span named {string}') do |span1name, span2name|
+  
+  spans = spans_from_request_list(Maze::Server.list_for("traces"))
+
+  parentSpan = spans.find_all { |span| span['name'].eql?(span1name) }.first
+
+  childSpans2 = spans.find_all { |span| span['name'].eql?(span2name) }
+
+  childSpans2.map { |span| Maze.check.true(parentSpan['spanId'] == span['parentSpanId']) }
 end

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -103,6 +103,11 @@ Then('every span string attribute {string} does not exist') do |attribute|
   spans.map { |span| Maze.check.nil span['attributes'].find { |a| a['key'] == attribute } }
 end
 
+Then('every span integer attribute {string} does not exist') do |attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze.check.nil span['attributes'].find { |a| a['key'] == attribute } }
+end
+
 Then('all span bool attribute {string} is true') do |attribute|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('boolValue') } }.compact


### PR DESCRIPTION
## Goal
Report frame metrics on all first class spans, and simplify implementation.

## Changeset
This PR reduces the scope of frame metrics reporting to only first class spans, as adding it to nested spans does not add any real value.

## Testing

E2E Tests