### PR TITLE
Remove explicit trace calls

### DIFF
--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -266,9 +266,6 @@ def assert_received_exactly_spans(span_count, list)
   wait = Maze::Wait.new(timeout: 5)
 
   Maze.check.operator(span_count, :==, received_count, "#{received_count} spans received")
-
-  Maze::Schemas::Validator.verify_against_schema(list, 'trace')
-  Maze::Schemas::Validator.validate_payload_elements(list, 'trace')
 end
 
 Then('a span double attribute {string} equals {float}') do |attribute, value|


### PR DESCRIPTION
## Goal

All schemas and validation are called implicitly, and modified through configuration, we shouldn't call them explicitly at all.