### PR TITLE
Don't send rendering metrics if total frames count is zero

### DIFF
--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
@@ -47,7 +47,7 @@ static const CGFloat kSlowFrameRatioThreshold = 1.3;
         _justEnteredForeground = true;
         _lastFrozenFrame = [FrozenFrameData root];
         _frameTimestampAdjustment = [NSDate date].timeIntervalSinceReferenceDate - CACurrentMediaTime();
-        _autoInstrumentRendering = true;
+        _autoInstrumentRendering = false;
     }
     return self;
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -81,7 +81,7 @@ private:
     FrameMetricsCollector *frameMetricsCollector_;
 
     std::atomic<bool> willDiscardPrewarmSpans_{false};
-    std::atomic<bool> autoInstrumentRendering_{true};
+    std::atomic<bool> autoInstrumentRendering_{false};
     std::mutex prewarmSpansMutex_;
     NSMutableArray<BugsnagPerformanceSpan *> *prewarmSpans_;
     NSArray<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks_;

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -211,6 +211,9 @@ void Tracer::processFrameMetrics(BugsnagPerformanceSpan *span) noexcept {
     }
     auto mergedSnapshot = [FrameMetricsSnapshot mergeWithStart:startSnapshot
                                                            end:endSnapshot];
+    if (mergedSnapshot.totalFrames == 0) {
+        return;
+    }
     [span setAttribute:@"bugsnag.rendering.total_frames" withValue:@(mergedSnapshot.totalFrames)];
     [span setAttribute:@"bugsnag.rendering.slow_frames" withValue:@(mergedSnapshot.totalSlowFrames)];
     [span setAttribute:@"bugsnag.rendering.frozen_frames" withValue:@(mergedSnapshot.totalFrozenFrames)];

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -34,7 +34,7 @@ using namespace bugsnag;
         _autoInstrumentAppStarts = YES;
         _autoInstrumentViewControllers = YES;
         _autoInstrumentNetworkRequests = YES;
-        _autoInstrumentRendering = YES;
+        _autoInstrumentRendering = NO;
         _onSpanEndCallbacks = [NSMutableArray array];
         _attributeArrayLengthLimit = DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT;
         _attributeStringValueLimit = DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT;

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -14,10 +14,11 @@ typedef NS_ENUM(uint8_t, BSGFirstClass) {
     BSGFirstClassUnset = 2,
 };
 
+// Affects whether or not a span should include rendering metrics
 typedef NS_ENUM(uint8_t, BSGInstrumentRendering) {
-    BSGInstrumentRenderingNo = 0,
-    BSGInstrumentRenderingYes = 1,
-    BSGInstrumentRenderingUnset = 2,
+    BSGInstrumentRenderingNo = 0, // Never include rendering metrics
+    BSGInstrumentRenderingYes = 1, // Always include rendering metrics, as long as the autoInstrumentRendering configuration option is on
+    BSGInstrumentRenderingUnset = 2, // Include rendering metrics only if the span is first class, start and end times were not set when creating/closing the span and the autoInstrumentRendering configuration option is on
 };
 
 // Span options allow the user to affect how spans are created.
@@ -36,7 +37,6 @@ OBJC_EXPORT
 // If true, this span will be considered "first class" on the dashboard.
 @property(nonatomic, readonly) BSGFirstClass firstClass;
 
-// If true, this span will always include frame rendering metrics
 @property(nonatomic, readonly) BSGInstrumentRendering instrumentRendering;
 
 - (instancetype _Nonnull)setStartTime:(NSDate * _Nullable)startTime;


### PR DESCRIPTION
## Goal

Don't send rendering metrics if total frames count is zero

## Design

Spans with rendering metrics and zero total frames look confusing so we decided not to display them

## Changeset

- Do not include rendering metrics if there are zero total frames

## Testing

Existing E2E tests