### PR TITLE
[PLAT-12326] Fix visionOS compile issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix visionOS compilation errors. Note that visionOS is not yet officially supported.
+  [327](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/327)
+
 ## 1.10.0 (2024-09-30)
 
 ### Enhancements

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("SystemConfiguration"),
                 .linkedFramework("UIKit"),
-                .linkedFramework("CoreTelephony"),
+                .linkedFramework("CoreTelephony", .when(platforms: [.iOS])),
             ]
         ),
         .target(

--- a/Sources/BugsnagPerformance/Private/ResourceAttributes.mm
+++ b/Sources/BugsnagPerformance/Private/ResourceAttributes.mm
@@ -49,6 +49,8 @@ static NSString *hostArch() noexcept {
 static NSString *osName() noexcept {
 #if TARGET_OS_IOS
     return @"iOS";
+#elif TARGET_OS_VISION
+    return @"iOS";
 #else
 #error Other platforms not supported yet
 #endif

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -62,6 +62,7 @@ static NSDictionary *accessTechnologyMappingDictionary() {
     static dispatch_once_t onceT;
     dispatch_once(&onceT, ^(){
         accessTechnologyMapping = [@{
+#if TARGET_OS_IOS
             CTRadioAccessTechnologyGPRS: @"gprs",
             CTRadioAccessTechnologyEdge: @"edge",
             CTRadioAccessTechnologyWCDMA: @"wcdma",
@@ -73,11 +74,14 @@ static NSDictionary *accessTechnologyMappingDictionary() {
             CTRadioAccessTechnologyCDMAEVDORevB: @"evdo_b",
             CTRadioAccessTechnologyeHRPD: @"ehrpd",
             CTRadioAccessTechnologyLTE: @"lte",
+#endif
         } mutableCopy];
+#if TARGET_OS_IOS
         if (@available(iOS 14.1, *)) {
             accessTechnologyMapping[CTRadioAccessTechnologyNRNSA] = @"nrnsa";
             accessTechnologyMapping[CTRadioAccessTechnologyNR] = @"nr";
         }
+#endif
     });
     return accessTechnologyMapping;
 }


### PR DESCRIPTION
Fix some compilation issues that happen on visionOS.

visionOS isn't yet officially supported because we don't have tests for it, but it at least compiles and runs and sends spans.
