### PR TITLE
Add method to get configuration via cross-talk API

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "SpanStackingHandler.h"
+#import "BugsnagPerformanceImpl.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Configuration and Internal Functions
 
 @property(nonatomic) std::shared_ptr<SpanStackingHandler> spanStackingHandler;
+@property(nonatomic) BugsnagPerformanceConfiguration *configuration;
 
 @end
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.h
@@ -8,11 +8,11 @@
 
 #import <Foundation/Foundation.h>
 #import "SpanStackingHandler.h"
-#import "BugsnagPerformanceImpl.h"
+#import "PhasedStartup.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BugsnagPerformanceCrossTalkAPI : NSObject
+@interface BugsnagPerformanceCrossTalkAPI : NSObject<BSGPhasedStartup>
 
 #pragma mark Mandatory Methods
 
@@ -21,7 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Configuration and Internal Functions
 
 @property(nonatomic) std::shared_ptr<SpanStackingHandler> spanStackingHandler;
-@property(nonatomic) BugsnagPerformanceConfiguration *configuration;
 
 @end
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
@@ -34,6 +34,10 @@
     ];
 }
 
+- (BugsnagPerformanceConfiguration * _Nullable)getConfigurationV1 {
+    return self.configuration;
+}
+
 #pragma mark Internal Functionality
 
 static NSString *BSGUserInfoKeyMapped = @"mapped";
@@ -54,6 +58,8 @@ static NSString *BSGUserInfoValueMappedNo = @"NO";
     // Note: ALWAYS ALWAYS ALWAYS check every single API mapping with a unit test!!!
     if ([apiName isEqualToString:@"getCurrentTraceAndSpanIdV1"]) {
         fromSelector = @selector(getCurrentTraceAndSpanIdV1);
+    } else if ([apiName isEqualToString:@"getConfigurationV1"]) {
+        fromSelector = @selector(getConfigurationV1);
     } else {
         err = [NSError errorWithDomain:@"com.bugsnag.BugsnagCocoaPerformance"
                                   code:0

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
@@ -11,6 +11,8 @@
 
 @implementation BugsnagPerformanceCrossTalkAPI
 
+static BugsnagPerformanceConfiguration *configuration;
+
 #pragma mark Exposed API
 
 /**
@@ -34,9 +36,26 @@
     ];
 }
 
+/**
+ * Return the final configuration that was provided to [BugsnagPerformance start], or return nil if start has not been called.
+ */
 - (BugsnagPerformanceConfiguration * _Nullable)getConfigurationV1 {
-    return self.configuration;
+    return configuration;
 }
+
+#pragma mark BSGPhasedStartup
+
+- (void)earlyConfigure:(BSGEarlyConfiguration *)config {}
+
+- (void)earlySetup {}
+
+- (void)configure:(BugsnagPerformanceConfiguration *)config {
+    configuration = config;
+}
+
+- (void)start {}
+
+- (void)preStartSetup {}
 
 #pragma mark Internal Functionality
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
@@ -9,9 +9,11 @@
 #import "BugsnagPerformanceCrossTalkAPI.h"
 #import <objc/runtime.h>
 
-@implementation BugsnagPerformanceCrossTalkAPI
+@interface BugsnagPerformanceCrossTalkAPI ()
+@property(readwrite, nonatomic) BugsnagPerformanceConfiguration *configuration;
+@end
 
-static BugsnagPerformanceConfiguration *configuration;
+@implementation BugsnagPerformanceCrossTalkAPI
 
 #pragma mark Exposed API
 
@@ -40,7 +42,7 @@ static BugsnagPerformanceConfiguration *configuration;
  * Return the final configuration that was provided to [BugsnagPerformance start], or return nil if start has not been called.
  */
 - (BugsnagPerformanceConfiguration * _Nullable)getConfigurationV1 {
-    return configuration;
+    return self.configuration;
 }
 
 #pragma mark BSGPhasedStartup
@@ -50,7 +52,7 @@ static BugsnagPerformanceConfiguration *configuration;
 - (void)earlySetup {}
 
 - (void)configure:(BugsnagPerformanceConfiguration *)config {
-    configuration = config;
+    self.configuration = config;
 }
 
 - (void)start {}

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -135,6 +135,7 @@ void BugsnagPerformanceImpl::configure(BugsnagPerformanceConfiguration *config) 
     instrumentation_->configure(config);
     [worker_ configure:config];
     [frameMetricsCollector_ configure:config];
+    [BugsnagPerformanceCrossTalkAPI.sharedInstance configure:config];
 }
 
 void BugsnagPerformanceImpl::preStartSetup() noexcept {

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
@@ -6,6 +6,7 @@
 //
 
 #import "BugsnagPerformanceLibrary.h"
+#import "BugsnagPerformanceCrossTalkAPI.h"
 #import "Reachability.h"
 
 using namespace bugsnag;
@@ -67,6 +68,7 @@ void BugsnagPerformanceLibrary::configureLibrary(BugsnagPerformanceConfiguration
         }
 
         sharedInstance().configure(config);
+        BugsnagPerformanceCrossTalkAPI.sharedInstance.configuration = config;
     }
 }
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceLibrary.mm
@@ -6,7 +6,6 @@
 //
 
 #import "BugsnagPerformanceLibrary.h"
-#import "BugsnagPerformanceCrossTalkAPI.h"
 #import "Reachability.h"
 
 using namespace bugsnag;
@@ -68,7 +67,6 @@ void BugsnagPerformanceLibrary::configureLibrary(BugsnagPerformanceConfiguration
         }
 
         sharedInstance().configure(config);
-        BugsnagPerformanceCrossTalkAPI.sharedInstance.configuration = config;
     }
 }
 

--- a/Tests/BugsnagPerformanceTests/CrossTalkTests.m
+++ b/Tests/BugsnagPerformanceTests/CrossTalkTests.m
@@ -9,6 +9,8 @@
 #import <XCTest/XCTest.h>
 #import <objc/runtime.h>
 
+#import <BugsnagPerformance/BugsnagPerformance.h>
+
 @interface CrossTalkAPITester: NSObject
 
 // Do NOT make implementations for any of these selectors.
@@ -18,6 +20,7 @@
 #pragma mark API Methods to Test
 
 - (NSArray *) testingGetCurrentTraceAndSpanIdV1;
+- (BugsnagPerformanceConfiguration *) testingGetConfigurationV1;
 
 @end
 
@@ -68,6 +71,11 @@ static id crossTalkRealAPI = nil;
 - (void)testGetCurrentTraceAndSpanIdV1 {
     XCTAssertNil([CrossTalkAPITester mapAPINamed:@"getCurrentTraceAndSpanIdV1" toSelector:@selector(testingGetCurrentTraceAndSpanIdV1)]);
     [CrossTalkAPITester.sharedInstance testingGetCurrentTraceAndSpanIdV1];
+}
+
+- (void)testGetConfigurationV1 {
+    XCTAssertNil([CrossTalkAPITester mapAPINamed:@"getConfigurationV1" toSelector:@selector(testingGetConfigurationV1)]);
+    [CrossTalkAPITester.sharedInstance testingGetConfigurationV1];
 }
 
 @end


### PR DESCRIPTION
## Goal

Adds a new method `getConfigurationV1` to the cross-talk API to allow reading the configuration passed to `start`.

This isn't used yet but will be required for the upcoming react native integration.

## Design

Added a configuration property to the crosstalk API, which is set in  `BugsnagPerformanceLibrary::configureLibrary`.

`getConfigurationV1` therefore returns nil if the SDK has not been configured (i.e. if `start` has not been called) 

## Testing

Added a unit test for the new crosstalk method, and tested manually with a React Native project