### PR TITLE
Fixed a crash after shared NSURLSession invalidate

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		966DD5012A211D7F002030B2 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		966DD5022A211D7F002030B2 /* BugsnagPerformance.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		967F6F1829C3783B0054EED8 /* BugsnagPerformanceConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */; };
+		968AA5FB2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 968AA5FA2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h */; };
+		968AA5FD2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm in Sources */ = {isa = PBXBuildFile; fileRef = 968AA5FC2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm */; };
 		96D415F329E6ADC500AEE435 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D415F229E6ADC500AEE435 /* AppDelegate.swift */; };
 		96D415F729E6ADC500AEE435 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D415F629E6ADC500AEE435 /* ViewController.swift */; };
 		96D415FA29E6ADC500AEE435 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 96D415F829E6ADC500AEE435 /* Main.storyboard */; };
@@ -322,6 +324,8 @@
 		966634D92C8A39B1004A934D /* FrozenFrameData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrozenFrameData.h; sourceTree = "<group>"; };
 		966634DB2C8A39C1004A934D /* FrozenFrameData.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FrozenFrameData.mm; sourceTree = "<group>"; };
 		967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
+		968AA5FA2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGPerformanceSharedSessionProxy.h; sourceTree = "<group>"; };
+		968AA5FC2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGPerformanceSharedSessionProxy.mm; sourceTree = "<group>"; };
 		96D415F029E6ADC500AEE435 /* BugsnagPerformanceTestsApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BugsnagPerformanceTestsApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		96D415F229E6ADC500AEE435 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		96D415F629E6ADC500AEE435 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -780,6 +784,8 @@
 			children = (
 				CB34771C29068C350033759C /* BSGURLSessionPerformanceProxy.h */,
 				CB34771B29068C350033759C /* BSGURLSessionPerformanceProxy.mm */,
+				968AA5FA2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h */,
+				968AA5FC2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm */,
 				CBA22C982A03EA300066A2C1 /* NetworkCommon.h */,
 				CB34771D29068C350033759C /* NSURLSession+Instrumentation.h */,
 				CB34771A29068C350033759C /* NSURLSession+Instrumentation.mm */,
@@ -861,6 +867,7 @@
 				CBEC51BC296D9EEE009C0CE3 /* PersistentState.h in Headers */,
 				0122C23829019770002D243C /* BugsnagPerformanceSpan.h in Headers */,
 				966634DA2C8A39B1004A934D /* FrozenFrameData.h in Headers */,
+				968AA5FB2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h in Headers */,
 				CB0AD76A296573FC002A3FB6 /* BugsnagPerformanceErrors.h in Headers */,
 				0122C23B29019770002D243C /* BugsnagPerformance.h in Headers */,
 				0122C24B29019770002D243C /* ViewLoadInstrumentation.h in Headers */,
@@ -1212,6 +1219,7 @@
 				966634DC2C8A39C1004A934D /* FrozenFrameData.mm in Sources */,
 				0122C23E29019770002D243C /* BugsnagPerformanceSpan.mm in Sources */,
 				0987F27A2C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm in Sources */,
+				968AA5FD2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm in Sources */,
 				CBEC51DD2976F1F9009C0CE3 /* RetryQueue.mm in Sources */,
 				01A414CE2913C0F0003152A4 /* SpanAttributes.mm in Sources */,
 				CB34771E29068C350033759C /* NSURLSession+Instrumentation.mm in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fixed a crash after shared NSURLSession invalidate
+  [334](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/334)
+
 * Fix visionOS compilation errors. Note that visionOS is not yet officially supported.
   [327](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/327)
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGPerformanceSharedSessionProxy.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGPerformanceSharedSessionProxy.h
@@ -1,0 +1,19 @@
+//
+//  BSGPerformanceSharedSessionProxy.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Robert B on 24/10/2024.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ *  A proxy for NSURLSession that ignores finishTasksAndInvalidate and invalidateAndCancel calls
+ */
+@interface BSGPerformanceSharedSessionProxy: NSProxy
+
+- (id)initWithSession:(NSURLSession *)session;
+
+@end
+

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGPerformanceSharedSessionProxy.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGPerformanceSharedSessionProxy.mm
@@ -10,6 +10,9 @@
 #import "BSGPerformanceSharedSessionProxy.h"
 #import <objc/runtime.h>
 
+#define FINISH_TASK_AND_INVALIDATE_SELECTOR @selector(finishTasksAndInvalidate)
+#define INVALIDATE_AND_CANCEL_SELECTOR @selector(invalidateAndCancel)
+
 @interface BSGPerformanceSharedSessionProxy ()
 
 @property (nonatomic, strong) NSURLSession *session;
@@ -27,8 +30,8 @@
 }
 
 + (BOOL)selectorShouldBeForwarded:(SEL)aSelector {
-    NSString *selectorString = NSStringFromSelector(aSelector);
-    return !([selectorString isEqual:@"finishTasksAndInvalidate"] || [selectorString isEqual:@"invalidateAndCancel"]);
+    return !(sel_isEqual(aSelector, FINISH_TASK_AND_INVALIDATE_SELECTOR) ||
+             sel_isEqual(aSelector, INVALIDATE_AND_CANCEL_SELECTOR));
 }
 
 - (id)initWithSession:(NSURLSession *)session {

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGPerformanceSharedSessionProxy.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGPerformanceSharedSessionProxy.mm
@@ -1,0 +1,58 @@
+//
+//  BSGPerformanceSharedSessionProxy.mm
+//  BugsnagPerformance-iOS
+//
+//  Created by Robert B on 24/10/2024.
+//  Copyright © 2024 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "BSGPerformanceSharedSessionProxy.h"
+#import <objc/runtime.h>
+
+@interface BSGPerformanceSharedSessionProxy ()
+
+@property (nonatomic, strong) NSURLSession *session;
+
+@end
+
+@implementation BSGPerformanceSharedSessionProxy
+
++ (BOOL)respondsToSelector:(SEL)aSelector {
+    return [NSURLSession respondsToSelector:aSelector];
+}
+
++ (Class)class {
+    return [NSURLSession class];
+}
+
++ (BOOL)selectorShouldBeForwarded:(SEL)aSelector {
+    NSString *selectorString = NSStringFromSelector(aSelector);
+    return !([selectorString isEqual:@"finishTasksAndInvalidate"] || [selectorString isEqual:@"invalidateAndCancel"]);
+}
+
+- (id)initWithSession:(NSURLSession *)session {
+    _session = session;
+    return self;
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+    if ([BSGPerformanceSharedSessionProxy selectorShouldBeForwarded:aSelector]) {
+        return self.session;
+    } else {
+        return self;
+    }
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+    if (![BSGPerformanceSharedSessionProxy selectorShouldBeForwarded:invocation.selector]) {
+        return;
+    }
+    [self.session forwardInvocation:invocation];
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel {
+    return [self.session methodSignatureForSelector:sel];
+}
+
+@end

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -607,6 +607,28 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
 
+  Scenario: Invalidate calls on shared session should be ignored
+    Given I run "AutoInstrumentNetworkSharedSessionInvalidateScenario"
+    And I wait for exactly 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "parentSpanId" does not exist
+    * a span field "name" equals "[HTTP/GET]"
+    * a span string attribute "http.flavor" exists
+    * a span string attribute "http.url" matches the regex "http://.*:9[0-9]{3}/reflect\?status=200"
+    * a span string attribute "http.method" equals "GET"
+    * a span integer attribute "http.status_code" is greater than 0
+    * a span integer attribute "http.response_content_length" is greater than 0
+    * a span string attribute "net.host.connection.type" equals "wifi"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+
   Scenario: Capture automatic network span before configuration (disabled)
     Given I run "AutoInstrumentNetworkPreStartDisabledScenario"
     And I should receive no traces

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		09F025152BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */; };
 		960EECE92B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960EECE82B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift */; };
 		96284DCE2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96284DCD2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift */; };
+		964735CB2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964735CA2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */; };
 		9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */; };
 		9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */; };
 		966634DE2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966634DD2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift */; };
@@ -145,6 +146,7 @@
 		09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDidLoadDoesntTriggerScenario.swift; sourceTree = "<group>"; };
 		960EECE82B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentGenericViewLoadScenario.swift; sourceTree = "<group>"; };
 		96284DCD2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentPreLoadedViewLoadScenario.swift; sourceTree = "<group>"; };
+		964735CA2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkSharedSessionInvalidateScenario.swift; sourceTree = "<group>"; };
 		9657A8982A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentTabViewLoadScenario.swift; sourceTree = "<group>"; };
 		9657A89A2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNavigationViewLoadScenario.swift; sourceTree = "<group>"; };
 		966634DD2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetricsFronzenFramesScenario.swift; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 				09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */,
 				091B95732CA18F66007DC8A9 /* AutoInstrumentNetworkPreStartDisabledScenario.swift */,
 				091B95712CA179AC007DC8A9 /* AutoInstrumentNetworkPreStartScenario.swift */,
+				964735CA2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */,
 				09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
 				097FFC0A2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift */,
@@ -469,6 +472,7 @@
 				967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */,
 				9657A8992A3CF75B001CEF5D /* AutoInstrumentTabViewLoadScenario.swift in Sources */,
 				CBEC89452A4ED0590088A3CE /* MaxPayloadSizeScenario.swift in Sources */,
+				964735CB2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift in Sources */,
 				CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */,
 				966634E02C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift in Sources */,
 				CB2B8A9F2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift in Sources */,

--- a/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		96D528CC2C72B14300FEA2E2 /* AppDataOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */; };
 		96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */; };
 		96D528D02C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */; };
+		96E0B34B2CD0E21C008AEB9C /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E0B34A2CD0E21C008AEB9C /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */; };
 		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
@@ -176,6 +177,7 @@
 		96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataOverrideScenario.swift; sourceTree = "<group>"; };
 		96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityOneScenario.swift; sourceTree = "<group>"; };
 		96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityZeroScenario.swift; sourceTree = "<group>"; };
+		96E0B34A2CD0E21C008AEB9C /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkSharedSessionInvalidateScenario.swift; sourceTree = "<group>"; };
 		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackSetToNilScenario.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
@@ -291,6 +293,7 @@
 				09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */,
 				091B95732CA18F66007DC8A9 /* AutoInstrumentNetworkPreStartDisabledScenario.swift */,
 				091B95712CA179AC007DC8A9 /* AutoInstrumentNetworkPreStartScenario.swift */,
+				96E0B34A2CD0E21C008AEB9C /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */,
 				09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */,
 				CB3477172901481F0033759C /* AutoInstrumentNetworkWithParentScenario.swift */,
 				097FFC0A2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift */,
@@ -470,6 +473,7 @@
 				099331FC2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift in Sources */,
 				097FFC0B2C33D931000E03E8 /* AutoInstrumentNullNetworkCallbackScenario.swift in Sources */,
 				01FE4DAB28E1AEBD00D1F239 /* SceneDelegate.swift in Sources */,
+				96E0B34B2CD0E21C008AEB9C /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift in Sources */,
 				960EECE92B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift in Sources */,
 				0983A1792B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift in Sources */,
 				CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/AutoInstrumentNetworkSharedSessionInvalidateScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentNetworkSharedSessionInvalidateScenario.swift
@@ -1,0 +1,28 @@
+//
+//  AutoInstrumentNetworkSharedSessionInvalidateScenario.swift
+//  Fixture
+//
+//  Created by Robert B on 26/10/2024.
+//
+
+import Foundation
+
+@objcMembers
+class AutoInstrumentNetworkSharedSessionInvalidateScenario: Scenario {
+    
+    override func configure() {
+        super.configure()
+        config.autoInstrumentNetworkRequests = true
+    }
+    
+    override func run() {
+        URLSession.shared.finishTasksAndInvalidate()
+        URLSession.shared.invalidateAndCancel()
+        query(string: "?status=200")
+    }
+    
+    func query(string: String) {
+        let url = URL(string: string, relativeTo: fixtureConfig.reflectURL)!
+        URLSession.shared.dataTask(with: url).resume()
+    }
+}


### PR DESCRIPTION
## Goal

Fixed a crash after shared NSURLSession is invalidated and then used

## Design

In the Bugsnag SDK for iOS it replaces the [NSURLSession sharedSession] with another normal session by [method|this method](https://github.com/bugsnag/bugsnag-cocoa-performance/blob/next/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/NSURLSession%2BInstrumentation.mm#L41-L65).
   While according to Apple, [here](https://developer.apple.com/documentation/foundation/nsurlsession/1407428-finishtasksandinvalidate%7Cdoc), the sharedSession is actually a little bit special, as finishTasksAndInvalidate and invalidateAndCancel should take no effect on the sharedSession. 
   Otherwise, it will cause crash with
   Task created in a session that has been invalidated when another task is created with the sharedSession after the invalidation.

## Changeset

Create a proxy for the shared NSURLSession that does nothing in its finishTasksAndInvalidate and invalidateAndCancel

## Testing

E2E Test