### PR TITLE
[PLAT-12988] Set bugsnag.span.category to 'custom' for custom spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Set bugsnag.span.category to 'custom' for custom spans.
+  [336](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/336)
+
 * Fix visionOS compilation errors. Note that visionOS is not yet officially supported.
   [327](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/327)
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -45,9 +45,9 @@ public:
 
     void reportNetworkSpan(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept;
 
-    BugsnagPerformanceSpan *startSpan(NSString *name) noexcept;
+    BugsnagPerformanceSpan *startCustomSpan(NSString *name) noexcept;
 
-    BugsnagPerformanceSpan *startSpan(NSString *name, BugsnagPerformanceSpanOptions *options) noexcept;
+    BugsnagPerformanceSpan *startCustomSpan(NSString *name, BugsnagPerformanceSpanOptions *options) noexcept;
 
     BugsnagPerformanceSpan *startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType) noexcept;
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -485,15 +485,17 @@ void BugsnagPerformanceImpl::uploadPackage(std::unique_ptr<OtlpPackage> package,
 
 #pragma mark Spans
 
-BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name) noexcept {
+BugsnagPerformanceSpan *BugsnagPerformanceImpl::startCustomSpan(NSString *name) noexcept {
     SpanOptions options;
     auto span = tracer_->startCustomSpan(name, options);
+    [span internalSetMultipleAttributes:spanAttributesProvider_->customSpanAttributes()];
     return span;
 }
 
-BugsnagPerformanceSpan *BugsnagPerformanceImpl::startSpan(NSString *name, BugsnagPerformanceSpanOptions *optionsIn) noexcept {
+BugsnagPerformanceSpan *BugsnagPerformanceImpl::startCustomSpan(NSString *name, BugsnagPerformanceSpanOptions *optionsIn) noexcept {
     auto options = SpanOptions(optionsIn);
     auto span = tracer_->startCustomSpan(name, options);
+    [span internalSetMultipleAttributes:spanAttributesProvider_->customSpanAttributes()];
     return span;
 }
 

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -22,6 +22,7 @@ public:
     NSMutableDictionary *viewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
     NSMutableDictionary *preloadedViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
     NSMutableDictionary *viewLoadPhaseSpanAttributes(NSString *className, NSString *phase) noexcept;
+    NSMutableDictionary *customSpanAttributes() noexcept;
 
     static NSString *httpUrlAttributeKey();
 };

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -192,3 +192,10 @@ SpanAttributesProvider::viewLoadPhaseSpanAttributes(NSString *className, NSStrin
         @"bugsnag.phase": phase,
     }.mutableCopy;
 }
+
+NSMutableDictionary *
+SpanAttributesProvider::customSpanAttributes() noexcept {
+    return @{
+        @"bugsnag.span.category": @"custom",
+    }.mutableCopy;
+}

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -27,11 +27,11 @@ using namespace bugsnag;
 }
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name {
-    return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startSpan(name);
+    return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startCustomSpan(name);
 }
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name options:(BugsnagPerformanceSpanOptions *)options {
-    return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startSpan(name, options);
+    return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startCustomSpan(name, options);
 }
 
 + (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name viewType:(BugsnagPerformanceViewType)viewType {

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -15,6 +15,7 @@ Feature: Manual creation of spans
     * a span field "name" equals "WillRetry"
     * a span field "name" equals "Success"
     * every span bool attribute "bugsnag.span.first_class" is true
+    * every span string attribute "bugsnag.span.category" equals "custom"
 
   Scenario: Manually start and end a span
     Given I run "ManualSpanScenario"
@@ -47,6 +48,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "10.0"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * every span string attribute "bugsnag.span.category" equals "custom"
 
   Scenario: Starting and ending a span before starting the SDK
     Given I run "ManualSpanBeforeStartScenario"
@@ -66,6 +68,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" equals "42.42"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "42"
+    * every span string attribute "bugsnag.span.category" equals "custom"
 
   Scenario: Manually report a view load span
     Given I run "ManualViewLoadScenario"


### PR DESCRIPTION
Custom spans now set attribute `bugsnag.span.category` to `custom`.

e2e tests have been updated to check for this.
