### PR TITLE
NOTICKET: fix catalyst build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("SystemConfiguration"),
                 .linkedFramework("UIKit"),
-                .linkedFramework("CoreTelephony", .when(platforms: [.iOS])),
+                .linkedFramework("CoreTelephony"),
             ]
         ),
         .target(


### PR DESCRIPTION
## Goal

Fixes build on MacCatalyst.
The error I get is that symbols from CoreTelephone are not defined.

## Design

Apparently, the package is defined as supporting iOS+MacCatalyst (e.g. SupportedPlatform = .iOS)
But the 'CoreTelephony' is only linked for iOS, so fix that.

I guess this was written before macCatalyst, and it was correct back then.
Still, since macOS/tvOS is not a supported platform, there is no reason to conditionally link CoreTelephony.

## Changeset

Unconditionally link CoreTelephony.

## Testing

Build succeeds.