### PR TITLE
Buildkite pipeline tidy-up

### DIFF
--- a/.buildkite/block.full.yml
+++ b/.buildkite/block.full.yml
@@ -3,5 +3,8 @@ steps:
     key: 'trigger-full-build'
 
   - label: 'Upload the full test pipeline'
+    timeout_in_minutes: 5
+    agents:
+      queue: macos
     depends_on: 'trigger-full-build'
     command: buildkite-agent pipeline upload .buildkite/pipeline.full.yml

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -9,6 +9,7 @@ steps:
   - group: ":xcode_simulator: Unit Tests"
     steps:
       - label: "iOS 17 Unit Tests"
+        timeout_in_minutes: 10
         commands:
           - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=17.5 DEVICE="iPhone 15"
         plugins:
@@ -17,6 +18,7 @@ steps:
               - "logs/*"
 
       - label: "iOS 16 Unit Tests"
+        timeout_in_minutes: 10
         commands:
           - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=16.4 DEVICE="iPhone 14"
         plugins:
@@ -25,6 +27,7 @@ steps:
               - "logs/*"
 
       - label: "iOS 15 Unit Tests"
+        timeout_in_minutes: 10
         commands:
           - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=15.5 DEVICE="iPhone 13"
         plugins:
@@ -33,6 +36,7 @@ steps:
               - "logs/*"
 
       - label: "iOS 14 Unit Tests"
+        timeout_in_minutes: 10
         commands:
           - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=14.5
         plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,5 @@
 env:
   LANG: "en_GB.UTF-8"
-  XCODE_VERSION: "15.4.0"
 
 agents:
   queue: macos-14
@@ -14,6 +13,8 @@ steps:
         timeout_in_minutes: 20
         commands:
           - make build_xcframework
+        env:
+          XCODE_VERSION: "15.4.0"
         plugins:
           - artifacts#v1.9.3:
               upload:
@@ -24,16 +25,22 @@ steps:
         commands:
           - bundle install
           - ./features/fixtures/carthage/build.sh
+        env:
+          XCODE_VERSION: "15.4.0"
 
       - label: "CocoaPods"
         commands:
           - bundle install
           - pod lib lint BugsnagPerformance.podspec.json
+        env:
+          XCODE_VERSION: "15.4.0"
 
       - label: "Example"
         commands:
           - bundle install
           - ./Example/build.sh
+        env:
+          XCODE_VERSION: "15.4.0"
 
       - label: "Fixture"
         key: ios_fixture
@@ -42,6 +49,8 @@ steps:
           - bundle install
           - bundle exec upload-app --farm=bb --app=./features/fixtures/ios/output/Fixture.ipa --app-id-file=./features/fixtures/ios/output/bb_ipa_url.txt
           - bundle exec upload-app --farm=bs --app=./features/fixtures/ios/output/Fixture.ipa --app-id-file=./features/fixtures/ios/output/bs_ipa_url.txt
+        env:
+          XCODE_VERSION: "15.4.0"
         artifact_paths:
           - features/fixtures/ios/output/bb_ipa_url.txt
           - features/fixtures/ios/output/bs_ipa_url.txt
@@ -54,6 +63,8 @@ steps:
           - bundle install
           - bundle exec upload-app --farm=bb --app=./features/fixtures/ios/output/FixtureXcFramework.ipa --app-id-file=./features/fixtures/ios/output/bb_xcframework_ipa_url.txt
           - bundle exec upload-app --farm=bs --app=./features/fixtures/ios/output/FixtureXcFramework.ipa --app-id-file=./features/fixtures/ios/output/bs_xcframework_ipa_url.txt
+        env:
+          XCODE_VERSION: "15.4.0"
         plugins:
           - artifacts#v1.9.3:
               download:
@@ -70,6 +81,8 @@ steps:
           - bundle install
           - bundle exec upload-app --farm=bb --app=./features/fixtures/ios/output/FixtureWithDisableSwizzling.ipa --app-id-file=./features/fixtures/ios/output/bb_url_swizzling_disabled.txt
           - bundle exec upload-app --farm=bs --app=./features/fixtures/ios/output/FixtureWithDisableSwizzling.ipa --app-id-file=./features/fixtures/ios/output/bs_url_swizzling_disabled.txt
+        env:
+          XCODE_VERSION: "15.4.0"
         artifact_paths:
           - features/fixtures/ios/output/bb_url_swizzling_disabled.txt
           - features/fixtures/ios/output/bs_url_swizzling_disabled.txt
@@ -81,6 +94,8 @@ steps:
           - bundle install
           - bundle exec upload-app --farm=bb --app=./features/fixtures/ios/output/FixtureWithSwizzlingPremain.ipa --app-id-file=./features/fixtures/ios/output/bb_url_swizzling_premain.txt
           - bundle exec upload-app --farm=bs --app=./features/fixtures/ios/output/FixtureWithSwizzlingPremain.ipa --app-id-file=./features/fixtures/ios/output/bs_url_swizzling_premain.txt
+        env:
+          XCODE_VERSION: "15.4.0"
         artifact_paths:
           - features/fixtures/ios/output/bb_url_swizzling_premain.txt
           - features/fixtures/ios/output/bs_url_swizzling_premain.txt
@@ -88,23 +103,28 @@ steps:
   - group: ":xcode_simulator: Unit Tests"
     steps:
       - label: "iOS 18 Unit Tests"
+        timeout_in_minutes: 10
         commands:
           - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=18.0 DEVICE="iPhone 15"
+        env:
+          XCODE_VERSION: "15.4.0"
         plugins:
           artifacts#v1.9.3:
             upload:
               - "logs/*"
+
       - label: "iOS 13 Unit Tests"
-        commands:
-          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=13.7
-        plugins:
-          artifacts#v1.9.3:
-            upload:
-              - "logs/*"
+        timeout_in_minutes: 10
         agents:
           queue: macos-12-arm
+        commands:
+          - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=13.7
         env:
           XCODE_VERSION: "14"
+        plugins:
+          artifacts#v1.9.3:
+            upload:
+              - "logs/*"
 
   - group: "E2E Tests"
     steps:
@@ -371,4 +391,6 @@ steps:
         concurrency_method: eager
 
   - label: 'Conditionally trigger full set of tests'
+    agents:
+      queue: macos
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
     steps:
       - label: "XCFramework"
         key: xcframework
-        timeout_in_minutes: 20
+        timeout_in_minutes: 10
         commands:
           - make build_xcframework
         env:
@@ -22,6 +22,7 @@ steps:
                 - "BugsnagPerformanceSwift.xcframework.zip"
 
       - label: "Carthage"
+        timeout_in_minutes: 10
         commands:
           - bundle install
           - ./features/fixtures/carthage/build.sh
@@ -29,6 +30,7 @@ steps:
           XCODE_VERSION: "15.4.0"
 
       - label: "CocoaPods"
+        timeout_in_minutes: 10
         commands:
           - bundle install
           - pod lib lint BugsnagPerformance.podspec.json
@@ -36,6 +38,7 @@ steps:
           XCODE_VERSION: "15.4.0"
 
       - label: "Example"
+        timeout_in_minutes: 10
         commands:
           - bundle install
           - ./Example/build.sh
@@ -44,6 +47,7 @@ steps:
 
       - label: "Fixture"
         key: ios_fixture
+        timeout_in_minutes: 10
         commands:
           - ./features/fixtures/ios/build.sh
           - bundle install
@@ -58,6 +62,7 @@ steps:
       - label: "XcFramework Fixture"
         key: ios_xcframework_fixture
         depends_on: xcframework
+        timeout_in_minutes: 10
         commands:
           - ./features/fixtures/ios/build_xcframework.sh
           - bundle install
@@ -76,6 +81,7 @@ steps:
 
       - label: "Fixture swizzling disabled"
         key: ios_fixture_swizzling_disabled
+        timeout_in_minutes: 10
         commands:
           - ./features/fixtures/ios/build.sh --disableSwizzling --fixtureName FixtureWithDisableSwizzling
           - bundle install
@@ -89,6 +95,7 @@ steps:
 
       - label: "Fixture swizzling premain"
         key: ios_fixture_swizzling_premain
+        timeout_in_minutes: 10
         commands:
           - ./features/fixtures/ios/build.sh --swizzlingPremain --fixtureName FixtureWithSwizzlingPremain
           - bundle install
@@ -393,4 +400,5 @@ steps:
   - label: 'Conditionally trigger full set of tests'
     agents:
       queue: macos
+    timeout_in_minutes: 2
     command: sh -c .buildkite/pipeline_trigger.sh


### PR DESCRIPTION
## Goal

General tidy-up of the Buildkite pipeline to:
- Ensure all steps have an adequate but not excessive timeout
- Agent queues are explicitly stated in each file (even if a default is used)
- Generic `macos` queue is used instead of specific macOS versions where possible

## Testing

Covered by a full CI run.