### PR TITLE
[PLAT-31288] Split out ending a span and closing/sending for processing

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -46,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BSGFirstClass firstClass;
 @property (nonatomic) SpanKind kind;
 @property (nonatomic,readwrite) BOOL isMutable;
+@property (nonatomic,readwrite) BOOL hasBeenProcessed;
 @property (nonatomic,readonly) NSUInteger attributeCountLimit;
 @property (nonatomic,readwrite) BOOL wasStartOrEndTimeProvided;
 @property (nonatomic) BSGInstrumentRendering instrumentRendering;


### PR DESCRIPTION
## Goal

The RN library needs to be able to set the end time multiple times, so we need to split out:
- ending a span (marking the end time)
- closing the span and sending for processing (at which time it becomes immutable)

## Design

`BugsnagPerformanceSpan` now has two new internal APIs:
- `- (void)markEndTime:(NSDate *)endTime` to set the end time of the span (can be called multiple times)
- `- (void)sendForProcessing` to send for processing (idempotent, only performs operation once)

## Testing

Existing tests are sufficient since the public `end` functions now call these functions.
