### PR TITLE
Replace internal access to `traceId` property with `traceIdHi` and `traceIdLo`

### DIFF
--- a/Sources/BugsnagPerformance/Private/Batch.h
+++ b/Sources/BugsnagPerformance/Private/Batch.h
@@ -60,12 +60,12 @@ public:
         }
     }
 
-    void removeSpan(TraceId traceId, SpanId spanId) noexcept {
-        BSGLogDebug(@"Batch:removeSpan(%llx%llx, %llx)", traceId.hi, traceId.lo, spanId);
+    void removeSpan(uint64_t traceIdHi, uint64_t traceIdLo, SpanId spanId) noexcept {
+        BSGLogDebug(@"Batch:removeSpan(%llx%llx, %llx)", traceIdHi, traceIdLo, spanId);
         std::lock_guard<std::mutex> guard(mutex_);
 
         if (spans_.count == 0) {
-            BSGLogDebug(@"Batch:removeSpan(%llx%llx, %llx): Batch is empty", traceId.hi, traceId.lo, spanId);
+            BSGLogDebug(@"Batch:removeSpan(%llx%llx, %llx): Batch is empty", traceIdHi, traceIdLo, spanId);
             return;
         }
 
@@ -73,13 +73,13 @@ public:
         size_t index = 0;
         for(; index < spans_.count; index++) {
             BugsnagPerformanceSpan *potential = spans_[index];
-            if (potential.spanId == spanId && potential.traceId.value == traceId.value) {
+            if (potential.spanId == spanId && potential.traceIdHi == traceIdHi && potential.traceIdLo == traceIdLo) {
                 found = potential;
             }
         }
 
         if (found == nil) {
-            BSGLogDebug(@"Batch:removeSpan(%llx%llx, %llx): Span not found", traceId.hi, traceId.lo, spanId);
+            BSGLogDebug(@"Batch:removeSpan(%llx%llx, %llx): Span not found", traceIdHi, traceIdLo, spanId);
             return;
         }
 
@@ -87,12 +87,12 @@ public:
 //        [spans_ removeObjectAtIndex:index];
 
         for (BugsnagPerformanceSpan *span in spans_) {
-            if (span.parentId == spanId && span.traceId.value == traceId.value) {
+            if (span.parentId == spanId && span.traceIdHi == traceIdHi && span.traceIdLo == traceIdLo) {
                 span.parentId = 0;
             }
         }
         BSGLogDebug(@"Batch:removeSpan(%llx%llx, %llx): Span %@ removed. Batch size is now %zu",
-                    traceId.hi, traceId.lo, spanId, found.name, spans_.count);
+                    traceIdHi, traceIdLo, spanId, found.name, spans_.count);
     }
 
     /**

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
@@ -60,7 +60,7 @@ using namespace bugsnag;
         return nil;
     }
     return @[
-        [NSString stringWithFormat:@"%llx%llx", span.traceId.hi, span.traceId.lo],
+        [NSString stringWithFormat:@"%llx%llx", span.traceIdHi, span.traceIdLo],
         [NSString stringWithFormat:@"%llx", span.spanId]
     ];
 }

--- a/Sources/BugsnagPerformance/Private/NetworkHeaderInjector.mm
+++ b/Sources/BugsnagPerformance/Private/NetworkHeaderInjector.mm
@@ -22,7 +22,7 @@ NSString *NetworkHeaderInjector::generateTraceParent(BugsnagPerformanceSpan *spa
     }
     // Sampled status assumes that the current P value won't change soon.
     return [NSString stringWithFormat:@"00-%016llx%016llx-%016llx-0%d",
-            span.traceId.hi, span.traceId.lo,
+            span.traceIdHi, span.traceIdLo,
             span.spanId, sampler_->sampled(span)];
 }
 

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -17,8 +17,8 @@ static NSString * EncodeSpanId(SpanId const &spanId) {
     return [NSString stringWithFormat:@"%016llx", spanId];
 }
 
-static NSString * EncodeTraceId(TraceId const &traceId) {
-    return [NSString stringWithFormat:@"%016llx%016llx", traceId.hi, traceId.lo];
+static NSString * EncodeTraceId(uint64_t traceIdHi, uint64_t traceIdLo) {
+    return [NSString stringWithFormat:@"%016llx%016llx", traceIdHi, traceIdLo];
 }
 
 static NSString * EncodeCFAbsoluteTime(CFAbsoluteTime time) {
@@ -37,7 +37,7 @@ OtlpTraceEncoding::encode(BugsnagPerformanceSpan *span) noexcept {
     // random trace_id if empty or invalid trace_id was received.
     //
     // This field is required.
-    result[@"traceId"] = EncodeTraceId(span.traceId);
+    result[@"traceId"] = EncodeTraceId(span.traceIdHi, span.traceIdLo);
 
     // A unique identifier for a span within a trace, assigned when the span
     // is created. The ID is an 8-byte array. An ID with all zeroes is considered

--- a/Sources/BugsnagPerformance/Private/Sampler.h
+++ b/Sources/BugsnagPerformance/Private/Sampler.h
@@ -47,7 +47,7 @@ public:
         } else {
             idUpperBound = uint64_t(p * double(UINT64_MAX));
         }
-        return span.traceId.hi <= idUpperBound;
+        return span.traceIdHi <= idUpperBound;
     }
 
 private:

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -97,7 +97,8 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
         BSGLogTrace(@"Tracer::startSpan: No parent specified; using current span");
         parentSpan = spanStackingHandler_->currentSpan();
     }
-    auto traceId = parentSpan.traceId;
+
+    TraceId traceId = { .hi = parentSpan.traceIdHi, .lo = parentSpan.traceIdLo };
     if (traceId.value == 0) {
         BSGLogTrace(@"Tracer::startSpan: No parent traceId; generating one");
         traceId = IdGenerator::generateTraceId();
@@ -280,7 +281,7 @@ void Tracer::cancelQueuedSpan(BugsnagPerformanceSpan *span) noexcept {
     BSGLogTrace(@"Tracer::cancelQueuedSpan(%@)", span.name);
     if (span) {
         [span abortIfOpen];
-        batch_->removeSpan(span.traceId, span.spanId);
+        batch_->removeSpan(span.traceIdHi, span.traceIdLo, span.spanId);
     }
 }
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanContext.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanContext.mm
@@ -22,4 +22,12 @@
     return [self initWithTraceId:TraceId{.hi=traceIdHi, .lo=traceIdLo} spanId:spanId];
 }
 
+- (uint64_t) traceIdHi {
+    return self.traceId.hi;
+}
+
+- (uint64_t) traceIdLo {
+    return self.traceId.lo;
+}
+
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
@@ -25,6 +25,8 @@ OBJC_EXPORT
 
 @property(nonatomic,readonly) TraceId traceId;
 @property(nonatomic,readonly) SpanId spanId;
+@property(nonatomic,readonly) uint64_t traceIdHi;
+@property(nonatomic,readonly) uint64_t traceIdLo;
 
 - (instancetype) initWithTraceId:(TraceId)traceId spanId:(SpanId)spanId;
 


### PR DESCRIPTION
## Goal

Methods/properties that return a struct (such as `traceId` in `BugsnagPerformanceSpanContext`) cannot be proxied in the CrossTalk API and would crash if accessed through a proxy object.

This PR adds two new properties for `traceIDHi` and `traceIdLo` to `BugsnagPerformanceSpanContext` and updates internal code to never access `traceId` on a span or span context and use these new properties instead.

## Testing

Relied on existing tests