### PR TITLE
[PLAT-13288] Update snapshots whenever a span's end time is set (not just when the span is closed)

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -27,7 +27,7 @@ typedef enum {
     SpanStateAborted = 3,
 } SpanState;
 
-typedef void (^OnSpanClosed)(BugsnagPerformanceSpan * _Nonnull);
+typedef void (^SpanLifecycleCallback)(BugsnagPerformanceSpan * _Nonnull);
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,7 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) OnSpanDestroyAction onSpanDestroyAction;
 @property (nonatomic,readwrite) NSString *name;
 @property (nonatomic,readonly) NSMutableDictionary *attributes;
-@property (nonatomic) OnSpanClosed onSpanClosed;
+@property (nonatomic) SpanLifecycleCallback onSpanEndSet;
+@property (nonatomic) SpanLifecycleCallback onSpanClosed;
 @property (nonatomic,readwrite) SpanId parentId;
 @property (nonatomic) double samplingProbability;
 @property (nonatomic) BSGFirstClass firstClass;
@@ -67,7 +68,8 @@ NS_ASSUME_NONNULL_BEGIN
                   firstClass:(BSGFirstClass) firstClass
          attributeCountLimit:(NSUInteger)attributeCountLimit
          instrumentRendering:(BSGInstrumentRendering)instrumentRendering
-                onSpanClosed:(OnSpanClosed) onSpanEnded NS_DESIGNATED_INITIALIZER;
+                onSpanEndSet:(SpanLifecycleCallback) onSpanEndSet
+                onSpanClosed:(SpanLifecycleCallback) onSpanEnded NS_DESIGNATED_INITIALIZER;
 
 - (void)internalSetAttribute:(NSString *)attributeName withValue:(_Nullable id)value;
 - (void)internalSetMultipleAttributes:(NSDictionary *)attributes;

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -98,6 +98,7 @@ private:
     BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
     void createFrozenFrameSpan(NSTimeInterval startTime, NSTimeInterval endTime, BugsnagPerformanceSpanContext *parentContext) noexcept;
     void markPrewarmSpan(BugsnagPerformanceSpan *span) noexcept;
+    void onSpanEndSet(BugsnagPerformanceSpan *span);
     void onSpanClosed(BugsnagPerformanceSpan *span);
     void reprocessEarlySpans(void);
     void processFrameMetrics(BugsnagPerformanceSpan *span) noexcept;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -35,7 +35,8 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
                   firstClass:(BSGFirstClass) firstClass
          attributeCountLimit:(NSUInteger)attributeCountLimit
          instrumentRendering:(BSGInstrumentRendering)instrumentRendering
-                onSpanClosed:(OnSpanClosed) onSpanClosed {
+                onSpanEndSet:(SpanLifecycleCallback) onSpanEndSet
+                onSpanClosed:(SpanLifecycleCallback) onSpanClosed {
     if ((self = [super initWithTraceId:traceId spanId:spanId])) {
         _startClock = currentMonotonicClockNsecIfUnset(startAbsTime);
         _name = name;
@@ -44,6 +45,7 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
         _startClock = currentMonotonicClockNsecIfUnset(startAbsTime);
         _firstClass = firstClass;
         _onSpanDestroyAction = OnSpanDestroyAbort;
+        _onSpanEndSet = onSpanEndSet;
         _onSpanClosed = onSpanClosed;
         _kind = SPAN_KIND_INTERNAL;
         _samplingProbability = 1;
@@ -138,6 +140,10 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
 
 - (void)markEndAbsoluteTime:(CFAbsoluteTime)endTime {
     self.endAbsTime = currentTimeIfUnset(endTime);
+    auto onSpanEndSet = self.onSpanEndSet;
+    if(onSpanEndSet != nil) {
+        onSpanEndSet(self);
+    }
 }
 
 - (void)sendForProcessing {

--- a/Tests/BugsnagPerformanceTests/BatchTests.mm
+++ b/Tests/BugsnagPerformanceTests/BatchTests.mm
@@ -27,6 +27,7 @@ static BugsnagPerformanceSpan *newSpanData() {
                                              firstClass:BSGFirstClassUnset
                                     attributeCountLimit:128
                                     instrumentRendering:BSGInstrumentRenderingNo
+                                           onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
 }

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -185,6 +185,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                              firstClass:firstClass
                                     attributeCountLimit:128
                                     instrumentRendering:BSGInstrumentRenderingNo
+                                           onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {}];
 }
 

--- a/Tests/BugsnagPerformanceTests/SamplerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SamplerTests.mm
@@ -67,6 +67,7 @@ using namespace bugsnag;
                                                                          firstClass:BSGFirstClassUnset
                                                                 attributeCountLimit:128
                                                                 instrumentRendering:BSGInstrumentRenderingNo
+                                                                       onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                                                        onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
         }];
         if (sampler.sampled(span)) {

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -49,6 +49,7 @@ using namespace bugsnag;
                                                                      firstClass:BSGFirstClassNo
                                                             attributeCountLimit:128
                                                             instrumentRendering:BSGInstrumentRenderingNo
+                                                                   onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                                                    onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
     BugsnagPerformanceSpanOptions *objcOptions = [BugsnagPerformanceSpanOptions new];

--- a/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
@@ -25,6 +25,7 @@ static BugsnagPerformanceSpan *createSpan(std::shared_ptr<SpanStackingHandler> h
                                              firstClass:BSGFirstClassNo
                                     attributeCountLimit:128
                                     instrumentRendering:BSGInstrumentRenderingNo
+                                           onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull span) {
         handler->onSpanClosed(span.spanId);
     }];

--- a/Tests/BugsnagPerformanceTests/SpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanTests.mm
@@ -18,7 +18,7 @@ using namespace bugsnag;
 
 @implementation SpanTests
 
-static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, OnSpanClosed onEnded) {
+static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanLifecycleCallback onEnded) {
     TraceId tid = {.value = 1};
     return [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                 traceId:tid
@@ -28,6 +28,7 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, OnSpa
                                              firstClass:BSGFirstClassUnset
                                     attributeCountLimit:128
                                     instrumentRendering:BSGInstrumentRenderingNo
+                                           onSpanEndSet:^(BugsnagPerformanceSpan *) {}
                                            onSpanClosed:onEnded];
 }
 
@@ -278,6 +279,7 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, OnSpa
                                                   firstClass:BSGFirstClassUnset
                                          attributeCountLimit:5
                                          instrumentRendering:BSGInstrumentRenderingNo
+                                                onSpanEndSet:^(BugsnagPerformanceSpan *) {}
                                                 onSpanClosed:^(BugsnagPerformanceSpan *) {}];
 
     // Note: "bugsnag.sampling.p" is automatically added.

--- a/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
+++ b/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
@@ -27,6 +27,7 @@ static BugsnagPerformanceSpan *createSpan() {
                                              firstClass:BSGFirstClassNo
                                     attributeCountLimit:128
                                     instrumentRendering:BSGInstrumentRenderingNo
+                                           onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
 }


### PR DESCRIPTION
## Goal

Since the end time can be set long before the span is closed, we need to update snapshots as the end time is set, not at close time.
