### PR TITLE
Disable assertions on release build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,10 @@ let package = Package(
             resources: [
                .copy("resources/PrivacyInfo.xcprivacy")
             ],
+            cSettings: [
+                .define("NS_BLOCK_ASSERTIONS", .when(configuration: .release)),
+                .define("NDEBUG", .when(configuration: .release))
+            ],
             linkerSettings: [
                 .linkedFramework("SystemConfiguration"),
                 .linkedFramework("UIKit"),
@@ -35,7 +39,11 @@ let package = Package(
         .target(
             name: "BugsnagPerformanceSwift",
             dependencies: ["BugsnagPerformance"],
-            path: "Sources/BugsnagPerformanceSwift"
+            path: "Sources/BugsnagPerformanceSwift",
+            cSettings: [
+                .define("NS_BLOCK_ASSERTIONS", .when(configuration: .release)),
+                .define("NDEBUG", .when(configuration: .release))
+            ]
         ),
         .target(
             name: "BugsnagPerformanceSwiftUI",


### PR DESCRIPTION
## Goal

Disable assertions on release build. There's nothing in the library using assertions other than the API key check at the start, but if in future we do start using them more, it will be good to have them disabled on a release build.

Ref: https://github.com/bugsnag/bugsnag-cocoa/issues/1705