### PR TITLE
Crosstalk API: do not return a proxy config object when configuration is nil

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
@@ -73,6 +73,10 @@ using namespace bugsnag;
  * Return the final configuration that was provided to [BugsnagPerformance start], or return nil if start has not been called.
  */
 - (BugsnagPerformanceConfiguration * _Nullable)getConfigurationV1 {
+    if (self.configuration == nil) {
+        return nil;
+    }
+    
     return (BugsnagPerformanceConfiguration *)[BugsnagPerformanceCrossTalkProxiedObject proxied:self.configuration];
 }
 


### PR DESCRIPTION
## Goal

Updates the `getConfigurationV1` method in the crosstalk API to return nil if the configuration is nil

## Testing

Relied on existing tests