### PR TITLE
[PLAT-11294] View load spanfix for firstClass and set current context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* View load spans are now not first class by default, and don't set the current context.
+  [369](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/369)
+
 * Improved Swift mangled name handling when reporting view spans.
   [344](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/344)
 

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -251,6 +251,8 @@ BugsnagPerformanceSpan *
 Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
                           NSString *className,
                           SpanOptions options) noexcept {
+    // Always override this on a view load span
+    options.makeCurrentContext = false;
     NSString *type = getBugsnagPerformanceViewTypeName(viewType);
     onViewLoadSpanStarted_(className);
     NSString *name = [NSString stringWithFormat:@"[ViewLoad/%@]/%@", type, className];
@@ -259,7 +261,7 @@ Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
             options.firstClass = BSGFirstClassNo;
         }
     }
-    auto span = startSpan(name, options, BSGFirstClassYes);
+    auto span = startSpan(name, options, BSGFirstClassNo);
     if (willDiscardPrewarmSpans_) {
         markPrewarmSpan(span);
     }

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -81,7 +81,7 @@ Feature: Manual creation of spans
     * a span field "name" equals "[ViewLoad/SwiftUI]/ManualView"
     * a span string attribute "bugsnag.view.name" equals "ManualView"
     * a span string attribute "bugsnag.view.type" equals "SwiftUI"
-    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span bool attribute "bugsnag.span.first_class" is false
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
@@ -116,7 +116,7 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "view_load"
-    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span bool attribute "bugsnag.span.first_class" is false
 
   Scenario: Manually start a network span
     Given I run "ManualNetworkSpanScenario"


### PR DESCRIPTION
## Goal

View load spans should have firstClass = no by default, and not set current context.

## Testing

Updated tests