### PR TITLE
[PLAT-13438] Add periodic CPU sampling.

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -59,6 +59,12 @@
 		0986B7C02B287C9D00BD2CA3 /* WeakSpansList.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0986B7BF2B287C9D00BD2CA3 /* WeakSpansList.mm */; };
 		0987F2792C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 0987F2772C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0987F27A2C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0987F2782C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm */; };
+		098FC8462D2EB8E8001B627D /* BSGPSystemInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 098FC8452D2EB8E8001B627D /* BSGPSystemInfo.h */; };
+		098FC8472D2EB8E8001B627D /* BSGPSystemInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 098FC8442D2EB8E8001B627D /* BSGPSystemInfo.mm */; };
+		098FC84E2D350E60001B627D /* FixedLengthDequeue.h in Headers */ = {isa = PBXBuildFile; fileRef = 098FC84D2D350E60001B627D /* FixedLengthDequeue.h */; };
+		098FC8542D37A08D001B627D /* SystemInfoSampler.h in Headers */ = {isa = PBXBuildFile; fileRef = 098FC8532D37A08D001B627D /* SystemInfoSampler.h */; };
+		098FC8552D37A08D001B627D /* SystemInfoSampler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 098FC8522D37A08D001B627D /* SystemInfoSampler.mm */; };
+		098FC8792D3FADFE001B627D /* SpanAttributesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 098FC8782D3FADFE001B627D /* SpanAttributesTests.mm */; };
 		09B473072B23087D0024CF11 /* WeakSpansList.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B473052B23087D0024CF11 /* WeakSpansList.h */; };
 		09B4730A2B2313570024CF11 /* WeakSpansListTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09B473092B2313570024CF11 /* WeakSpansListTests.mm */; };
 		09D59E1A2BDFE0D900199E1B /* NetworkHeaderInjector.h in Headers */ = {isa = PBXBuildFile; fileRef = 09D59E182BDFE0D900199E1B /* NetworkHeaderInjector.h */; };
@@ -302,6 +308,14 @@
 		0986B7BF2B287C9D00BD2CA3 /* WeakSpansList.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WeakSpansList.mm; sourceTree = "<group>"; };
 		0987F2772C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanContext.h; sourceTree = "<group>"; };
 		0987F2782C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceSpanContext.mm; sourceTree = "<group>"; };
+		098FC8442D2EB8E8001B627D /* BSGPSystemInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGPSystemInfo.mm; sourceTree = "<group>"; };
+		098FC8452D2EB8E8001B627D /* BSGPSystemInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGPSystemInfo.h; sourceTree = "<group>"; };
+		098FC84D2D350E60001B627D /* FixedLengthDequeue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FixedLengthDequeue.h; sourceTree = "<group>"; };
+		098FC8522D37A08D001B627D /* SystemInfoSampler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SystemInfoSampler.mm; sourceTree = "<group>"; };
+		098FC8532D37A08D001B627D /* SystemInfoSampler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SystemInfoSampler.h; sourceTree = "<group>"; };
+		098FC8772D3E8D43001B627D /* Metrics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Metrics.h; sourceTree = "<group>"; };
+		098FC8782D3FADFE001B627D /* SpanAttributesTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SpanAttributesTests.mm; sourceTree = "<group>"; };
+		098FC87A2D3FD095001B627D /* TestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestHelpers.h; sourceTree = "<group>"; };
 		09B473052B23087D0024CF11 /* WeakSpansList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WeakSpansList.h; sourceTree = "<group>"; };
 		09B473092B2313570024CF11 /* WeakSpansListTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WeakSpansListTests.mm; sourceTree = "<group>"; };
 		09D59E182BDFE0D900199E1B /* NetworkHeaderInjector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkHeaderInjector.h; sourceTree = "<group>"; };
@@ -546,6 +560,8 @@
 				CB572EA829BB783200FD7A2A /* AppStateTracker.h */,
 				CB572EA929BB783200FD7A2A /* AppStateTracker.m */,
 				CBE8EA1C294B5E1500702950 /* Batch.h */,
+				098FC8452D2EB8E8001B627D /* BSGPSystemInfo.h */,
+				098FC8442D2EB8E8001B627D /* BSGPSystemInfo.mm */,
 				967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */,
 				09FFD43E2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.h */,
 				09FFD43F2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm */,
@@ -563,6 +579,7 @@
 				CBA22C952A0137230066A2C1 /* EarlyConfiguration.mm */,
 				CBEC51D42976BCAD009C0CE3 /* Filesystem.h */,
 				CBEC51D52976BCAD009C0CE3 /* Filesystem.mm */,
+				098FC84D2D350E60001B627D /* FixedLengthDequeue.h */,
 				966634D82C8A3939004A934D /* FrameRateMetrics */,
 				CBF7C5DF297A8E9100D47719 /* Gzip.h */,
 				CBF7C5E0297A8E9100D47719 /* Gzip.m */,
@@ -570,6 +587,7 @@
 				0122C22929019770002D243C /* Instrumentation */,
 				CBEC51BE296DB311009C0CE3 /* JSON.h */,
 				CBEC51BF296DB311009C0CE3 /* JSON.mm */,
+				098FC8772D3E8D43001B627D /* Metrics.h */,
 				09D59E182BDFE0D900199E1B /* NetworkHeaderInjector.h */,
 				09D59E192BDFE0D900199E1B /* NetworkHeaderInjector.mm */,
 				CBB48A3A295EE1E10044E9AC /* ObjCUtils.h */,
@@ -605,6 +623,8 @@
 				96D55C7F2A1EA5C6006D1F29 /* SpanStackingHandler.mm */,
 				CBEBE59129F2783C00BF0B4F /* Swizzle.h */,
 				CBEBE59029F2783C00BF0B4F /* Swizzle.mm */,
+				098FC8532D37A08D001B627D /* SystemInfoSampler.h */,
+				098FC8522D37A08D001B627D /* SystemInfoSampler.mm */,
 				CBC90C4429C84DEB00280884 /* Targets.h */,
 				0122C23329019770002D243C /* Tracer.h */,
 				0122C22529019770002D243C /* Tracer.mm */,
@@ -675,6 +695,7 @@
 				01A414C42912B93F003152A4 /* ResourceAttributesTests.mm */,
 				CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */,
 				01A58C10290931A5006E4DF7 /* SamplerTests.mm */,
+				098FC8782D3FADFE001B627D /* SpanAttributesTests.mm */,
 				CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */,
 				96D55C872A1EE26A006D1F29 /* SpanStackingHandlerTests.mm */,
 				CB2B8A9A2A0924A50054FBBE /* SpanTests.mm */,
@@ -682,6 +703,7 @@
 				09509B742ADFE9A900A358EC /* TracerTests.mm */,
 				09B473092B2313570024CF11 /* WeakSpansListTests.mm */,
 				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
+				098FC87A2D3FD095001B627D /* TestHelpers.h */,
 			);
 			path = BugsnagPerformanceTests;
 			sourceTree = "<group>";
@@ -848,6 +870,7 @@
 				CBE0873329FA984C007455F2 /* BugsnagPerformanceViewType+Private.h in Headers */,
 				CBEC51D62976BCAD009C0CE3 /* Filesystem.h in Headers */,
 				0987F2792C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h in Headers */,
+				098FC8542D37A08D001B627D /* SystemInfoSampler.h in Headers */,
 				CBEC51C0296DB312009C0CE3 /* JSON.h in Headers */,
 				09B473072B23087D0024CF11 /* WeakSpansList.h in Headers */,
 				09F23A8C2CE351ED00F0D769 /* BugsnagSwiftTools.h in Headers */,
@@ -859,7 +882,9 @@
 				09D59E1A2BDFE0D900199E1B /* NetworkHeaderInjector.h in Headers */,
 				0122C23F29019770002D243C /* OtlpTraceEncoding.h in Headers */,
 				0122C24229019770002D243C /* SpanKind.h in Headers */,
+				098FC84E2D350E60001B627D /* FixedLengthDequeue.h in Headers */,
 				CB78819D29E587CE00A58906 /* BugsnagPerformanceLibrary.h in Headers */,
+				098FC8462D2EB8E8001B627D /* BSGPSystemInfo.h in Headers */,
 				CB572EAA29BB783200FD7A2A /* AppStateTracker.h in Headers */,
 				CBEC51DC2976F1F9009C0CE3 /* RetryQueue.h in Headers */,
 				01A414CD2913C0F0003152A4 /* SpanAttributes.h in Headers */,
@@ -1176,6 +1201,7 @@
 				CB747D21299E5458003CA1B4 /* TimeTests.mm in Sources */,
 				0122C27129019CEF002D243C /* OtlpTraceEncodingTests.mm in Sources */,
 				09509B752ADFE9A900A358EC /* TracerTests.mm in Sources */,
+				098FC8792D3FADFE001B627D /* SpanAttributesTests.mm in Sources */,
 				962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */,
 				CB747D1F299E4984003CA1B4 /* SpanOptionsTests.mm in Sources */,
 				CB0AD76C296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm in Sources */,
@@ -1216,6 +1242,7 @@
 			files = (
 				CB0AD7682965734F002A3FB6 /* BugsnagPerformanceErrors.m in Sources */,
 				0122C24E29019770002D243C /* OtlpTraceEncoding.mm in Sources */,
+				098FC8472D2EB8E8001B627D /* BSGPSystemInfo.mm in Sources */,
 				0122C24929019770002D243C /* AppStartupInstrumentation.mm in Sources */,
 				0122C24429019770002D243C /* Tracer.mm in Sources */,
 				CB04969829150D860097E526 /* OtlpPackage.mm in Sources */,
@@ -1237,6 +1264,7 @@
 				CB34771E29068C350033759C /* NSURLSession+Instrumentation.mm in Sources */,
 				CBE8EA1B294B5AB800702950 /* Worker.mm in Sources */,
 				CB78819C29E587CE00A58906 /* BugsnagPerformanceLibrary.mm in Sources */,
+				098FC8552D37A08D001B627D /* SystemInfoSampler.mm in Sources */,
 				0122C23C29019770002D243C /* BugsnagPerformanceConfiguration.mm in Sources */,
 				CBEBE59229F2783C00BF0B4F /* Swizzle.mm in Sources */,
 				CBA22C972A0137230066A2C1 /* EarlyConfiguration.mm in Sources */,
@@ -1608,7 +1636,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagPerformance;
 				PRODUCT_NAME = BugsnagPerformance;
@@ -1637,7 +1665,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagPerformance;
 				PRODUCT_NAME = BugsnagPerformance;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Spans can now capture CPU usage data.
+  [377](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/377)
+
 ## 1.11.1 (2025-01-20)
 
 ### Bug fixes

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', '~>9.0'
+gem 'bugsnag-maze-runner', '~>9.22.0'
 gem 'cocoapods'
-gem 'xcpretty'
+gem 'xcpretty', '~>0.3.0'
 
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'integration/v8'
 

--- a/Sources/BugsnagPerformance/Private/BSGPSystemInfo.h
+++ b/Sources/BugsnagPerformance/Private/BSGPSystemInfo.h
@@ -1,0 +1,217 @@
+//
+//  BSGPSystemInfo.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 08.01.25.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <mach/mach.h>
+#import <sys/sysctl.h>
+#import <mutex>
+#import "FixedLengthDequeue.h"
+
+// https://web.mit.edu/darwin/src/modules/xnu/osfmk/man/
+
+namespace bugsnag {
+
+typedef struct {
+    task_vm_info_data_t taskVMInfo;
+    mach_task_basic_info_data_t taskBasicInfo;
+    task_power_info_data_t taskPowerInfo;
+    task_power_info_v2_data_t taskPowerInfoV2;
+    thread_basic_info_data_t threadBasicInfo;
+    thread_extended_info_data_t threadExtendedInfo;
+    task_thread_times_info_data_t taskThreadTimesInfo;
+    struct kinfo_proc kinfoProc;
+} BSGPSystemData;
+
+/**
+ * Interface to get information about the running system.
+ * Any calls that would require local storage will be stored locally in this object.
+ *
+ * WARNING:
+ * Methods that return a pointer to a xyz_data_t will point to data stored locally on this object (see BSGPSystemData).
+ * Therefore, calling the same method again on the same instance will OVERWRITE the pointed-to data!
+ * Save any pointed-to data before calling another method on the same BSGPSystemInfo instance.
+ *
+ * Needless to say, THIS CLASS IS NOT THREAD SAFE.
+ */
+class BSGPSystemInfo {
+public:
+    static constexpr size_t cpuHistogramSize{30};
+public:
+    /**
+     * Get the number of CPUs that are allocated to this process.
+     */
+    NSUInteger activeProcessorCount();
+
+    /**
+     * Get this device's unique model ID (for example, "iPhone12,8")
+     */
+    NSString *deviceModel();
+
+    struct kinfo_proc *kinfoProc();
+
+    // struct task_thread_times_info {
+    //     time_value_t    user_time;      /* total user run time for live threads */
+    //     time_value_t    system_time;    /* total system run time for live threads */ - Disabled on iOS
+    // };
+    task_thread_times_info_data_t *taskTimeInfo();
+
+    // struct task_vm_info {
+    //     mach_vm_size_t  virtual_size;       /* virtual memory size (bytes) */
+    //     integer_t       region_count;       /* number of memory regions */
+    //     integer_t       page_size;
+    //     mach_vm_size_t  resident_size;      /* resident memory size (bytes) */
+    //     mach_vm_size_t  resident_size_peak; /* peak resident size (bytes) */
+    //
+    //     mach_vm_size_t  device; - Disabled on iOS
+    //     mach_vm_size_t  device_peak; - Disabled on iOS
+    //     mach_vm_size_t  internal;
+    //     mach_vm_size_t  internal_peak;
+    //     mach_vm_size_t  external;
+    //     mach_vm_size_t  external_peak; - Disabled on iOS
+    //     mach_vm_size_t  reusable;
+    //     mach_vm_size_t  reusable_peak; - Disabled on iOS
+    //     mach_vm_size_t  purgeable_volatile_pmap; - Disabled on iOS
+    //     mach_vm_size_t  purgeable_volatile_resident; - Disabled on iOS
+    //     mach_vm_size_t  purgeable_volatile_virtual; - Disabled on iOS
+    //     mach_vm_size_t  compressed; - Disabled on iOS
+    //     mach_vm_size_t  compressed_peak; - Disabled on iOS
+    //     mach_vm_size_t  compressed_lifetime; - Disabled on iOS
+    //
+    //     /* added for rev1 */
+    //     mach_vm_size_t  phys_footprint;
+    //
+    //     /* added for rev2 */
+    //     mach_vm_address_t       min_address;
+    //     mach_vm_address_t       max_address;
+    //
+    //     /* added for rev3 */
+    //     int64_t ledger_phys_footprint_peak;
+    //     int64_t ledger_purgeable_nonvolatile;
+    //     int64_t ledger_purgeable_novolatile_compressed; - Disabled on iOS
+    //     int64_t ledger_purgeable_volatile; - Disabled on iOS
+    //     int64_t ledger_purgeable_volatile_compressed; - Disabled on iOS
+    //     int64_t ledger_tag_network_nonvolatile; - Disabled on iOS
+    //     int64_t ledger_tag_network_nonvolatile_compressed; - Disabled on iOS
+    //     int64_t ledger_tag_network_volatile; - Disabled on iOS
+    //     int64_t ledger_tag_network_volatile_compressed; - Disabled on iOS
+    //     int64_t ledger_tag_media_footprint; - Disabled on iOS
+    //     int64_t ledger_tag_media_footprint_compressed; - Disabled on iOS
+    //     int64_t ledger_tag_media_nofootprint; - Disabled on iOS
+    //     int64_t ledger_tag_media_nofootprint_compressed; - Disabled on iOS
+    //     int64_t ledger_tag_graphics_footprint; - Disabled on iOS
+    //     int64_t ledger_tag_graphics_footprint_compressed; - Disabled on iOS
+    //     int64_t ledger_tag_graphics_nofootprint; - Disabled on iOS
+    //     int64_t ledger_tag_graphics_nofootprint_compressed; - Disabled on iOS
+    //     int64_t ledger_tag_neural_footprint; - Disabled on iOS
+    //     int64_t ledger_tag_neural_footprint_compressed; - Disabled on iOS
+    //     int64_t ledger_tag_neural_nofootprint; - Disabled on iOS
+    //     int64_t ledger_tag_neural_nofootprint_compressed; - Disabled on iOS
+    //
+    //     /* added for rev4 */
+    //     uint64_t limit_bytes_remaining;
+    //
+    //     /* added for rev5 */
+    //     integer_t decompressions; - Disabled on iOS
+    //
+    //     /* added for rev6 */
+    //     int64_t ledger_swapins; - Disabled on iOS
+    // };
+    task_vm_info_data_t *taskVMInfo();
+
+    // struct task_power_info {
+    //     uint64_t                total_user;
+    //     uint64_t                total_system; - Disabled on iOS
+    //     uint64_t                task_interrupt_wakeups;
+    //     uint64_t                task_platform_idle_wakeups;
+    //     uint64_t                task_timer_wakeups_bin_1;
+    //     uint64_t                task_timer_wakeups_bin_2;
+    // };
+    //
+    // typedef struct {
+    //     uint64_t                task_gpu_utilisation; - Disabled on iOS
+    //     uint64_t                task_gpu_stat_reserved0;
+    //     uint64_t                task_gpu_stat_reserved1;
+    //     uint64_t                task_gpu_stat_reserved2;
+    // } gpu_energy_data;
+    //
+    // struct task_power_info_v2 {
+    //     task_power_info_data_t  cpu_energy;
+    //     gpu_energy_data gpu_energy;
+    // #if defined(__arm__) || defined(__arm64__)
+    //     uint64_t                task_energy; // in nanojoules
+    // #endif /* defined(__arm__) || defined(__arm64__) */
+    //     uint64_t                task_ptime;
+    //     uint64_t                task_pset_switches;
+    // };
+    task_power_info_v2_data_t *taskPowerInfoV2();
+
+    // struct thread_basic_info {
+    //     time_value_t    user_time;      /* user run time */
+    //     time_value_t    system_time;    /* system run time */ - Disabled on iOS
+    //     integer_t       cpu_usage;      /* scaled cpu usage percentage */ - Disabled on iOS?
+    //     policy_t        policy;         /* scheduling policy in effect */
+    //     integer_t       run_state;      /* run state (see below) */
+    //     integer_t       flags;          /* various flags (see below) */
+    //     integer_t       suspend_count;  /* suspend count for thread */
+    //     integer_t       sleep_time;     /* number of seconds that thread has been sleeping */
+    // };
+    thread_basic_info_data_t *threadBasicInfo(mach_port_t thread);
+
+    // Returned array contains 4 elements per CPU:
+    //     #define CPU_STATE_USER          0
+    //     #define CPU_STATE_SYSTEM        1
+    //     #define CPU_STATE_IDLE          2
+    //     #define CPU_STATE_NICE          3
+    //
+    // Only USER and IDLE are populated on iOS.
+    processor_info_array_t cpuLoadInfo(int *out_elementCount);
+
+    // Returned array contains one thread ID per element.
+    thread_act_array_t allThreads(int *out_elementCount);
+
+    // UIDeviceBatteryStateUnknown,
+    // UIDeviceBatteryStateUnplugged,   // on battery, discharging
+    // UIDeviceBatteryStateCharging,    // plugged in, less than 100%
+    // UIDeviceBatteryStateFull,        // plugged in, at 100%
+    UIDeviceBatteryState batteryState();
+
+    // 0 .. 1.0. -1.0 if UIDeviceBatteryStateUnknown
+    float batteryLevel();
+
+    unsigned long long physicalMemoryBytes();
+
+    double calcCPUUsagePct(CFAbsoluteTime lastSampledAtSec,
+                           uint64_t *lastTimeValueUSInOut,
+                           CFAbsoluteTime nowSampledAtSec,
+                           time_value_t nowTimeValue);
+
+private:
+    void deallocAllThreads();
+    void deallocCPUInfo();
+
+private:
+    BSGPSystemData data_; // Don't need to initialize
+    processor_info_array_t cpuInfo_{0};
+    mach_msg_type_number_t cpuInfoCount_{0};
+    thread_act_array_t allThreads_{0};
+    mach_msg_type_number_t allThreadsCount_{0};
+    NSString *deviceModel_{nil};
+    uint64_t lastProcessCPUTimeUS_{0};
+    CFAbsoluteTime lastProcessCPUSampledAtSec_{0};
+    uint64_t lastThisThreadCPUTimeUS_{0};
+    CFAbsoluteTime lastThisThreadCPUSampledAtSec_{0};
+    CFAbsoluteTime lastCPUSampledAtSec_{0};
+
+public:
+    ~BSGPSystemInfo() {
+        deallocAllThreads();
+    }
+};
+
+}
+

--- a/Sources/BugsnagPerformance/Private/BSGPSystemInfo.mm
+++ b/Sources/BugsnagPerformance/Private/BSGPSystemInfo.mm
@@ -1,0 +1,145 @@
+//
+//  BSGPSystemInfo.mm
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 08.01.25.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import "BSGPSystemInfo.h"
+#import <sys/utsname.h>
+#import "Utils.h"
+
+using namespace bugsnag;
+
+struct kinfo_proc *BSGPSystemInfo::kinfoProc() {
+    size_t len = 4;
+    int mib[len];
+    sysctlnametomib("kern.proc.pid", mib, &len);
+    mib[3] = getpid();
+    len = sizeof(data_.kinfoProc);
+    sysctl(mib, 4, &data_.kinfoProc, &len, NULL, 0);
+    return &data_.kinfoProc;
+}
+
+task_thread_times_info_data_t *BSGPSystemInfo::taskTimeInfo() {
+    mach_msg_type_number_t count = TASK_THREAD_TIMES_INFO_COUNT;
+    auto status = task_info(mach_task_self(), TASK_THREAD_TIMES_INFO, (task_info_t)&data_.taskThreadTimesInfo, &count);
+    if (status != KERN_SUCCESS) {
+        BSGLogDebug(@"task_info(TASK_THREAD_TIMES_INFO) failed. Status = %d", status);
+        return nullptr;
+    }
+    return &data_.taskThreadTimesInfo;
+}
+
+task_vm_info_data_t *BSGPSystemInfo::taskVMInfo() {
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    auto status = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&data_.taskVMInfo, &count);
+    if (status != KERN_SUCCESS) {
+        BSGLogDebug(@"task_info(TASK_VM_INFO) failed. Status = %d", status);
+        return nullptr;
+    }
+    return &data_.taskVMInfo;
+}
+
+task_power_info_v2_data_t *BSGPSystemInfo::taskPowerInfoV2() {
+    mach_msg_type_number_t count = TASK_POWER_INFO_V2_COUNT;
+    auto status = task_info(mach_task_self(), TASK_POWER_INFO_V2, (task_info_t)&data_.taskPowerInfoV2, &count);
+    if (status != KERN_SUCCESS) {
+        BSGLogDebug(@"task_info(TASK_POWER_INFO_V2) failed. Status = %d", status);
+        return nullptr;
+    }
+    return &data_.taskPowerInfoV2;
+}
+
+thread_basic_info_data_t *BSGPSystemInfo::threadBasicInfo(mach_port_t thread) {
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    auto status = thread_info(thread, THREAD_BASIC_INFO, (thread_info_t)&data_.threadBasicInfo, &count);
+    if (status != KERN_SUCCESS) {
+        BSGLogDebug(@"thread_info(THREAD_BASIC_INFO) on thread %d failed. Status = %d", thread, status);
+        return nullptr;
+    }
+    return &data_.threadBasicInfo;
+}
+
+processor_info_array_t BSGPSystemInfo::cpuLoadInfo(int *elementCount) {
+    deallocCPUInfo();
+    natural_t cpuCount = 0;
+    auto status = host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &cpuCount, &cpuInfo_, &cpuInfoCount_);
+    if(status != KERN_SUCCESS) {
+        BSGLogDebug(@"host_processor_info(PROCESSOR_CPU_LOAD_INFO) failed. Status = %d", status);
+        cpuInfo_ = nullptr;
+        cpuInfoCount_ = 0;
+    }
+    *elementCount = (int)cpuInfoCount_;
+    return cpuInfo_;
+}
+
+thread_act_array_t BSGPSystemInfo::allThreads(int *elementCount) {
+    deallocAllThreads();
+    auto status = task_threads(mach_task_self(), &allThreads_, &allThreadsCount_);
+    if (status != KERN_SUCCESS) {
+        BSGLogDebug(@"task_threads() failed. Status = %d", status);
+        deallocAllThreads();
+    }
+    *elementCount = (int)allThreadsCount_;
+    return allThreads_;
+}
+
+void BSGPSystemInfo::deallocAllThreads() {
+    if (allThreads_ != nullptr) {
+        vm_deallocate(mach_task_self(), (vm_address_t)allThreads_, sizeof(allThreads_[0]) * allThreadsCount_);
+        allThreadsCount_ = 0;
+        allThreads_ = nullptr;
+    }
+}
+
+void BSGPSystemInfo::deallocCPUInfo() {
+    if (cpuInfo_ != nullptr) {
+        vm_deallocate(mach_task_self(), (vm_address_t)cpuInfo_, sizeof(cpuInfo_[0]) * cpuInfoCount_);
+        cpuInfo_ = nullptr;
+        cpuInfoCount_ = 0;
+    }
+}
+
+NSString *BSGPSystemInfo::deviceModel() {
+    if (deviceModel_ == nil) {
+        struct utsname systemInfo;
+        uname(&systemInfo);
+        deviceModel_ = [NSString stringWithUTF8String:systemInfo.machine];
+    }
+    return deviceModel_;
+}
+
+float BSGPSystemInfo::batteryLevel() {
+    UIDevice *dev = UIDevice.currentDevice;
+    dev.batteryMonitoringEnabled = YES;
+    return dev.batteryLevel;
+}
+
+UIDeviceBatteryState BSGPSystemInfo::batteryState() {
+    UIDevice *dev = UIDevice.currentDevice;
+    dev.batteryMonitoringEnabled = YES;
+    return dev.batteryState;
+}
+
+unsigned long long BSGPSystemInfo::physicalMemoryBytes() {
+    return NSProcessInfo.processInfo.physicalMemory;
+}
+
+NSUInteger BSGPSystemInfo::activeProcessorCount() {
+    return NSProcessInfo.processInfo.activeProcessorCount;
+}
+
+double BSGPSystemInfo::calcCPUUsagePct(CFAbsoluteTime lastSampledAtSec,
+                                       uint64_t *lastTimeValueUSInOut,
+                                       CFAbsoluteTime nowSampledAtSec,
+                                       time_value_t nowTimeValue) {
+    uint64_t lastTimeValueUS = *lastTimeValueUSInOut;
+    uint64_t nowTimeValueUS = (uint64_t)(nowTimeValue.seconds * TIME_MICROS_MAX + nowTimeValue.microseconds);
+    *lastTimeValueUSInOut = nowTimeValueUS;
+
+    double diffCPUTimeSec = (double)(nowTimeValueUS - lastTimeValueUS) / TIME_MICROS_MAX;
+    CFAbsoluteTime diffClockSec = nowSampledAtSec - lastSampledAtSec;
+    return (double)diffCPUTimeSec / diffClockSec * 100;
+}

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
@@ -83,7 +83,7 @@ using namespace bugsnag;
     }
 
     auto options = SpanOptions(optionsIn);
-    auto span = tracer->startSpan(name, options, BSGFirstClassUnset);
+    auto span = tracer->startSpan(name, options, BSGTriStateUnset);
     return (BugsnagPerformanceSpan *)[BugsnagPerformanceCrossTalkProxiedObject proxied:span];
 }
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -27,10 +27,12 @@
 #import "NetworkHeaderInjector.h"
 #import "OtlpTraceEncoding.h"
 #import "FrameRateMetrics/FrameMetricsCollector.h"
+#import "SystemInfoSampler.h"
 
 #import <mutex>
 
 namespace bugsnag {
+
 class BugsnagPerformanceImpl: public PhasedStartup {
 public:
     BugsnagPerformanceImpl(std::shared_ptr<Reachability> reachability,
@@ -112,6 +114,9 @@ private:
     bool sendRetriesTask() noexcept;
     bool sweepTracerTask() noexcept;
 
+    // Periodic Measurements
+    SystemInfoSampler systemInfoSampler_;
+
     // Event reactions
     void onBatchFull() noexcept;
     void onConnectivityChanged(Reachability::Connectivity connectivity) noexcept;
@@ -130,6 +135,7 @@ private:
     void possiblyMakeSpanCurrent(BugsnagPerformanceSpan *span, SpanOptions &options);
     NSMutableArray<BugsnagPerformanceSpan *> *
       sendableSpans(NSMutableArray<BugsnagPerformanceSpan *> *spans) noexcept;
+    bool shouldSampleCPU(BugsnagPerformanceSpan *span) noexcept;
 
 public: // For testing
     void testing_setProbability(double probability) { onProbabilityChanged(probability); };

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -16,14 +16,18 @@
 #import "BugsnagPerformanceCrossTalkAPI.h"
 #import "Utils.h"
 #import "FrameRateMetrics/FrameMetricsCollector.h"
+#import "BugsnagPerformanceSpan+Private.h"
 
 using namespace bugsnag;
 
+static constexpr double SAMPLER_INTERVAL_SECONDS = 1.0;
+static constexpr double SAMPLER_HISTORY_SECONDS = 10 * 60;
+
 // App start spans will be thrown out if the early app start duration exceeds this.
-static CFTimeInterval maxAppStartDuration = 2.0;
+static constexpr CFTimeInterval maxAppStartDuration = 2.0;
 
 // App start spans will be thrown out if the app gets backgrounded within this timeframe after starting.
-static CFTimeInterval minTimeToBackgrounding = 2.0;
+static constexpr CFTimeInterval minTimeToBackgrounding = 2.0;
 
 
 static NSString *getPersistenceDir() {
@@ -53,6 +57,7 @@ BugsnagPerformanceImpl::BugsnagPerformanceImpl(std::shared_ptr<Reachability> rea
 , worker_([[Worker alloc] initWithInitialTasks:buildInitialTasks() recurringTasks:buildRecurringTasks()])
 , deviceID_(std::make_shared<PersistentDeviceID>(persistence_))
 , resourceAttributes_(std::make_shared<ResourceAttributes>(deviceID_))
+, systemInfoSampler_(SAMPLER_INTERVAL_SECONDS, SAMPLER_HISTORY_SECONDS)
 , networkRequestCallback_(
     ^BugsnagPerformanceNetworkRequestInfo * _Nonnull(BugsnagPerformanceNetworkRequestInfo * _Nonnull info) {
         return info;
@@ -66,6 +71,8 @@ BugsnagPerformanceImpl::~BugsnagPerformanceImpl() {
 
 void BugsnagPerformanceImpl::earlyConfigure(BSGEarlyConfiguration *config) noexcept {
     BSGLogDebug(@"BugsnagPerformanceImpl::earlyConfigure()");
+    // Do systemInfoSampler first so that any early spans will always have a bounding sample
+    systemInfoSampler_.earlyConfigure(config);
     persistentState_->earlyConfigure(config);
     traceEncoding_.earlyConfigure(config);
     tracer_->earlyConfigure(config);
@@ -96,6 +103,7 @@ void BugsnagPerformanceImpl::earlyConfigure(BSGEarlyConfiguration *config) noexc
 
 void BugsnagPerformanceImpl::earlySetup() noexcept {
     BSGLogDebug(@"BugsnagPerformanceImpl::earlySetup()");
+    systemInfoSampler_.earlySetup();
     persistentState_->earlySetup();
     traceEncoding_.earlySetup();
     tracer_->earlySetup();
@@ -124,6 +132,7 @@ void BugsnagPerformanceImpl::configure(BugsnagPerformanceConfiguration *config) 
     }
 
     configuration_ = config;
+    systemInfoSampler_.configure(config);
     persistentState_->configure(config);
     traceEncoding_.configure(config);
     deviceID_->configure(config);
@@ -140,6 +149,7 @@ void BugsnagPerformanceImpl::configure(BugsnagPerformanceConfiguration *config) 
 
 void BugsnagPerformanceImpl::preStartSetup() noexcept {
     BSGLogDebug(@"BugsnagPerformanceImpl::preStartSetup()");
+    systemInfoSampler_.preStartSetup();
     persistentState_->preStartSetup();
     traceEncoding_.preStartSetup();
     tracer_->preStartSetup();
@@ -213,6 +223,8 @@ void BugsnagPerformanceImpl::start() noexcept {
     resourceAttributes_->start();
     networkHeaderInjector_->start();
 
+    systemInfoSampler_.start();
+
     [worker_ start];
     [frameMetricsCollector_ start];
 
@@ -273,6 +285,13 @@ BugsnagPerformanceImpl::sendableSpans(NSMutableArray<BugsnagPerformanceSpan *> *
     return sendableSpans;
 }
 
+bool BugsnagPerformanceImpl::shouldSampleCPU(BugsnagPerformanceSpan *span) noexcept {
+    if (span.metricsOptions.cpu == BSGTriStateUnset) {
+        return span.firstClass == BSGTriStateYes;
+    }
+    return span.metricsOptions.cpu == BSGTriStateYes;
+}
+
 bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
     BSGLogDebug(@"BugsnagPerformanceImpl::sendCurrentBatchTask()");
     auto origSpans = batch_->drain(false);
@@ -289,10 +308,29 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
     }
     bool includeSamplingHeader = configuration_ == nil || configuration_.samplingProbability == nil;
 
+    // Delay so that the sampler has time to fetch one more sample.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((SAMPLER_INTERVAL_SECONDS + 0.5) * NSEC_PER_SEC)),
+                   dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0), ^{
+        BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): Delayed %f seconds, now getting system info", SAMPLER_INTERVAL_SECONDS + 0.5);
+        for(BugsnagPerformanceSpan *span: spans) {
+            auto samples = systemInfoSampler_.samplesAroundTimePeriod(span.actuallyStartedAt, span.actuallyEndedAt);
+            BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): System info sample size = %zu", samples.size());
+            if (samples.size() >= 2) {
+                if (shouldSampleCPU(span)) {
+                    BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): Getting CPU sample attributes for span %@", span.name);
+                    [span forceMutate:^() {
+                        [span internalSetMultipleAttributes:spanAttributesProvider_->cpuSampleAttributes(samples)];
+                    }];
+                }
+            }
+        }
+
 #ifndef __clang_analyzer__
-    BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): Sending %zu sampled spans (out of %zu)", origSpansSize, spans.count);
+        BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): Sending %zu sampled spans (out of %zu)", origSpansSize, spans.count);
 #endif
-    uploadPackage(traceEncoding_.buildUploadPackage(spans, resourceAttributes_->get(), includeSamplingHeader), false);
+        uploadPackage(traceEncoding_.buildUploadPackage(spans, resourceAttributes_->get(), includeSamplingHeader), false);
+    });
+
     return true;
 }
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -11,6 +11,7 @@
 #import "BugsnagPerformanceSpanContext+Private.h"
 #import "SpanKind.h"
 #import "FrameRateMetrics/FrameMetricsSnapshot.h"
+#import "SpanOptions.h"
 
 #import <memory>
 
@@ -35,6 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, copy) void (^onDumped)(BugsnagPerformanceSpan *);
 
+// These mark the actual times that the span was instantiated and ended,
+// irrespective of any time values this span will report.
+// We need this because we're recording metrics data in spans instead of metrics.
+@property (nonatomic) CFAbsoluteTime actuallyStartedAt;
+@property (nonatomic) CFAbsoluteTime actuallyEndedAt;
+
 @property (nonatomic) CFAbsoluteTime startAbsTime;
 @property (nonatomic) CFAbsoluteTime endAbsTime;
 @property (nonatomic) OnSpanDestroyAction onSpanDestroyAction;
@@ -44,13 +51,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) SpanLifecycleCallback onSpanClosed;
 @property (nonatomic,readwrite) SpanId parentId;
 @property (nonatomic) double samplingProbability;
-@property (nonatomic) BSGFirstClass firstClass;
+@property (nonatomic) BSGTriState firstClass;
 @property (nonatomic) SpanKind kind;
 @property (nonatomic,readwrite) BOOL isMutable;
 @property (nonatomic,readwrite) BOOL hasBeenProcessed;
 @property (nonatomic,readonly) NSUInteger attributeCountLimit;
 @property (nonatomic,readwrite) BOOL wasStartOrEndTimeProvided;
-@property (nonatomic) BSGInstrumentRendering instrumentRendering;
+@property (nonatomic) MetricsOptions metricsOptions;
 @property (nonatomic, strong) FrameMetricsSnapshot *startFramerateSnapshot;
 @property (nonatomic, strong) FrameMetricsSnapshot *endFramerateSnapshot;
 
@@ -65,9 +72,9 @@ NS_ASSUME_NONNULL_BEGIN
                       spanId:(SpanId) spanId
                     parentId:(SpanId) parentId
                    startTime:(CFAbsoluteTime) startTime
-                  firstClass:(BSGFirstClass) firstClass
+                  firstClass:(BSGTriState) firstClass
          attributeCountLimit:(NSUInteger)attributeCountLimit
-         instrumentRendering:(BSGInstrumentRendering)instrumentRendering
+              metricsOptions:(MetricsOptions) metricsOptions
                 onSpanEndSet:(SpanLifecycleCallback) onSpanEndSet
                 onSpanClosed:(SpanLifecycleCallback) onSpanEnded NS_DESIGNATED_INITIALIZER;
 
@@ -86,6 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateName:(NSString *)name;
 - (void)updateStartTime:(NSDate *)startTime;
 - (void)updateSamplingProbability:(double) value;
+
+- (void)forceMutate:(void (^)())block;
 
 @end
 

--- a/Sources/BugsnagPerformance/Private/FixedLengthDequeue.h
+++ b/Sources/BugsnagPerformance/Private/FixedLengthDequeue.h
@@ -1,0 +1,56 @@
+//
+//  FixedLengthQueue.hpp
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 13.01.25.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#include <deque>
+
+namespace bugsnag {
+
+/**
+ * Deque of fixed length that auto-pops the entry at the other end if the length is already at the maximum.
+ */
+template<class T, class Allocator = std::allocator<T>>
+class FixedLengthDequeue: public std::deque<T, Allocator> {
+public:
+    FixedLengthDequeue(size_t maxSize)
+    : std::deque<T, Allocator>()
+    , maxSize_(maxSize)
+    {}
+    void push_back( const T& value ) {
+        std::deque<T>::push_back(value);
+        popFrontIfOversized();
+    }
+    void push_back( const T&& value ) {
+        std::deque<T>::push_back(value);
+        popFrontIfOversized();
+    }
+    void push_front( const T& value ) {
+        std::deque<T>::push_front(value);
+        popBackIfOversized();
+    }
+    void push_front( const T&& value ) {
+        std::deque<T>::push_front(value);
+        popBackIfOversized();
+    }
+
+private:
+    void popFrontIfOversized() {
+        if(this->size() > maxSize_) {
+            this->pop_front();
+        }
+    }
+    void popBackIfOversized() {
+        if(this->size() > maxSize_) {
+            this->pop_back();
+        }
+    }
+    size_t maxSize_;
+};
+
+}

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
@@ -80,7 +80,7 @@ static const CGFloat kSlowFrameRatioThreshold = 1.3;
 - (void)earlySetup {}
 
 - (void)configure:(BugsnagPerformanceConfiguration *)config {
-    self.autoInstrumentRendering = config.autoInstrumentRendering;
+    self.autoInstrumentRendering = config.enabledMetrics.rendering;
 }
 
 - (void)start {

--- a/Sources/BugsnagPerformance/Private/Metrics.h
+++ b/Sources/BugsnagPerformance/Private/Metrics.h
@@ -1,0 +1,28 @@
+//
+//  Metrics.h
+//  BugsnagPerformance
+//
+//  Created by Karl Stenerud on 20.01.25.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
+
+namespace bugsnag {
+
+class MetricsOptions {
+public:
+    MetricsOptions() {}
+
+    MetricsOptions(BugsnagPerformanceSpanMetricsOptions *metrics)
+    : rendering(metrics.rendering)
+    , cpu(metrics.cpu)
+    {}
+
+    BSGTriState rendering{BSGTriStateUnset};
+    BSGTriState cpu{BSGTriStateUnset};
+};
+
+};

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -7,6 +7,7 @@
 //
 #import <Foundation/Foundation.h>
 #import "BugsnagPerformanceViewType+Private.h"
+#import "SystemInfoSampler.h"
 
 namespace bugsnag {
 class SpanAttributesProvider {
@@ -23,6 +24,8 @@ public:
     NSMutableDictionary *preloadedViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
     NSMutableDictionary *viewLoadPhaseSpanAttributes(NSString *className, NSString *phase) noexcept;
     NSMutableDictionary *customSpanAttributes() noexcept;
+
+    NSMutableDictionary *cpuSampleAttributes(const std::vector<SystemInfoSampleData> &samples) noexcept;
 
     static NSString *httpUrlAttributeKey();
 };

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -9,6 +9,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 #import "Utils.h"
+#import "Metrics.h"
 
 namespace bugsnag {
 
@@ -17,13 +18,13 @@ public:
     SpanOptions(BugsnagPerformanceSpanContext *parentContext,
                 CFAbsoluteTime startTime,
                 bool makeCurrentContext,
-                BSGFirstClass firstClass,
-                BSGInstrumentRendering instrumentRendering)
+                BSGTriState firstClass,
+                MetricsOptions metricsOptions)
     : parentContext(parentContext)
     , startTime(startTime)
     , makeCurrentContext(makeCurrentContext)
     , firstClass(firstClass)
-    , instrumentRendering(instrumentRendering)
+    , metricsOptions(metricsOptions)
     {}
     
     SpanOptions(BugsnagPerformanceSpanOptions *options)
@@ -31,7 +32,7 @@ public:
                   dateToAbsoluteTime(options.startTime),
                   options.makeCurrentContext,
                   options.firstClass,
-                  options.instrumentRendering)
+                  options.metricsOptions)
     {}
     
     SpanOptions()
@@ -39,15 +40,15 @@ public:
     : SpanOptions(nil,
                   CFABSOLUTETIME_INVALID,
                   true,
-                  BSGFirstClassUnset,
-                  BSGInstrumentRenderingUnset)
+                  BSGTriStateUnset,
+                  MetricsOptions())
     {}
     
     BugsnagPerformanceSpanContext *parentContext{nil};
     CFAbsoluteTime startTime{CFABSOLUTETIME_INVALID};
     bool makeCurrentContext{false};
-    BSGFirstClass firstClass{BSGFirstClassUnset};
-    BSGInstrumentRendering instrumentRendering{BSGInstrumentRenderingUnset};
+    BSGTriState firstClass{BSGTriStateUnset};
+    MetricsOptions metricsOptions;
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/SystemInfoSampler.h
+++ b/Sources/BugsnagPerformance/Private/SystemInfoSampler.h
@@ -1,0 +1,109 @@
+//
+//  SystemInfoSampler.h
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 15.01.25.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <vector>
+#import <mutex>
+#import "BSGPSystemInfo.h"
+#import "FixedLengthDequeue.h"
+#import "PhasedStartup.h"
+
+namespace bugsnag {
+
+struct SystemInfoSampleData {
+    SystemInfoSampleData() {}
+    SystemInfoSampleData(CFAbsoluteTime sampledAtTime)
+    : sampledAt(sampledAtTime)
+    {}
+
+    CFAbsoluteTime sampledAt{-1};
+    double processCPUPct{-1};
+    double mainThreadCPUPct{-1};
+    double monitorThreadCPUPct{-1};
+
+    bool isSampledAtValid()           const { return sampledAt > 0; }
+    bool isProcessCPUPctValid()       const { return processCPUPct >= 0; }
+    bool isMainThreadCPUPctValid()    const { return mainThreadCPUPct >= 0; }
+    bool isMonitorThreadCPUPctValid() const { return monitorThreadCPUPct >= 0; }
+
+    bool hasValidCPUData() const {
+        return isProcessCPUPctValid() ||
+        isMainThreadCPUPctValid() ||
+        isMonitorThreadCPUPctValid();
+    }
+
+    bool hasValidData() {
+        if (!isSampledAtValid()) {
+            return false;
+        }
+        return hasValidCPUData();
+    }
+
+    static struct {
+        bool operator() (const SystemInfoSampleData &left, const CFAbsoluteTime &right) const {
+            return left.sampledAt < right;
+        }
+    } CompareSampledAtLower;
+    static struct {
+        bool operator() (const CFAbsoluteTime &left, const SystemInfoSampleData &right) const {
+            return left < right.sampledAt;
+        }
+    } CompareSampledAtUpper;
+};
+
+class SystemInfoSampler: public PhasedStartup {
+public:
+    SystemInfoSampler(NSTimeInterval samplePeriod, NSTimeInterval historyDuration)
+    : samplePeriod_(samplePeriod)
+    , samples_((size_t)(historyDuration*2.0/samplePeriod)) // Collect double what we'll be using
+    {}
+    virtual ~SystemInfoSampler() {}
+
+    // Phased Startup
+    virtual void earlyConfigure(BSGEarlyConfiguration *) noexcept;
+    virtual void earlySetup() noexcept;
+    virtual void configure(BugsnagPerformanceConfiguration *config) noexcept;
+    virtual void preStartSetup() noexcept {};
+    virtual void start() noexcept {};
+
+    /**
+     * Collect any sampled data around the time range specified (1 sample prior to the start, and 1 sample after the end).
+     */
+    std::vector<SystemInfoSampleData> samplesAroundTimePeriod(CFAbsoluteTime startTime, CFAbsoluteTime endTime);
+
+private:
+    CFAbsoluteTime calculateAppStartTime();
+    void recordSample();
+
+private:
+    std::mutex mutex_;
+    BSGPSystemInfo systemInfo_;
+    FixedLengthDequeue<SystemInfoSampleData> samples_;
+
+    // Set in constructor
+    NSTimeInterval samplePeriod_;
+
+    // These require "zeroed" defaults
+    mach_port_t mainThread_{0};
+    NSThread *samplerThread_{nil};
+    bool shouldAbortSamplerThread_{false};
+
+    // These start off enabled until disabled via config
+    bool shouldSampleCPU_{true};
+
+    // Cached sampling checkpoints
+    CFAbsoluteTime lastSampledAtTime_{0};
+    time_value_t lastSampleProcessCPU_{0};
+    time_value_t lastSampleMainThreadCPU_{0};
+    time_value_t lastSampleMonitorThreadCPU_{0};
+};
+
+}

--- a/Sources/BugsnagPerformance/Private/SystemInfoSampler.mm
+++ b/Sources/BugsnagPerformance/Private/SystemInfoSampler.mm
@@ -1,0 +1,148 @@
+//
+//  SystemInfoSampler.mm
+//  BugsnagPerformance-iOS
+//
+//  Created by Karl Stenerud on 15.01.25.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import "SystemInfoSampler.h"
+#import <algorithm>
+#import "Utils.h"
+
+using namespace bugsnag;
+
+static inline NSTimeInterval timeValToTimeInterval(time_value_t value) {
+    return (NSTimeInterval)value.seconds + ((NSTimeInterval)value.microseconds / TIME_MICROS_MAX);
+}
+
+CFAbsoluteTime SystemInfoSampler::calculateAppStartTime() {
+    auto kinfoProc = systemInfo_.kinfoProc();
+    struct timeval startTime = kinfoProc->kp_proc.p_un.__p_starttime;
+    struct timeval nowTime;
+    gettimeofday(&nowTime, NULL);
+
+    int64_t diff = ((int64_t)nowTime.tv_sec * (int64_t)USEC_PER_SEC) + (int64_t)nowTime.tv_usec;
+    diff -= ((int64_t)startTime.tv_sec * (int64_t)USEC_PER_SEC) + (int64_t)startTime.tv_usec;
+
+    return CFAbsoluteTimeGetCurrent() - (double)diff / USEC_PER_SEC;
+}
+
+void SystemInfoSampler::earlyConfigure(BSGEarlyConfiguration *) noexcept {
+    // Get our first sample as early as possible.
+    // This sample will be relative to the app start.
+    lastSampledAtTime_ = calculateAppStartTime();
+    recordSample();
+}
+
+void SystemInfoSampler::earlySetup() noexcept {
+    // Assume for now that the user wants to record samples.
+    mainThread_ = mach_thread_self();
+    samplerThread_ = [[NSThread alloc] initWithBlock:^{
+
+        for (;;) {
+            [NSThread sleepForTimeInterval:samplePeriod_];
+            if (shouldAbortSamplerThread_) {
+                // It turns out that the user didn't want to record samples.
+                break;
+            }
+            recordSample();
+        }
+
+        // We've aborted because config.enabledMetrics.cpu was false.
+        // Clear everything and leave this thread.
+        samples_.clear();
+    }];
+
+    [samplerThread_ start];
+}
+
+void SystemInfoSampler::configure(BugsnagPerformanceConfiguration *config) noexcept {
+    shouldSampleCPU_ = config.enabledMetrics.cpu;
+    if (!shouldSampleCPU_) {
+        shouldAbortSamplerThread_ = true;
+    }
+}
+
+static double calcCPUUsagePct(CFAbsoluteTime earlierSampledAtTime,
+                              time_value_t earlierTimeValue,
+                              CFAbsoluteTime currentSampledAtTime,
+                              time_value_t currentTimeValue) {
+    auto diffClockSec = currentSampledAtTime - earlierSampledAtTime;
+    if (diffClockSec <= 0) {
+        BSGLogDebug(@"calcCPUUsagePct(): Clock %f - %f = %f, so returning 0", currentSampledAtTime, earlierSampledAtTime, diffClockSec);
+        return 0;
+    }
+    auto diffCPUTimeSec = timeValToTimeInterval(currentTimeValue) - timeValToTimeInterval(earlierTimeValue);
+    BSGLogTrace(@"calcCPUUsagePct(): CPU %f - %f = %f, so returning %f / %f * 100 = %f",
+                timeValToTimeInterval(currentTimeValue), timeValToTimeInterval(earlierTimeValue), diffCPUTimeSec,
+                diffCPUTimeSec, diffClockSec, diffCPUTimeSec / diffClockSec * 100);
+    return diffCPUTimeSec / diffClockSec * 100;
+}
+
+void SystemInfoSampler::recordSample() {
+    SystemInfoSampleData sample(CFAbsoluteTimeGetCurrent());
+
+    if (shouldSampleCPU_) {
+        auto taskInfo = systemInfo_.taskTimeInfo();
+        if (taskInfo != nullptr) {
+            sample.processCPUPct = calcCPUUsagePct(lastSampledAtTime_,
+                                                   lastSampleProcessCPU_,
+                                                   sample.sampledAt,
+                                                   taskInfo->user_time);
+            lastSampleProcessCPU_ = taskInfo->user_time;
+            BSGLogTrace(@"taskInfo: %d.%d = %f", taskInfo->user_time.seconds, taskInfo->user_time.microseconds, sample.processCPUPct);
+        }
+
+        auto mainThreadInfo = systemInfo_.threadBasicInfo(mainThread_);
+        if (mainThreadInfo != nullptr) {
+            sample.mainThreadCPUPct = calcCPUUsagePct(lastSampledAtTime_,
+                                                      lastSampleMainThreadCPU_,
+                                                      sample.sampledAt,
+                                                      mainThreadInfo->user_time);
+            lastSampleMainThreadCPU_ = mainThreadInfo->user_time;
+            BSGLogTrace(@"mainThreadInfo: %d.%d = %f", mainThreadInfo->user_time.seconds, mainThreadInfo->user_time.microseconds, sample.mainThreadCPUPct);
+        }
+
+        // First call to captureSample() will be from the main thread because the monitor thread
+        // won't exist yet
+        auto thread_self = mach_thread_self();
+        if (thread_self != mainThread_) {
+            auto monitorThreadInfo = systemInfo_.threadBasicInfo(thread_self);
+            if (monitorThreadInfo != nullptr) {
+                sample.monitorThreadCPUPct = calcCPUUsagePct(lastSampledAtTime_,
+                                                             lastSampleMonitorThreadCPU_,
+                                                             sample.sampledAt,
+                                                             monitorThreadInfo->user_time);
+                lastSampleMonitorThreadCPU_ = monitorThreadInfo->user_time;
+                BSGLogTrace(@"monitorThreadInfo: %d.%d = %f", monitorThreadInfo->user_time.seconds, monitorThreadInfo->user_time.microseconds, sample.monitorThreadCPUPct);
+            }
+        }
+    }
+
+    lastSampledAtTime_ = sample.sampledAt;
+
+    if (sample.hasValidData()) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        samples_.push_back(sample);
+    }
+}
+
+std::vector<SystemInfoSampleData> SystemInfoSampler::samplesAroundTimePeriod(CFAbsoluteTime startTime, CFAbsoluteTime endTime) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (samples_.empty()) {
+        BSGLogTrace(@"SystemInfoSampler::samplesAroundTimePeriod(): No samples available");
+        return std::vector<SystemInfoSampleData>();
+    }
+
+    auto lower = std::lower_bound(samples_.begin(), samples_.end(), startTime, SystemInfoSampleData::CompareSampledAtLower);
+    auto upper = std::upper_bound(samples_.begin(), samples_.end(), endTime, SystemInfoSampleData::CompareSampledAtUpper);
+
+    auto lowerMinus1 = lower == samples_.begin() || lower == samples_.end() ? samples_.begin() : lower - 1;
+    auto upperPlus1 = upper == samples_.end() ? samples_.end() : upper + 1;
+
+    std::vector<SystemInfoSampleData> result;
+    result.insert(result.begin(), lowerMinus1, upperPlus1);
+    BSGLogTrace(@"SystemInfoSampler::samplesAroundTimePeriod(): Found %zu samples around times %f and %f", result.size(), startTime, endTime);
+    return result;
+}

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -17,6 +17,7 @@
 #import "SpanStackingHandler.h"
 #import "WeakSpansList.h"
 #import "FrameRateMetrics/FrameMetricsCollector.h"
+#import "BSGPSystemInfo.h"
 
 #import <memory>
 
@@ -40,7 +41,7 @@ public:
     void configure(BugsnagPerformanceConfiguration *config) noexcept {
         onSpanEndCallbacks_ = config.onSpanEndCallbacks;
         attributeCountLimit_ = config.attributeCountLimit;
-        autoInstrumentRendering_ = config.autoInstrumentRendering;
+        enabledMetrics_ = [config.enabledMetrics clone];
     };
     void preStartSetup() noexcept;
     void start() noexcept {}
@@ -49,8 +50,8 @@ public:
         onViewLoadSpanStarted_ = onViewLoadSpanStarted;
     }
 
-    BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
-    
+    BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGTriState defaultFirstClass) noexcept;
+
     BugsnagPerformanceSpan *startAppStartSpan(NSString *name, SpanOptions options) noexcept;
 
     BugsnagPerformanceSpan *startCustomSpan(NSString *name, SpanOptions options) noexcept;
@@ -83,7 +84,7 @@ private:
     FrameMetricsCollector *frameMetricsCollector_;
 
     std::atomic<bool> willDiscardPrewarmSpans_{false};
-    std::atomic<bool> autoInstrumentRendering_{false};
+    BugsnagPerformanceEnabledMetrics *enabledMetrics_{nil};
     std::mutex prewarmSpansMutex_;
     NSMutableArray<BugsnagPerformanceSpan *> *prewarmSpans_;
     NSArray<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks_;

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -14,6 +14,7 @@
 #import "Instrumentation/ViewLoadInstrumentation.h"
 #import "BugsnagPerformanceLibrary.h"
 #import "FrameRateMetrics/FrameMetricsCollector.h"
+#import <algorithm>
 
 using namespace bugsnag;
 
@@ -59,10 +60,10 @@ void Tracer::reprocessEarlySpans(void) {
             [span abortUnconditionally];
             continue;
         }
-        span.isMutable = true;
-        [span updateSamplingProbability:sampler_->getProbability()];
-        callOnSpanEndCallbacks(span);
-        span.isMutable = false;
+        [span forceMutate:^() {
+            [span updateSamplingProbability:sampler_->getProbability()];
+            callOnSpanEndCallbacks(span);
+        }];
         if (span.state == SpanStateAborted) {
             BSGLogDebug(@"Tracer::reprocessEarlySpans: span %@ was rejected in the OnEnd callbacks, so dropping", span.name);
             [span abortUnconditionally];
@@ -89,7 +90,7 @@ Tracer::sweep() noexcept {
 }
 
 BugsnagPerformanceSpan *
-Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept {
+Tracer::startSpan(NSString *name, SpanOptions options, BSGTriState defaultFirstClass) noexcept {
     BSGLogDebug(@"Tracer::startSpan(%@, opts, %d)", name, defaultFirstClass);
     __block auto blockThis = this;
     auto parentSpan = options.parentContext;
@@ -103,8 +104,8 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
         BSGLogTrace(@"Tracer::startSpan: No parent traceId; generating one");
         traceId = IdGenerator::generateTraceId();
     }
-    BSGFirstClass firstClass = options.firstClass;
-    if (firstClass == BSGFirstClassUnset) {
+    BSGTriState firstClass = options.firstClass;
+    if (firstClass == BSGTriStateUnset) {
         BSGLogTrace(@"Tracer::startSpan: firstClass not specified; using default of %d", defaultFirstClass);
         firstClass = defaultFirstClass;
     }
@@ -115,6 +116,7 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
     auto onSpanClosed = ^(BugsnagPerformanceSpan * _Nonnull endedSpan) {
         blockThis->onSpanClosed(endedSpan);
     };
+
     BugsnagPerformanceSpan *span = [[BugsnagPerformanceSpan alloc] initWithName:name
                                                                         traceId:traceId
                                                                          spanId:spanId
@@ -122,7 +124,7 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
                                                                       startTime:options.startTime
                                                                      firstClass:firstClass
                                                             attributeCountLimit:attributeCountLimit_
-                                                            instrumentRendering: options.instrumentRendering
+                                                                 metricsOptions:options.metricsOptions
                                                                    onSpanEndSet:onSpanEndSet
                                                                    onSpanClosed:onSpanClosed];
     if (shouldInstrumentRendering(span)) {
@@ -238,13 +240,13 @@ void Tracer::processFrameMetrics(BugsnagPerformanceSpan *span) noexcept {
 BugsnagPerformanceSpan *
 Tracer::startAppStartSpan(NSString *name,
                         SpanOptions options) noexcept {
-    return startSpan(name, options, BSGFirstClassUnset);
+    return startSpan(name, options, BSGTriStateUnset);
 }
 
 BugsnagPerformanceSpan *
 Tracer::startCustomSpan(NSString *name,
                         SpanOptions options) noexcept {
-    return startSpan(name, options, BSGFirstClassYes);
+    return startSpan(name, options, BSGTriStateYes);
 }
 
 BugsnagPerformanceSpan *
@@ -256,12 +258,12 @@ Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
     NSString *type = getBugsnagPerformanceViewTypeName(viewType);
     onViewLoadSpanStarted_(className);
     NSString *name = [NSString stringWithFormat:@"[ViewLoad/%@]/%@", type, className];
-    if (options.firstClass == BSGFirstClassUnset) {
+    if (options.firstClass == BSGTriStateUnset) {
         if (spanStackingHandler_->hasSpanWithAttribute(@"bugsnag.span.category", @"view_load")) {
-            options.firstClass = BSGFirstClassNo;
+            options.firstClass = BSGTriStateNo;
         }
     }
-    auto span = startSpan(name, options, BSGFirstClassNo);
+    auto span = startSpan(name, options, BSGTriStateNo);
     if (willDiscardPrewarmSpans_) {
         markPrewarmSpan(span);
     }
@@ -271,7 +273,7 @@ Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
 BugsnagPerformanceSpan *
 Tracer::startNetworkSpan(NSString *httpMethod, SpanOptions options) noexcept {
     auto name = [NSString stringWithFormat:@"[HTTP/%@]", httpMethod];
-    auto span = startSpan(name, options, BSGFirstClassUnset);
+    auto span = startSpan(name, options, BSGTriStateUnset);
     span.kind = SPAN_KIND_CLIENT;
     return span;
 }
@@ -283,7 +285,7 @@ Tracer::startViewLoadPhaseSpan(NSString *className,
     NSString *name = [NSString stringWithFormat:@"[ViewLoadPhase/%@]/%@", phase, className];
     SpanOptions options;
     options.parentContext = parentContext;
-    auto span = startSpan(name, options, BSGFirstClassUnset);
+    auto span = startSpan(name, options, BSGTriStateUnset);
     if (willDiscardPrewarmSpans_) {
         markPrewarmSpan(span);
     }
@@ -314,7 +316,7 @@ Tracer::createFrozenFrameSpan(NSTimeInterval startTime,
     options.startTime = startTime;
     options.parentContext = parentContext;
     options.makeCurrentContext = false;
-    auto span = startSpan(@"FrozenFrame", options, BSGFirstClassNo);
+    auto span = startSpan(@"FrozenFrame", options, BSGTriStateNo);
     [span endWithAbsoluteTime:endTime];
 }
 
@@ -334,14 +336,14 @@ Tracer::onPrewarmPhaseEnded(void) noexcept {
 
 bool 
 Tracer::shouldInstrumentRendering(BugsnagPerformanceSpan *span) noexcept {
-    switch (span.instrumentRendering) {
-        case BSGInstrumentRenderingYes:
-            return autoInstrumentRendering_;
-        case BSGInstrumentRenderingNo:
+    switch (span.metricsOptions.rendering) {
+        case BSGTriStateYes:
+            return enabledMetrics_.rendering;
+        case BSGTriStateNo:
             return false;
-        case BSGInstrumentRenderingUnset:
-            return autoInstrumentRendering_ &&
+        case BSGTriStateUnset:
+            return enabledMetrics_.rendering &&
             !span.wasStartOrEndTimeProvided && 
-            span.firstClass == BSGFirstClassYes;
+            span.firstClass == BSGTriStateYes;
     }
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -24,6 +24,26 @@ using namespace bugsnag;
 #define MAX_ATTRIBUTE_COUNT_LIMIT 1000
 #define DEFAULT_ATTRIBUTE_COUNT_LIMIT 128
 
+@implementation BugsnagPerformanceEnabledMetrics
+
+- (instancetype) initWithRendering:(BOOL)rendering cpu:(BOOL)cpu {
+    if ((self = [super init])) {
+        _rendering = rendering;
+        _cpu = cpu;
+    }
+    return self;
+}
+
+- (instancetype) init {
+    return [self initWithRendering:NO cpu:NO];
+}
+
+- (instancetype) clone {
+    return [[BugsnagPerformanceEnabledMetrics alloc] initWithRendering:self.rendering cpu:self.cpu];
+}
+
+@end
+
 @implementation BugsnagPerformanceConfiguration
 
 - (instancetype)initWithApiKey:(NSString *)apiKey {
@@ -34,7 +54,7 @@ using namespace bugsnag;
         _autoInstrumentAppStarts = YES;
         _autoInstrumentViewControllers = YES;
         _autoInstrumentNetworkRequests = YES;
-        _autoInstrumentRendering = NO;
+        _enabledMetrics = [BugsnagPerformanceEnabledMetrics new];
         _onSpanEndCallbacks = [NSMutableArray array];
         _attributeArrayLengthLimit = DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT;
         _attributeStringValueLimit = DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT;
@@ -46,6 +66,14 @@ using namespace bugsnag;
 #endif
     }
     return self;
+}
+
+- (void)setAutoInstrumentRendering:(BOOL)autoInstrumentRendering {
+    self.enabledMetrics.rendering = autoInstrumentRendering;
+}
+
+- (BOOL)autoInstrumentRendering {
+    return self.enabledMetrics.rendering;
 }
 
 static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInteger max, NSUInteger def) {
@@ -146,7 +174,7 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
         configuration.autoInstrumentNetworkRequests = [autoInstrumentNetworkRequests boolValue];
     }
     if (autoInstrumentRendering != nil) {
-        configuration.autoInstrumentRendering = [autoInstrumentRendering boolValue];
+        configuration.enabledMetrics.rendering = [autoInstrumentRendering boolValue];
     }
     if (samplingProbability != nil) {
         configuration.samplingProbability = samplingProbability;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -10,12 +10,33 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 
+@implementation BugsnagPerformanceSpanMetricsOptions
+
+- (instancetype)initWithRendering:(BSGTriState)rendering
+                              cpu:(BSGTriState)cpu {
+    if ((self = [super init])) {
+        _rendering = rendering;
+        _cpu = cpu;
+    }
+    return self;
+}
+
+- (instancetype)init {
+    return [self initWithRendering:BSGTriStateUnset cpu:BSGTriStateUnset];
+}
+
+- (instancetype)clone {
+    return [[BugsnagPerformanceSpanMetricsOptions alloc] initWithRendering:self.rendering
+                                                                       cpu:self.cpu];
+}
+
+@end
+
 @interface BugsnagPerformanceSpanOptions()
 @property(nonatomic,strong) NSDate *startTime_;
 @property(nonatomic,strong) BugsnagPerformanceSpanContext *parentContext_;
 @property(nonatomic) BOOL makeCurrentContext_;
-@property(nonatomic) BSGFirstClass firstClass_;
-@property(nonatomic) BSGInstrumentRendering instrumentRendering_;
+@property(nonatomic) BSGTriState firstClass_;
 @end
 
 @implementation BugsnagPerformanceSpanOptions
@@ -24,28 +45,27 @@
 @synthesize parentContext_ = _parentContext;
 @synthesize makeCurrentContext_ = _makeCurrentContext;
 @synthesize firstClass_ = _firstClass;
-@synthesize instrumentRendering_ = _instrumentRendering;
 
 - (instancetype)init {
     // These defaults must match the defaults in SpanOptions.h
     return [self initWithStartTime:nil
                      parentContext:nil
                 makeCurrentContext:true
-                        firstClass:BSGFirstClassUnset
-               instrumentRendering:BSGInstrumentRenderingUnset];
+                        firstClass:BSGTriStateUnset
+                    metricsOptions:[BugsnagPerformanceSpanMetricsOptions new]];
 }
 
 - (instancetype)initWithStartTime:(NSDate *)startTime
                     parentContext:(BugsnagPerformanceSpanContext *)parentContext
                makeCurrentContext:(BOOL)makeCurrentContext
-                       firstClass:(BSGFirstClass)firstClass
-              instrumentRendering:(BSGInstrumentRendering)instrumentRendering {
+                       firstClass:(BSGTriState)firstClass
+                   metricsOptions:(BugsnagPerformanceSpanMetricsOptions *)metricsOptions {
     if ((self = [super init])) {
         _startTime = startTime;
         _parentContext = parentContext;
         _makeCurrentContext = makeCurrentContext;
         _firstClass = firstClass;
-        _instrumentRendering = instrumentRendering;
+        _metricsOptions = metricsOptions;
     }
     return self;
 }
@@ -65,14 +85,14 @@
     return _makeCurrentContext;
 }
 
-- (BSGFirstClass)firstClass {
+- (BSGTriState)firstClass {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     return _firstClass;
 }
 
-- (BSGInstrumentRendering)instrumentRendering {
+- (BSGTriState)instrumentRendering {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    return _instrumentRendering;
+    return _metricsOptions.rendering;
 }
 
 - (instancetype)setStartTime:(NSDate *)startTime {
@@ -93,15 +113,15 @@
     return self;
 }
 
-- (instancetype)setFirstClass:(BSGFirstClass)firstClass {
+- (instancetype)setFirstClass:(BSGTriState)firstClass {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     _firstClass = firstClass;
     return self;
 }
 
-- (instancetype _Nonnull)setInstrumentRendering:(BSGInstrumentRendering)instrumentRendering {
+- (instancetype _Nonnull)setInstrumentRendering:(BSGTriState)instrumentRendering {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    _instrumentRendering = instrumentRendering;
+    _metricsOptions.rendering = instrumentRendering;
     return self;
 }
 
@@ -111,7 +131,7 @@
                                                       parentContext:_parentContext
                                                  makeCurrentContext:_makeCurrentContext
                                                          firstClass:_firstClass
-                                                instrumentRendering:_instrumentRendering];
+                                                     metricsOptions:[self.metricsOptions clone]];
 }
 
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -18,6 +18,16 @@ typedef BOOL (^ BugsnagPerformanceViewControllerInstrumentationCallback)(UIViewC
 typedef BOOL (^ BugsnagPerformanceSpanEndCallback)(BugsnagPerformanceSpan *span);
 
 OBJC_EXPORT
+@interface BugsnagPerformanceEnabledMetrics : NSObject
+
+@property(nonatomic) BOOL rendering; // (default NO)
+@property(nonatomic) BOOL cpu;       // (default NO)
+
+- (instancetype) clone;
+
+@end
+
+OBJC_EXPORT
 @interface BugsnagPerformanceConfiguration : NSObject
 
 - (instancetype)initWithApiKey:(NSString *)apiKey NS_DESIGNATED_INITIALIZER;
@@ -44,7 +54,9 @@ OBJC_EXPORT
 
 @property (nonatomic) BOOL autoInstrumentNetworkRequests;
 
-@property (nonatomic) BOOL autoInstrumentRendering;
+@property (nonatomic) BOOL autoInstrumentRendering DEPRECATED_ATTRIBUTE;
+
+@property(nonatomic,strong) BugsnagPerformanceEnabledMetrics *enabledMetrics;
 
 /**
  *  The version of the application

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -8,17 +8,46 @@
 
 #import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 
+typedef NS_ENUM(uint8_t, BSGTriState) {
+    BSGTriStateNo = 0,
+    BSGTriStateYes = 1,
+    BSGTriStateUnset = 2,
+};
+
+@interface BugsnagPerformanceSpanMetricsOptions : NSObject
+
+/**
+ * No = never include these metrics
+ * Yes = Always include these metrics, as long as the corresponding enabledMetrics configuration option is on
+ * Unset = Include metrics only if the span is first class, start and end times were not set when creating/closing
+ *       the span and the corresponding enabledMetrics configuration option is on
+ * Default: Unset
+ */
+@property(nonatomic) BSGTriState rendering;
+
+/**
+ * No = never include these metrics
+ * Yes = Always include these metrics, as long as the corresponding enabledMetrics configuration option is on
+ * Unset = Include metrics only if the span is first class and the corresponding enabledMetrics configuration option is on
+ * Default: Unset
+ */
+@property(nonatomic) BSGTriState cpu;
+
+- (_Nonnull instancetype)clone;
+
+@end
+
 typedef NS_ENUM(uint8_t, BSGFirstClass) {
-    BSGFirstClassNo = 0,
-    BSGFirstClassYes = 1,
-    BSGFirstClassUnset = 2,
+    BSGFirstClassNo __attribute__((deprecated)) = BSGTriStateNo,
+    BSGFirstClassYes __attribute__((deprecated)) = BSGTriStateYes,
+    BSGFirstClassUnset __attribute__((deprecated)) = BSGTriStateUnset,
 };
 
 // Affects whether or not a span should include rendering metrics
 typedef NS_ENUM(uint8_t, BSGInstrumentRendering) {
-    BSGInstrumentRenderingNo = 0, // Never include rendering metrics
-    BSGInstrumentRenderingYes = 1, // Always include rendering metrics, as long as the autoInstrumentRendering configuration option is on
-    BSGInstrumentRenderingUnset = 2, // Include rendering metrics only if the span is first class, start and end times were not set when creating/closing the span and the autoInstrumentRendering configuration option is on
+    BSGInstrumentRenderingNo __attribute__((deprecated)) = BSGTriStateNo, // Never include rendering metrics
+    BSGInstrumentRenderingYes __attribute__((deprecated)) = BSGTriStateYes, // Always include rendering metrics, as long as the autoInstrumentRendering configuration option is on
+    BSGInstrumentRenderingUnset __attribute__((deprecated)) = BSGTriStateUnset, // Include rendering metrics only if the span is first class, start and end times were not set when creating/closing the span and the autoInstrumentRendering configuration option is on
 };
 
 // Span options allow the user to affect how spans are created.
@@ -35,15 +64,17 @@ OBJC_EXPORT
 @property(nonatomic, readonly) BOOL makeCurrentContext;
 
 // If true, this span will be considered "first class" on the dashboard.
-@property(nonatomic, readonly) BSGFirstClass firstClass;
+@property(nonatomic, readonly) BSGTriState firstClass;
 
-@property(nonatomic, readonly) BSGInstrumentRendering instrumentRendering;
+@property(nonatomic, readonly) BSGTriState instrumentRendering DEPRECATED_ATTRIBUTE;
+
+@property(nonatomic, strong) BugsnagPerformanceSpanMetricsOptions * _Nonnull metricsOptions;
 
 - (instancetype _Nonnull)setStartTime:(NSDate * _Nullable)startTime;
 - (instancetype _Nonnull)setParentContext:(BugsnagPerformanceSpanContext * _Nullable)parentContext;
 - (instancetype _Nonnull)setMakeCurrentContext:(BOOL)makeCurrentContext;
-- (instancetype _Nonnull)setFirstClass:(BSGFirstClass)firstClass;
-- (instancetype _Nonnull)setInstrumentRendering:(BSGInstrumentRendering)instrumentRendering;
+- (instancetype _Nonnull)setFirstClass:(BSGTriState)firstClass;
+- (instancetype _Nonnull)setInstrumentRendering:(BSGTriState)instrumentRendering DEPRECATED_ATTRIBUTE;
 
 - (instancetype _Nonnull)clone;
 

--- a/Tests/BugsnagPerformanceTests/BatchTests.mm
+++ b/Tests/BugsnagPerformanceTests/BatchTests.mm
@@ -19,14 +19,15 @@ using namespace bugsnag;
 
 static BugsnagPerformanceSpan *newSpanData() {
     TraceId tid = {.value = 1};
-    return [[BugsnagPerformanceSpan alloc] initWithName:@"test" 
+    MetricsOptions metricsOptions;
+    return [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                 traceId:tid
                                                  spanId:1
                                                parentId:0
                                               startTime:0
-                                             firstClass:BSGFirstClassUnset
+                                             firstClass:BSGTriStateUnset
                                     attributeCountLimit:128
-                                    instrumentRendering:BSGInstrumentRenderingNo
+                                         metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
@@ -135,7 +135,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
-    XCTAssertFalse(config.autoInstrumentRendering);
+    XCTAssertFalse(config.enabledMetrics.rendering);
 }
 
 - (void)testLoadConfigDoesntTakeValuesFromBugsnagWhenAllValuesAreInPerformanceDictionary {
@@ -181,7 +181,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
-    XCTAssertTrue(config.autoInstrumentRendering);
+    XCTAssertTrue(config.enabledMetrics.rendering);
 }
 
 - (void)testLoadConfigDoesTakeValuesFromBugsnagWhenSomeValuesAreMissingInPerformanceDictionary {
@@ -212,7 +212,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
-    XCTAssertTrue(config.autoInstrumentRendering);
+    XCTAssertTrue(config.enabledMetrics.rendering);
 }
 
 - (void)testShouldSetIncludeApiKeyInTheDefaultEndpoint {

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -176,7 +176,9 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                   spanId:(SpanId) spanId
                                 parentId:(SpanId) parentId
                                startTime:(CFAbsoluteTime) startAbsTime
-                              firstClass:(BSGFirstClass) firstClass {
+                              firstClass:(BSGTriState) firstClass {
+    MetricsOptions metricsOptions;
+    metricsOptions.rendering = BSGTriStateNo;
     return [[BugsnagPerformanceSpan alloc] initWithName:name
                                                 traceId:traceId
                                                  spanId:spanId
@@ -184,7 +186,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                               startTime:startAbsTime
                                              firstClass:firstClass
                                     attributeCountLimit:128
-                                    instrumentRendering:BSGInstrumentRenderingNo
+                                         metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {}];
 }
@@ -198,7 +200,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:CFAbsoluteTimeGetCurrent()
-                             firstClass:BSGFirstClassYes]];
+                             firstClass:BSGTriStateYes]];
     auto json = encoder->encode(spans, @{});
     
     XCTAssertIsKindOfClass(json[@"resourceSpans"], [NSArray class]);
@@ -224,7 +226,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:CFAbsoluteTimeGetCurrent()
-                             firstClass:BSGFirstClassNo]];
+                             firstClass:BSGTriStateNo]];
     auto json = encoder->encode(spans, @{});
     
     XCTAssertIsKindOfClass(json[@"resourceSpans"], [NSArray class]);
@@ -250,7 +252,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:CFAbsoluteTimeGetCurrent()
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     auto json = encoder->encode(spans, @{});
     
     XCTAssertIsKindOfClass(json[@"resourceSpans"], [NSArray class]);
@@ -280,7 +282,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                                spanId:0xface
                                              parentId:0
                                             startTime:startTime
-                                           firstClass:BSGFirstClassUnset];
+                                           firstClass:BSGTriStateUnset];
     [span setEndAbsTime:startTime + 15];
     
     auto json = encoder->encode(span);
@@ -316,7 +318,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                                spanId:0xface
                                              parentId:0xcafe
                                             startTime:startTime
-                                           firstClass:BSGFirstClassUnset];
+                                           firstClass:BSGTriStateUnset];
     [span setEndAbsTime:startTime + 15];
     
     auto json = encoder->encode(span);
@@ -366,7 +368,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     auto resourceAttributes = @{};
     auto package = encoder->buildUploadPackage(spans, resourceAttributes, true);
 
@@ -389,7 +391,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.3];
 
     auto resourceAttributes = @{};
@@ -408,13 +410,13 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test2"
                                 traceId:tid
                                  spanId:2
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.3];
     [spans[1] updateSamplingProbability:0.1];
 
@@ -434,13 +436,13 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test2"
                                 traceId:tid
                                  spanId:2
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.5];
     [spans[1] updateSamplingProbability:0.5];
 
@@ -460,31 +462,31 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test2"
                                 traceId:tid
                                  spanId:2
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test3"
                                 traceId:tid
                                  spanId:3
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test4"
                                 traceId:tid
                                  spanId:4
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test5"
                                 traceId:tid
                                  spanId:5
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.3];
     [spans[1] updateSamplingProbability:0.1];
     [spans[2] updateSamplingProbability:0.3];
@@ -507,67 +509,67 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test1"
                                 traceId:tid
                                  spanId:2
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test2"
                                 traceId:tid
                                  spanId:3
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test3"
                                 traceId:tid
                                  spanId:4
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test4"
                                 traceId:tid
                                  spanId:5
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test5"
                                 traceId:tid
                                  spanId:6
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test6"
                                 traceId:tid
                                  spanId:7
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test7"
                                 traceId:tid
                                  spanId:8
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test8"
                                 traceId:tid
                                  spanId:9
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test9"
                                 traceId:tid
                                  spanId:10
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test10"
                                 traceId:tid
                                  spanId:11
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.0];
     [spans[1] updateSamplingProbability:0.1];
     [spans[2] updateSamplingProbability:0.2];
@@ -596,31 +598,31 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test2"
                                 traceId:tid
                                  spanId:2
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test3"
                                 traceId:tid
                                  spanId:3
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test4"
                                 traceId:tid
                                  spanId:4
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test5"
                                 traceId:tid
                                  spanId:5
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.3];
     [spans[1] updateSamplingProbability:0.1];
     [spans[2] updateSamplingProbability:0.3];

--- a/Tests/BugsnagPerformanceTests/SamplerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SamplerTests.mm
@@ -59,14 +59,15 @@ using namespace bugsnag;
     auto numSamplesTries = 1'000;
     auto count = 0;
     for (auto i = 0; i < numSamplesTries; i++) {
+        MetricsOptions metricsOptions;
         BugsnagPerformanceSpan *span = [[BugsnagPerformanceSpan alloc] initWithName:@"a"
                                                                             traceId:IdGenerator::generateTraceId()
                                                                              spanId:IdGenerator::generateSpanId()
                                                                            parentId:0
                                                                           startTime:0
-                                                                         firstClass:BSGFirstClassUnset
+                                                                         firstClass:BSGTriStateUnset
                                                                 attributeCountLimit:128
-                                                                instrumentRendering:BSGInstrumentRenderingNo
+                                                                     metricsOptions:metricsOptions
                                                                        onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                                                        onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
         }];

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -1,0 +1,345 @@
+//
+//  SpanAttributesTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Karl Stenerud on 21.01.25.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import "TestHelpers.h"
+#import "../../Sources/BugsnagPerformance/Private/SpanAttributesProvider.h"
+
+using namespace bugsnag;
+
+@interface SpanAttributesTests : XCTestCase
+
+@end
+
+@implementation SpanAttributesTests
+
+- (void)testNetworkSpanUrlAttributes {
+    SpanAttributesProvider provider;
+    NSURL *url = [NSURL URLWithString:@"https://bugsnag.com"];
+    NSError *error = [NSError errorWithDomain:@"test" code:1 userInfo:nil];
+
+    auto attributes = provider.networkSpanUrlAttributes(url, error);
+    XCTAssertEqual(2U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"http.url"], url.absoluteString);
+    XCTAssertEqualObjects(attributes[@"bugsnag.instrumentation_message"], @"Error Domain=test Code=1 \"(null)\"");
+
+    attributes = provider.networkSpanUrlAttributes(url, nil);
+    XCTAssertEqual(1U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"http.url"], url.absoluteString);
+    XCTAssertNil(attributes[@"bugsnag.instrumentation_message"]);
+
+    attributes = provider.networkSpanUrlAttributes(nil, error);
+    XCTAssertEqual(1U, attributes.count);
+    XCTAssertNil(attributes[@"http.url"]);
+    XCTAssertEqualObjects(attributes[@"bugsnag.instrumentation_message"], @"Error Domain=test Code=1 \"(null)\"");
+
+    attributes = provider.networkSpanUrlAttributes(nil, nil);
+    XCTAssertEqual(0U, attributes.count);
+}
+
+- (void)testAppStartPhaseSpanAttributes {
+    SpanAttributesProvider provider;
+
+    auto attributes = provider.appStartPhaseSpanAttributes(@"phase1");
+    XCTAssertEqual(2U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"app_start_phase");
+    XCTAssertEqualObjects(attributes[@"bugsnag.phase"], @"phase1");
+}
+
+- (void)testAppStartSpanAttributes {
+    SpanAttributesProvider provider;
+
+    auto attributes = provider.appStartSpanAttributes(@"firstView", true);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"app_start");
+    XCTAssertEqualObjects(attributes[@"bugsnag.app_start.type"], @"cold");
+    XCTAssertEqualObjects(attributes[@"bugsnag.app_start.first_view_name"], @"firstView");
+
+    attributes = provider.appStartSpanAttributes(@"firstView", false);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"app_start");
+    XCTAssertEqualObjects(attributes[@"bugsnag.app_start.type"], @"warm");
+    XCTAssertEqualObjects(attributes[@"bugsnag.app_start.first_view_name"], @"firstView");
+
+    attributes = provider.appStartSpanAttributes(nil, false);
+    XCTAssertEqual(2U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"app_start");
+    XCTAssertEqualObjects(attributes[@"bugsnag.app_start.type"], @"warm");
+    XCTAssertNil(attributes[@"bugsnag.app_start.first_view_name"]);
+}
+
+- (void)testViewLoadSpanAttributes {
+    SpanAttributesProvider provider;
+
+    auto attributes = provider.viewLoadSpanAttributes(@"myView", BugsnagPerformanceViewTypeUIKit);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"UIKit");
+
+    attributes = provider.viewLoadSpanAttributes(@"myView", BugsnagPerformanceViewTypeSwiftUI);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"SwiftUI");
+
+    attributes = provider.viewLoadSpanAttributes(@"myView", (BugsnagPerformanceViewType)100);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"?");
+}
+
+- (void)testPreloadedViewLoadSpanAttributes {
+    SpanAttributesProvider provider;
+
+    auto attributes = provider.preloadedViewLoadSpanAttributes(@"myView", BugsnagPerformanceViewTypeUIKit);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (pre-loaded)");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"UIKit");
+
+    attributes = provider.preloadedViewLoadSpanAttributes(@"myView", BugsnagPerformanceViewTypeSwiftUI);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (pre-loaded)");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"SwiftUI");
+
+    attributes = provider.preloadedViewLoadSpanAttributes(@"myView", (BugsnagPerformanceViewType)100);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (pre-loaded)");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"?");
+}
+
+- (void)testViewLoadPhaseSpanAttributes {
+    SpanAttributesProvider provider;
+
+    auto attributes = provider.viewLoadPhaseSpanAttributes(@"myView", @"myPhase");
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load_phase");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView");
+    XCTAssertEqualObjects(attributes[@"bugsnag.phase"], @"myPhase");
+}
+
+- (void)testCustomSpanAttributes {
+    SpanAttributesProvider provider;
+
+    auto attributes = provider.customSpanAttributes();
+    XCTAssertEqual(1U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"custom");
+}
+
+- (void)testCPUSampleAttributesInsufficient {
+    SpanAttributesProvider provider;
+
+    // Not enough samples
+    std::vector<SystemInfoSampleData> samples;
+    auto attributes = provider.cpuSampleAttributes(samples);
+    XCTAssertEqual(0U, attributes.count);
+
+    // Still not enough samples
+    samples.push_back(SystemInfoSampleData(1));
+    attributes = provider.cpuSampleAttributes(samples);
+    XCTAssertEqual(0U, attributes.count);
+
+    // Both samples don't contain any valid data
+    samples.push_back(SystemInfoSampleData(2));
+    attributes = provider.cpuSampleAttributes(samples);
+    XCTAssertEqual(0U, attributes.count);
+
+    // Only one sample contains valid data and we need at least 2
+    samples[0].mainThreadCPUPct = 10;
+    attributes = provider.cpuSampleAttributes(samples);
+    XCTAssertEqual(0U, attributes.count);
+}
+
+- (void)testCPUSampleAttributes {
+    SpanAttributesProvider provider;
+    std::vector<SystemInfoSampleData> samples = {
+        SystemInfoSampleData(1),
+        SystemInfoSampleData(2),
+    };
+
+    samples[0].processCPUPct = 10;
+    samples[0].mainThreadCPUPct = 20;
+    samples[0].monitorThreadCPUPct = 30;
+
+    samples[1].processCPUPct = 40;
+    samples[1].mainThreadCPUPct = 50;
+    samples[1].monitorThreadCPUPct = 60;
+
+    auto attributes = provider.cpuSampleAttributes(samples);
+    XCTAssertEqual(7U, attributes.count);
+    NSArray *expectedTimestamps = @[
+        @978307201000000000,
+        @978307202000000000,
+    ];
+    NSArray *expectedProcess = @[
+        @10.0,
+        @40.0,
+    ];
+    NSArray *expectedMainThread = @[
+        @20.0,
+        @50.0,
+    ];
+    NSArray *expectedMonitorThread = @[
+        @30.0,
+        @60.0,
+    ];
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_timestamps"], expectedTimestamps);
+
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_total"], expectedProcess);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_total"], @25.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_main_thread"], expectedMainThread);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_main_thread"], @35.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_overhead"], expectedMonitorThread);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_overhead"], @45.0);
+}
+
+- (void)testCPUSampleAttributesProcessOnly {
+    SpanAttributesProvider provider;
+    std::vector<SystemInfoSampleData> samples = {
+        SystemInfoSampleData(11),
+        SystemInfoSampleData(12),
+    };
+
+    samples[0].processCPUPct = 10;
+    samples[1].processCPUPct = 40;
+
+    auto attributes = provider.cpuSampleAttributes(samples);
+    XCTAssertEqual(3U, attributes.count);
+    NSArray *expectedTimestamps = @[
+        @978307211000000000,
+        @978307212000000000,
+    ];
+    NSArray *expectedProcess = @[
+        @10.0,
+        @40.0,
+    ];
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_timestamps"], expectedTimestamps);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_total"], expectedProcess);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_total"], @25.0);
+}
+
+- (void)testCPUSampleAttributesMainThreadOnly {
+    SpanAttributesProvider provider;
+    std::vector<SystemInfoSampleData> samples = {
+        SystemInfoSampleData(1),
+        SystemInfoSampleData(2),
+    };
+
+    samples[0].mainThreadCPUPct = 20;
+    samples[1].mainThreadCPUPct = 50;
+
+    auto attributes = provider.cpuSampleAttributes(samples);
+    XCTAssertEqual(3U, attributes.count);
+    NSArray *expectedTimestamps = @[
+        @978307201000000000,
+        @978307202000000000,
+    ];
+    NSArray *expectedMainThread = @[
+        @20.0,
+        @50.0,
+    ];
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_timestamps"], expectedTimestamps);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_main_thread"], expectedMainThread);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_main_thread"], @35.0);
+}
+
+- (void)testCPUSampleAttributesOverheadOnly {
+    SpanAttributesProvider provider;
+    std::vector<SystemInfoSampleData> samples = {
+        SystemInfoSampleData(1),
+        SystemInfoSampleData(2),
+    };
+
+    samples[0].monitorThreadCPUPct = 30;
+    samples[1].monitorThreadCPUPct = 60;
+
+    auto attributes = provider.cpuSampleAttributes(samples);
+    XCTAssertEqual(3U, attributes.count);
+    NSArray *expectedTimestamps = @[
+        @978307201000000000,
+        @978307202000000000,
+    ];
+    NSArray *expectedMonitorThread = @[
+        @30.0,
+        @60.0,
+    ];
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_timestamps"], expectedTimestamps);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_overhead"], expectedMonitorThread);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_overhead"], @45.0);
+}
+
+- (void)testCPUSampleAttributesComplex {
+    SpanAttributesProvider provider;
+    std::vector<SystemInfoSampleData> samples = {
+        SystemInfoSampleData(1),
+        SystemInfoSampleData(2),
+        SystemInfoSampleData(3),
+        SystemInfoSampleData(8),
+        SystemInfoSampleData(9),
+    };
+
+    samples[0].processCPUPct = 10;
+    samples[0].mainThreadCPUPct = -1;
+    samples[0].monitorThreadCPUPct = 30;
+
+    samples[1].processCPUPct = -1;
+    samples[1].mainThreadCPUPct = -1;
+    samples[1].monitorThreadCPUPct = 60;
+
+    samples[2].processCPUPct = 40;
+    samples[2].mainThreadCPUPct = 70;
+    samples[2].monitorThreadCPUPct = 60;
+
+    samples[3].processCPUPct = -1;
+    samples[3].mainThreadCPUPct = -1;
+    samples[3].monitorThreadCPUPct = -1;
+
+    samples[4].processCPUPct = 70;
+    samples[4].mainThreadCPUPct = 80;
+    samples[4].monitorThreadCPUPct = -1;
+
+    auto attributes = provider.cpuSampleAttributes(samples);
+    XCTAssertEqual(7U, attributes.count);
+    NSArray *expectedTimestamps = @[
+        @978307201000000000,
+        @978307202000000000,
+        @978307203000000000,
+        @978307209000000000,
+    ];
+    NSArray *expectedProcess = @[
+        @10.0,
+        @-1.0,
+        @40.0,
+        @70.0,
+    ];
+    NSArray *expectedMainThread = @[
+        @-1.0,
+        @-1.0,
+        @70.0,
+        @80.0,
+    ];
+    NSArray *expectedMonitorThread = @[
+        @30.0,
+        @60.0,
+        @60.0,
+        @-1.0,
+    ];
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_timestamps"], expectedTimestamps);
+
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_total"], expectedProcess);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_total"], @40.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_main_thread"], expectedMainThread);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_main_thread"], @75.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_overhead"], expectedMonitorThread);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_overhead"], @50.0);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -28,7 +28,7 @@ using namespace bugsnag;
     XCTAssertNil(objcOptions.parentContext);
     XCTAssertNil(objcOptions.startTime);
     XCTAssertTrue(objcOptions.makeCurrentContext);
-    XCTAssertEqual(objcOptions.firstClass, BSGFirstClassUnset);
+    XCTAssertEqual(objcOptions.firstClass, BSGTriStateUnset);
 }
 
 - (void)testConversionDefaults {
@@ -37,18 +37,20 @@ using namespace bugsnag;
     XCTAssertNil(cOptions.parentContext);
     XCTAssertTrue(isnan(cOptions.startTime));
     XCTAssertTrue(cOptions.makeCurrentContext);
-    XCTAssertEqual(cOptions.firstClass, BSGFirstClassUnset);
+    XCTAssertEqual(cOptions.firstClass, BSGTriStateUnset);
 }
 
 - (void)testConversion {
-    BugsnagPerformanceSpan *span = [[BugsnagPerformanceSpan alloc] initWithName:@"test" 
+    MetricsOptions metricsOptions;
+    metricsOptions.rendering = BSGTriStateNo;
+    BugsnagPerformanceSpan *span = [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                                         traceId:IdGenerator::generateTraceId()
                                                                          spanId:IdGenerator::generateSpanId()
                                                                        parentId:IdGenerator::generateSpanId()
                                                                       startTime:SpanOptions().startTime 
-                                                                     firstClass:BSGFirstClassNo
+                                                                     firstClass:BSGTriStateNo
                                                             attributeCountLimit:128
-                                                            instrumentRendering:BSGInstrumentRenderingNo
+                                                                 metricsOptions:metricsOptions
                                                                    onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                                                    onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
@@ -56,13 +58,13 @@ using namespace bugsnag;
     objcOptions.startTime = [NSDate dateWithTimeIntervalSinceReferenceDate:1.0];
     objcOptions.parentContext = span;
     objcOptions.makeCurrentContext = true;
-    objcOptions.firstClass = BSGFirstClassNo;
+    objcOptions.firstClass = BSGTriStateNo;
     
     SpanOptions cOptions(objcOptions);
     XCTAssertEqual(1.0, cOptions.startTime);
     XCTAssertEqual(span, cOptions.parentContext);
     XCTAssertEqual(true, cOptions.makeCurrentContext);
-    XCTAssertEqual(BSGFirstClassNo, cOptions.firstClass);
+    XCTAssertEqual(BSGTriStateNo, cOptions.firstClass);
 }
 
 @end

--- a/Tests/BugsnagPerformanceTests/SpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanTests.mm
@@ -20,14 +20,16 @@ using namespace bugsnag;
 
 static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanLifecycleCallback onEnded) {
     TraceId tid = {.value = 1};
+    MetricsOptions metricsOptions;
+    metricsOptions.rendering = BSGTriStateNo;
     return [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                 traceId:tid
                                                  spanId:1
                                                parentId:0
                                               startTime:startTime
-                                             firstClass:BSGFirstClassUnset
+                                             firstClass:BSGTriStateUnset
                                     attributeCountLimit:128
-                                    instrumentRendering:BSGInstrumentRenderingNo
+                                         metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan *) {}
                                            onSpanClosed:onEnded];
 }
@@ -39,6 +41,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, CFAbsoluteTimeGetCurrent(), 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartNearPastEndUnset {
@@ -48,6 +52,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, CFAbsoluteTimeGetCurrent(), 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartUnsetEndNearPast {
@@ -57,6 +63,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, endTime, 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartUnsetEndNearFuture {
@@ -66,6 +74,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, endTime, 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartNearPastEndNearFuture {
@@ -75,6 +85,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, endTime, 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartFarPastEndUnset {
@@ -84,6 +96,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, CFAbsoluteTimeGetCurrent(), 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartFarPastEndNearPast {
@@ -93,6 +107,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartFarPastEndNearFuture {
@@ -102,6 +118,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartNowEndFarFuture {
@@ -111,6 +129,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartFarPastEndFarFuture {
@@ -120,6 +140,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartNearPastEndFarFuture {
@@ -129,6 +151,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartNearFutureEndFarFuture {
@@ -138,6 +162,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartEndDistantPast {
@@ -147,6 +173,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testAddRemoveAttributes {
@@ -270,15 +298,16 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
 }
 
 - (void)testTooManyAttributes {
+    MetricsOptions metricsOptions;
     TraceId tid = {.value = 1};
     auto span = [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                      traceId:tid
                                                       spanId:1
                                                     parentId:0
                                                    startTime:0
-                                                  firstClass:BSGFirstClassUnset
+                                                  firstClass:BSGTriStateUnset
                                          attributeCountLimit:5
-                                         instrumentRendering:BSGInstrumentRenderingNo
+                                              metricsOptions:metricsOptions
                                                 onSpanEndSet:^(BugsnagPerformanceSpan *) {}
                                                 onSpanClosed:^(BugsnagPerformanceSpan *) {}];
 

--- a/Tests/BugsnagPerformanceTests/TestHelpers.h
+++ b/Tests/BugsnagPerformanceTests/TestHelpers.h
@@ -1,0 +1,14 @@
+//
+//  TestHelpers.h
+//  BugsnagPerformance
+//
+//  Created by Karl Stenerud on 21.01.25.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <XCTest/XCTest.h>
+
+// NSLog gets swallowed during unit tests, so work around it using printf.
+#define TesterLog(FMT, ...) printf("%s\n", [NSString stringWithFormat:FMT, __VA_ARGS__].UTF8String)

--- a/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
+++ b/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
@@ -19,14 +19,15 @@ using namespace bugsnag;
 @end
 
 static BugsnagPerformanceSpan *createSpan() {
+    MetricsOptions metricsOptions;
     return [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                 traceId:IdGenerator::generateTraceId()
                                                  spanId:IdGenerator::generateSpanId()
                                                parentId:IdGenerator::generateSpanId()
                                               startTime:SpanOptions().startTime 
-                                             firstClass:BSGFirstClassNo
+                                             firstClass:BSGTriStateNo
                                     attributeCountLimit:128
-                                    instrumentRendering:BSGInstrumentRenderingNo
+                                         metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];

--- a/features/default/metrics.feature
+++ b/features/default/metrics.feature
@@ -1,0 +1,278 @@
+Feature: Metrics
+
+  Scenario: With default settings, CPU metrics are disabled
+    Given I load scenario "CPUMetricsScenario"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "work_duration" to "0"
+    And I configure scenario "span_duration" to "0"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span attribute "bugsnag.system.cpu_measures_total" does not exist
+    * every span attribute "bugsnag.system.cpu_mean_total" does not exist
+    * every span attribute "bugsnag.system.cpu_measures_main_thread" does not exist
+    * every span attribute "bugsnag.system.cpu_mean_main_thread" does not exist
+    * every span attribute "bugsnag.system.cpu_measures_overhead" does not exist
+    * every span attribute "bugsnag.system.cpu_mean_overhead" does not exist
+
+  Scenario: When CPU metrics are disabled, no metrics are produced no matter what
+    Given I load scenario "CPUMetricsScenario"
+    And I configure bugsnag "cpuMetrics" to "false"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "work_duration" to "0"
+    And I configure scenario "span_duration" to "0"
+    And I configure scenario "opts_metrics_cpu" to "yes"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span attribute "bugsnag.system.cpu_measures_total" does not exist
+    * every span attribute "bugsnag.system.cpu_mean_total" does not exist
+    * every span attribute "bugsnag.system.cpu_measures_main_thread" does not exist
+    * every span attribute "bugsnag.system.cpu_mean_main_thread" does not exist
+    * every span attribute "bugsnag.system.cpu_measures_overhead" does not exist
+    * every span attribute "bugsnag.system.cpu_mean_overhead" does not exist
+
+  Scenario: First class spans produce CPU metrics
+    Given I load scenario "CPUMetricsScenario"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "work_duration" to "0"
+    And I configure scenario "span_duration" to "0"
+    And I configure scenario "opts_first_class" to "yes"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * a span array attribute "bugsnag.system.cpu_measures_total" contains 2 elements
+    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
+    * a span array attribute "bugsnag.system.cpu_measures_main_thread" contains 2 elements
+    * a span float attribute "bugsnag.system.cpu_mean_main_thread" is greater than 0.0
+    * a span array attribute "bugsnag.system.cpu_measures_overhead" contains 2 elements
+    * a span float attribute "bugsnag.system.cpu_mean_overhead" is greater than 0.0
+
+  Scenario: Non-first-class spans don't produce metrics
+    Given I load scenario "CPUMetricsScenario"
+    And I configure bugsnag "cpuMetrics" to "false"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "work_duration" to "0"
+    And I configure scenario "span_duration" to "0"
+    And I configure scenario "opts_first_class" to "no"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * every span bool attribute "bugsnag.span.first_class" is false
+    * every span attribute "bugsnag.system.cpu_measures_total" does not exist
+    * every span attribute "bugsnag.system.cpu_mean_total" does not exist
+    * every span attribute "bugsnag.system.cpu_measures_main_thread" does not exist
+    * every span attribute "bugsnag.system.cpu_mean_main_thread" does not exist
+    * every span attribute "bugsnag.system.cpu_measures_overhead" does not exist
+    * every span attribute "bugsnag.system.cpu_mean_overhead" does not exist
+
+  Scenario: When CPU metrics opts are enabled, we produce CPU metrics even if not first class
+    Given I load scenario "CPUMetricsScenario"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "work_duration" to "0"
+    And I configure scenario "span_duration" to "0"
+    And I configure scenario "opts_first_class" to "no"
+    And I configure scenario "opts_metrics_cpu" to "yes"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * every span bool attribute "bugsnag.span.first_class" is false
+    * a span array attribute "bugsnag.system.cpu_measures_total" contains 2 elements
+    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
+    * a span array attribute "bugsnag.system.cpu_measures_main_thread" contains 2 elements
+    * a span float attribute "bugsnag.system.cpu_mean_main_thread" is greater than 0.0
+    * a span array attribute "bugsnag.system.cpu_measures_overhead" contains 2 elements
+    * a span float attribute "bugsnag.system.cpu_mean_overhead" is greater than 0.0
+
+  Scenario: Longer span duration captures more samples
+    Given I load scenario "CPUMetricsScenario"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "work_duration" to "0"
+    And I configure scenario "span_duration" to "1.5"
+    And I configure scenario "opts_first_class" to "yes"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * a span array attribute "bugsnag.system.cpu_measures_total" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
+    * a span array attribute "bugsnag.system.cpu_measures_main_thread" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_main_thread" is greater than 0.0
+    * a span array attribute "bugsnag.system.cpu_measures_overhead" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_overhead" is greater than 0.0
+
+  Scenario: Generate spans later
+    Given I load scenario "CPUMetricsScenario"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure scenario "run_delay" to "1.1"
+    And I configure scenario "work_duration" to "0"
+    And I configure scenario "span_duration" to "1.5"
+    And I configure scenario "opts_first_class" to "yes"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * a span array attribute "bugsnag.system.cpu_measures_total" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
+    * a span float attribute "bugsnag.system.cpu_mean_total" is less than 10.0
+    * a span array attribute "bugsnag.system.cpu_measures_main_thread" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_main_thread" is greater than 0.0
+    * a span float attribute "bugsnag.system.cpu_mean_main_thread" is less than 10.0
+    * a span array attribute "bugsnag.system.cpu_measures_overhead" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_overhead" is greater than 0.0
+    * a span float attribute "bugsnag.system.cpu_mean_overhead" is less than 10.0
+
+  Scenario: Do heavy work on the main thread
+    Given I load scenario "CPUMetricsScenario"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure scenario "run_delay" to "1.1"
+    And I configure scenario "work_duration" to "3.0"
+    And I configure scenario "work_on_thread" to "main"
+    And I configure scenario "span_duration" to "1.5"
+    And I configure scenario "opts_first_class" to "yes"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * a span array attribute "bugsnag.system.cpu_measures_total" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 50.0
+    * a span array attribute "bugsnag.system.cpu_measures_main_thread" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_main_thread" is greater than 50.0
+    * a span array attribute "bugsnag.system.cpu_measures_overhead" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_overhead" is greater than 0.0
+    * a span float attribute "bugsnag.system.cpu_mean_overhead" is less than 10.0
+
+  Scenario: Do heavy work on a bg thread
+    Given I load scenario "CPUMetricsScenario"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure scenario "run_delay" to "1.1"
+    And I configure scenario "work_duration" to "3.0"
+    And I configure scenario "work_on_thread" to "main"
+    And I configure scenario "span_duration" to "1.5"
+    And I configure scenario "opts_first_class" to "yes"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "MySpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * a span array attribute "bugsnag.system.cpu_measures_total" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 50.0
+    * a span array attribute "bugsnag.system.cpu_measures_main_thread" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_main_thread" is greater than 0.0
+    * a span float attribute "bugsnag.system.cpu_mean_main_thread" is less than 10.0
+    * a span array attribute "bugsnag.system.cpu_measures_overhead" contains 3 elements
+    * a span float attribute "bugsnag.system.cpu_mean_overhead" is greater than 0.0
+    * a span float attribute "bugsnag.system.cpu_mean_overhead" is less than 10.0

--- a/features/default/network.feature
+++ b/features/default/network.feature
@@ -46,7 +46,7 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentNetworkTracePropagationScenario: Allow All
     Given I load scenario "AutoInstrumentNetworkTracePropagationScenario"
-    And I configure "propagateTraceParentToUrlsMatching" to ".*"
+    And I configure bugsnag "propagateTraceParentToUrlsMatching" to ".*"
     And I invoke "setCallSitesWithCallSiteStrs:" with parameter "?test=1"
     And I start bugsnag
     And I run the loaded scenario
@@ -63,7 +63,7 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentNetworkTracePropagationScenario: Allow Some
     Given I load scenario "AutoInstrumentNetworkTracePropagationScenario"
-    And I configure "propagateTraceParentToUrlsMatching" to ".*test.*"
+    And I configure bugsng "propagateTraceParentToUrlsMatching" to ".*test.*"
     And I invoke "setCallSitesWithCallSiteStrs:" with parameter "?test=1,?temp=1"
     And I start bugsnag
     And I run the loaded scenario

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		098C3B2D2C523EC5006F9886 /* OnEndCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098C3B2C2C523EC5006F9886 /* OnEndCallbackScenario.swift */; };
 		098C3B502C53CEC0006F9886 /* ErrorGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 098C3B4F2C53CEC0006F9886 /* ErrorGenerator.m */; };
 		098C3B522C53CECF006F9886 /* SwiftErrorGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098C3B512C53CECF006F9886 /* SwiftErrorGenerator.swift */; };
+		098FC87C2D40EAB8001B627D /* CPUMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098FC87B2D40EAB8001B627D /* CPUMetricsScenario.swift */; };
 		099331FC2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099331FB2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift */; };
 		09D59E172BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D59E162BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift */; };
 		09D59E1D2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */; };
@@ -133,6 +134,7 @@
 		098C3B4E2C53CEC0006F9886 /* ErrorGenerator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ErrorGenerator.h; sourceTree = "<group>"; };
 		098C3B4F2C53CEC0006F9886 /* ErrorGenerator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ErrorGenerator.m; sourceTree = "<group>"; };
 		098C3B512C53CECF006F9886 /* SwiftErrorGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftErrorGenerator.swift; sourceTree = "<group>"; };
+		098FC87B2D40EAB8001B627D /* CPUMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPUMetricsScenario.swift; sourceTree = "<group>"; };
 		099331FB2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentAVAssetScenario.swift; sourceTree = "<group>"; };
 		09D59E162BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkTracePropagationScenario.swift; sourceTree = "<group>"; };
 		09D59E1C2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkTracePropagationScenario.swift; sourceTree = "<group>"; };
@@ -330,6 +332,7 @@
 				094F41E52C4A84D6008162A4 /* SetAttributesScenario.swift */,
 				09E0455E2C94662B003882D3 /* SetAttributesWithLimitsScenario.swift */,
 				09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */,
+				098FC87B2D40EAB8001B627D /* CPUMetricsScenario.swift */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -437,6 +440,7 @@
 				09D59E172BDFA23600199E1B /* ManualNetworkTracePropagationScenario.swift in Sources */,
 				96D528D02C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift in Sources */,
 				09D59E1D2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift in Sources */,
+				098FC87C2D40EAB8001B627D /* CPUMetricsScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */,
 				093EE63D2C32E5B900632B30 /* ManualParentSpanScenario.swift in Sources */,

--- a/features/fixtures/ios/Fixture/Fixture.swift
+++ b/features/fixtures/ios/Fixture/Fixture.swift
@@ -53,6 +53,11 @@ class Fixture: NSObject, CommandReceiver {
                                       value: command.args["value"] as! String)
                 self.readyToReceiveCommand = true
                 break
+            case "configure_scenario":
+                self.configureScenario(path: command.args["path"] as! String,
+                                      value: command.args["value"] as! String)
+                self.readyToReceiveCommand = true
+                break
             case "start_bugsnag":
                 self.startBugsnag()
                 self.readyToReceiveCommand = true
@@ -100,6 +105,11 @@ class Fixture: NSObject, CommandReceiver {
     private func configureBugsnag(path: String, value: String) {
         logInfo("Configuring bugsnag [\(path)] to [\(value)]")
         scenario!.configureBugsnag(path: path, value: value)
+    }
+
+    private func configureScenario(path: String, value: String) {
+        logInfo("Configuring scenario [\(path)] to [\(value)]")
+        scenario!.configureScenario(path: path, value: value)
     }
 
     private func startBugsnag() {

--- a/features/fixtures/ios/Scenarios/CPUMetricsScenario.swift
+++ b/features/fixtures/ios/Scenarios/CPUMetricsScenario.swift
@@ -1,0 +1,53 @@
+//
+//  CPUMetricsScenario.swift
+//  Fixture
+//
+//  Created by Karl Stenerud on 22.01.25.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class CPUMetricsScenario: Scenario {
+    override func run() {
+        let runDelay = toDouble(string: scenarioConfig["run_delay"])
+        DispatchQueue.main.asyncAfter(deadline: .now() + runDelay) {
+            self.delayedRun()
+        }
+
+        let workDuration = toDouble(string: scenarioConfig["work_duration"])
+        if workDuration > 0 {
+            var queue = DispatchQueue.global()
+            if scenarioConfig["work_on_thread"] == "main" {
+                queue = DispatchQueue.main
+            }
+            queue.asyncAfter(deadline: .now()) {
+                self.doBusyWork(forSeconds: workDuration);
+            }
+        }
+    }
+
+    func delayedRun() {
+        let opts = BugsnagPerformanceSpanOptions()
+        opts.setFirstClass(toTriState(string: scenarioConfig["opts_first_class"]))
+        opts.metricsOptions.cpu = toTriState(string: scenarioConfig["opts_metrics_cpu"])
+        let span = BugsnagPerformance.startSpan(name: "MySpan", options: opts)
+        let spanDuration = toDouble(string: scenarioConfig["span_duration"])
+        DispatchQueue.main.asyncAfter(deadline: .now() + spanDuration) {
+            span.end();
+        }
+    }
+
+    func doBusyWork(forSeconds: Double) {
+        let deadline = Date().addingTimeInterval(forSeconds);
+        let values = Array(0...1000000)
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        var encoded = try! encoder.encode(values)
+        var decoded = try! decoder.decode(Array<Int>.self, from: encoded)
+        while(Date() < deadline) {
+            encoded = try! encoder.encode(decoded)
+            decoded = try! decoder.decode(Array<Int>.self, from: encoded)
+        }
+    }
+}

--- a/features/fixtures/ios/Scenarios/FrameMetricsAutoInstrumentRenderingOffScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsAutoInstrumentRenderingOffScenario.swift
@@ -13,7 +13,7 @@ class FrameMetricsAutoInstrumentRenderingOffScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = false
+        config.enabledMetrics.rendering = false
     }
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/FrameMetricsFronzenFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsFronzenFramesScenario.swift
@@ -13,7 +13,7 @@ class FrameMetricsFronzenFramesScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.enabledMetrics.rendering = true
         config.internal.autoTriggerExportOnBatchSize = 3
     }
     

--- a/features/fixtures/ios/Scenarios/FrameMetricsNoSlowFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsNoSlowFramesScenario.swift
@@ -13,7 +13,7 @@ class FrameMetricsNoSlowFramesScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.enabledMetrics.rendering = true
     }
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift
@@ -13,12 +13,12 @@ class FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.enabledMetrics.rendering = true
     }
     
     override func run() {
         let options = BugsnagPerformanceSpanOptions()
-        options.setInstrumentRendering(.yes)
+        options.metricsOptions.rendering = (.yes)
         options.setFirstClass(.no)
         let span = BugsnagPerformance.startSpan(name: "FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario", options: options)
         

--- a/features/fixtures/ios/Scenarios/FrameMetricsSlowFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsSlowFramesScenario.swift
@@ -13,7 +13,7 @@ class FrameMetricsSlowFramesScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.enabledMetrics.rendering = true
     }
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/FrameMetricsSpanInstrumentRenderingOffScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsSpanInstrumentRenderingOffScenario.swift
@@ -13,12 +13,12 @@ class FrameMetricsSpanInstrumentRenderingOffScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.enabledMetrics.rendering = true
     }
     
     override func run() {
         let options = BugsnagPerformanceSpanOptions()
-        options.setInstrumentRendering(.no)
+        options.metricsOptions.rendering = (.no)
         let span = BugsnagPerformance.startSpan(name: "FrameMetricsSpanInstrumentRenderingOffScenario", options: options)
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {


### PR DESCRIPTION
## Goal

Spans can now capture periodic samples of CPU usage (process level, main thread, and overhead) at 1-second intervals.

This PR also harmonizes the various tri-state types used in BugsnagPerformance into a single type.

Deprecations:
* `BugsnagPerformanceConfiguration .autoInstrumentRendering` has been deprecated. Please use `BugsnagPerformanceConfiguration. enabledMetrics. rendering` instead.
* `BugsnagPerformanceSpanOptions.instrumentRendering` has been deprecated. Please use `BugsnagPerformanceSpanOptions.metricsOptions.rendering` instead.
* The `BSGFirstClass` type has been deprecated. Please use `BSGTriState` instead.
* The `BSGInstrumentRendering` type has been deprecated. Please use `BSGTriState` instead.


## Design

`BSGPSystemInfo` encapsulates the C interfaces for capturing system information.

`SystemInfoSampler` runs the thread that captures system information samples. The samples are stored in a `FixedLengthDequeue`, which ensures that the size of the deque never exceeds a pre-set maximum.

Spans are delayed by 1.5 seconds when they are sent for processing (see `BugsnagPerformanceImpl.mm` https://github.com/bugsnag/bugsnag-cocoa-performance/pull/377/files#diff-d85557b5b6af6b9c586beb2a68cffea708b4873d083bf7580f46818074dc1d95R311 ). This ensures that the sampler can capture at least 1 more sample before we apply the captured samples to the span's attributes (so that we have 1 sample before the span began, and 1 sample after it ended).

Added new `BugsnagPerformanceSpanMetricsOptions` object to `BugsnagPerformanceSpanOptions` which will hold current and future metrics configuration options when creating spans.

Added new `BugsnagPerformanceEnabledMetrics` object to `BugsnagPerformanceConfiguration`, which controls overall whether certain metrics are collected or not.

`BSGTriState` replaces `BSGFirstClass` and `BSGInstrumentRendering` types.

## Testing

New unit and e2e tests.
