### PR TITLE
Replace tri-state types with a single type, deprecating their uses in public APIs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', '~>9.0'
+gem 'bugsnag-maze-runner', '~>9.22.0'
 gem 'cocoapods'
-gem 'xcpretty'
+gem 'xcpretty', '~>0.3.0'
 
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'integration/v8'
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
@@ -83,7 +83,7 @@ using namespace bugsnag;
     }
 
     auto options = SpanOptions(optionsIn);
-    auto span = tracer->startSpan(name, options, BSGFirstClassUnset);
+    auto span = tracer->startSpan(name, options, BSGTriStateUnset);
     return (BugsnagPerformanceSpan *)[BugsnagPerformanceCrossTalkProxiedObject proxied:span];
 }
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -11,6 +11,7 @@
 #import "BugsnagPerformanceSpanContext+Private.h"
 #import "SpanKind.h"
 #import "FrameRateMetrics/FrameMetricsSnapshot.h"
+#import "SpanOptions.h"
 
 #import <memory>
 
@@ -35,6 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, copy) void (^onDumped)(BugsnagPerformanceSpan *);
 
+// These mark the actual times that the span was instantiated and ended,
+// irrespective of any time values this span will report.
+// We need this because we're recording metrics data in spans instead of metrics.
+@property (nonatomic) CFAbsoluteTime actuallyStartedAt;
+@property (nonatomic) CFAbsoluteTime actuallyEndedAt;
+
 @property (nonatomic) CFAbsoluteTime startAbsTime;
 @property (nonatomic) CFAbsoluteTime endAbsTime;
 @property (nonatomic) OnSpanDestroyAction onSpanDestroyAction;
@@ -44,13 +51,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) SpanLifecycleCallback onSpanClosed;
 @property (nonatomic,readwrite) SpanId parentId;
 @property (nonatomic) double samplingProbability;
-@property (nonatomic) BSGFirstClass firstClass;
+@property (nonatomic) BSGTriState firstClass;
 @property (nonatomic) SpanKind kind;
 @property (nonatomic,readwrite) BOOL isMutable;
 @property (nonatomic,readwrite) BOOL hasBeenProcessed;
 @property (nonatomic,readonly) NSUInteger attributeCountLimit;
 @property (nonatomic,readwrite) BOOL wasStartOrEndTimeProvided;
-@property (nonatomic) BSGInstrumentRendering instrumentRendering;
+@property (nonatomic) MetricsOptions metricsOptions;
 @property (nonatomic, strong) FrameMetricsSnapshot *startFramerateSnapshot;
 @property (nonatomic, strong) FrameMetricsSnapshot *endFramerateSnapshot;
 
@@ -65,9 +72,9 @@ NS_ASSUME_NONNULL_BEGIN
                       spanId:(SpanId) spanId
                     parentId:(SpanId) parentId
                    startTime:(CFAbsoluteTime) startTime
-                  firstClass:(BSGFirstClass) firstClass
+                  firstClass:(BSGTriState) firstClass
          attributeCountLimit:(NSUInteger)attributeCountLimit
-         instrumentRendering:(BSGInstrumentRendering)instrumentRendering
+              metricsOptions:(MetricsOptions) metricsOptions
                 onSpanEndSet:(SpanLifecycleCallback) onSpanEndSet
                 onSpanClosed:(SpanLifecycleCallback) onSpanEnded NS_DESIGNATED_INITIALIZER;
 
@@ -86,6 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateName:(NSString *)name;
 - (void)updateStartTime:(NSDate *)startTime;
 - (void)updateSamplingProbability:(double) value;
+
+- (void)forceMutate:(void (^)())block;
 
 @end
 

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
@@ -80,7 +80,7 @@ static const CGFloat kSlowFrameRatioThreshold = 1.3;
 - (void)earlySetup {}
 
 - (void)configure:(BugsnagPerformanceConfiguration *)config {
-    self.autoInstrumentRendering = config.autoInstrumentRendering;
+    self.autoInstrumentRendering = config.enabledMetrics.rendering;
 }
 
 - (void)start {

--- a/Sources/BugsnagPerformance/Private/Metrics.h
+++ b/Sources/BugsnagPerformance/Private/Metrics.h
@@ -1,0 +1,28 @@
+//
+//  Metrics.h
+//  BugsnagPerformance
+//
+//  Created by Karl Stenerud on 20.01.25.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
+
+namespace bugsnag {
+
+class MetricsOptions {
+public:
+    MetricsOptions() {}
+
+    MetricsOptions(BugsnagPerformanceSpanMetricsOptions *metrics)
+    : rendering(metrics.rendering)
+    , cpu(metrics.cpu)
+    {}
+
+    BSGTriState rendering{BSGTriStateUnset};
+    BSGTriState cpu{BSGTriStateUnset};
+};
+
+};

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -9,6 +9,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 #import "Utils.h"
+#import "Metrics.h"
 
 namespace bugsnag {
 
@@ -17,13 +18,13 @@ public:
     SpanOptions(BugsnagPerformanceSpanContext *parentContext,
                 CFAbsoluteTime startTime,
                 bool makeCurrentContext,
-                BSGFirstClass firstClass,
-                BSGInstrumentRendering instrumentRendering)
+                BSGTriState firstClass,
+                MetricsOptions metricsOptions)
     : parentContext(parentContext)
     , startTime(startTime)
     , makeCurrentContext(makeCurrentContext)
     , firstClass(firstClass)
-    , instrumentRendering(instrumentRendering)
+    , metricsOptions(metricsOptions)
     {}
     
     SpanOptions(BugsnagPerformanceSpanOptions *options)
@@ -31,7 +32,7 @@ public:
                   dateToAbsoluteTime(options.startTime),
                   options.makeCurrentContext,
                   options.firstClass,
-                  options.instrumentRendering)
+                  options.metricsOptions)
     {}
     
     SpanOptions()
@@ -39,15 +40,15 @@ public:
     : SpanOptions(nil,
                   CFABSOLUTETIME_INVALID,
                   true,
-                  BSGFirstClassUnset,
-                  BSGInstrumentRenderingUnset)
+                  BSGTriStateUnset,
+                  MetricsOptions())
     {}
     
     BugsnagPerformanceSpanContext *parentContext{nil};
     CFAbsoluteTime startTime{CFABSOLUTETIME_INVALID};
     bool makeCurrentContext{false};
-    BSGFirstClass firstClass{BSGFirstClassUnset};
-    BSGInstrumentRendering instrumentRendering{BSGInstrumentRenderingUnset};
+    BSGTriState firstClass{BSGTriStateUnset};
+    MetricsOptions metricsOptions;
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -40,7 +40,7 @@ public:
     void configure(BugsnagPerformanceConfiguration *config) noexcept {
         onSpanEndCallbacks_ = config.onSpanEndCallbacks;
         attributeCountLimit_ = config.attributeCountLimit;
-        autoInstrumentRendering_ = config.autoInstrumentRendering;
+        enabledMetrics_ = [config.enabledMetrics clone];
     };
     void preStartSetup() noexcept;
     void start() noexcept {}
@@ -49,8 +49,8 @@ public:
         onViewLoadSpanStarted_ = onViewLoadSpanStarted;
     }
 
-    BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept;
-    
+    BugsnagPerformanceSpan *startSpan(NSString *name, SpanOptions options, BSGTriState defaultFirstClass) noexcept;
+
     BugsnagPerformanceSpan *startAppStartSpan(NSString *name, SpanOptions options) noexcept;
 
     BugsnagPerformanceSpan *startCustomSpan(NSString *name, SpanOptions options) noexcept;
@@ -83,7 +83,7 @@ private:
     FrameMetricsCollector *frameMetricsCollector_;
 
     std::atomic<bool> willDiscardPrewarmSpans_{false};
-    std::atomic<bool> autoInstrumentRendering_{false};
+    BugsnagPerformanceEnabledMetrics *enabledMetrics_{nil};
     std::mutex prewarmSpansMutex_;
     NSMutableArray<BugsnagPerformanceSpan *> *prewarmSpans_;
     NSArray<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks_;

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -14,6 +14,7 @@
 #import "Instrumentation/ViewLoadInstrumentation.h"
 #import "BugsnagPerformanceLibrary.h"
 #import "FrameRateMetrics/FrameMetricsCollector.h"
+#import <algorithm>
 
 using namespace bugsnag;
 
@@ -59,10 +60,10 @@ void Tracer::reprocessEarlySpans(void) {
             [span abortUnconditionally];
             continue;
         }
-        span.isMutable = true;
-        [span updateSamplingProbability:sampler_->getProbability()];
-        callOnSpanEndCallbacks(span);
-        span.isMutable = false;
+        [span forceMutate:^() {
+            [span updateSamplingProbability:sampler_->getProbability()];
+            callOnSpanEndCallbacks(span);
+        }];
         if (span.state == SpanStateAborted) {
             BSGLogDebug(@"Tracer::reprocessEarlySpans: span %@ was rejected in the OnEnd callbacks, so dropping", span.name);
             [span abortUnconditionally];
@@ -89,7 +90,7 @@ Tracer::sweep() noexcept {
 }
 
 BugsnagPerformanceSpan *
-Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirstClass) noexcept {
+Tracer::startSpan(NSString *name, SpanOptions options, BSGTriState defaultFirstClass) noexcept {
     BSGLogDebug(@"Tracer::startSpan(%@, opts, %d)", name, defaultFirstClass);
     __block auto blockThis = this;
     auto parentSpan = options.parentContext;
@@ -103,8 +104,8 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
         BSGLogTrace(@"Tracer::startSpan: No parent traceId; generating one");
         traceId = IdGenerator::generateTraceId();
     }
-    BSGFirstClass firstClass = options.firstClass;
-    if (firstClass == BSGFirstClassUnset) {
+    BSGTriState firstClass = options.firstClass;
+    if (firstClass == BSGTriStateUnset) {
         BSGLogTrace(@"Tracer::startSpan: firstClass not specified; using default of %d", defaultFirstClass);
         firstClass = defaultFirstClass;
     }
@@ -115,6 +116,7 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
     auto onSpanClosed = ^(BugsnagPerformanceSpan * _Nonnull endedSpan) {
         blockThis->onSpanClosed(endedSpan);
     };
+
     BugsnagPerformanceSpan *span = [[BugsnagPerformanceSpan alloc] initWithName:name
                                                                         traceId:traceId
                                                                          spanId:spanId
@@ -122,7 +124,7 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGFirstClass defaultFirs
                                                                       startTime:options.startTime
                                                                      firstClass:firstClass
                                                             attributeCountLimit:attributeCountLimit_
-                                                            instrumentRendering: options.instrumentRendering
+                                                                 metricsOptions:options.metricsOptions
                                                                    onSpanEndSet:onSpanEndSet
                                                                    onSpanClosed:onSpanClosed];
     if (shouldInstrumentRendering(span)) {
@@ -238,13 +240,13 @@ void Tracer::processFrameMetrics(BugsnagPerformanceSpan *span) noexcept {
 BugsnagPerformanceSpan *
 Tracer::startAppStartSpan(NSString *name,
                         SpanOptions options) noexcept {
-    return startSpan(name, options, BSGFirstClassUnset);
+    return startSpan(name, options, BSGTriStateUnset);
 }
 
 BugsnagPerformanceSpan *
 Tracer::startCustomSpan(NSString *name,
                         SpanOptions options) noexcept {
-    return startSpan(name, options, BSGFirstClassYes);
+    return startSpan(name, options, BSGTriStateYes);
 }
 
 BugsnagPerformanceSpan *
@@ -256,12 +258,12 @@ Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
     NSString *type = getBugsnagPerformanceViewTypeName(viewType);
     onViewLoadSpanStarted_(className);
     NSString *name = [NSString stringWithFormat:@"[ViewLoad/%@]/%@", type, className];
-    if (options.firstClass == BSGFirstClassUnset) {
+    if (options.firstClass == BSGTriStateUnset) {
         if (spanStackingHandler_->hasSpanWithAttribute(@"bugsnag.span.category", @"view_load")) {
-            options.firstClass = BSGFirstClassNo;
+            options.firstClass = BSGTriStateNo;
         }
     }
-    auto span = startSpan(name, options, BSGFirstClassNo);
+    auto span = startSpan(name, options, BSGTriStateNo);
     if (willDiscardPrewarmSpans_) {
         markPrewarmSpan(span);
     }
@@ -271,7 +273,7 @@ Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
 BugsnagPerformanceSpan *
 Tracer::startNetworkSpan(NSString *httpMethod, SpanOptions options) noexcept {
     auto name = [NSString stringWithFormat:@"[HTTP/%@]", httpMethod];
-    auto span = startSpan(name, options, BSGFirstClassUnset);
+    auto span = startSpan(name, options, BSGTriStateUnset);
     span.kind = SPAN_KIND_CLIENT;
     return span;
 }
@@ -283,7 +285,7 @@ Tracer::startViewLoadPhaseSpan(NSString *className,
     NSString *name = [NSString stringWithFormat:@"[ViewLoadPhase/%@]/%@", phase, className];
     SpanOptions options;
     options.parentContext = parentContext;
-    auto span = startSpan(name, options, BSGFirstClassUnset);
+    auto span = startSpan(name, options, BSGTriStateUnset);
     if (willDiscardPrewarmSpans_) {
         markPrewarmSpan(span);
     }
@@ -314,7 +316,7 @@ Tracer::createFrozenFrameSpan(NSTimeInterval startTime,
     options.startTime = startTime;
     options.parentContext = parentContext;
     options.makeCurrentContext = false;
-    auto span = startSpan(@"FrozenFrame", options, BSGFirstClassNo);
+    auto span = startSpan(@"FrozenFrame", options, BSGTriStateNo);
     [span endWithAbsoluteTime:endTime];
 }
 
@@ -334,14 +336,14 @@ Tracer::onPrewarmPhaseEnded(void) noexcept {
 
 bool 
 Tracer::shouldInstrumentRendering(BugsnagPerformanceSpan *span) noexcept {
-    switch (span.instrumentRendering) {
-        case BSGInstrumentRenderingYes:
-            return autoInstrumentRendering_;
-        case BSGInstrumentRenderingNo:
+    switch (span.metricsOptions.rendering) {
+        case BSGTriStateYes:
+            return enabledMetrics_.rendering;
+        case BSGTriStateNo:
             return false;
-        case BSGInstrumentRenderingUnset:
-            return autoInstrumentRendering_ &&
+        case BSGTriStateUnset:
+            return enabledMetrics_.rendering &&
             !span.wasStartOrEndTimeProvided && 
-            span.firstClass == BSGFirstClassYes;
+            span.firstClass == BSGTriStateYes;
     }
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -24,6 +24,26 @@ using namespace bugsnag;
 #define MAX_ATTRIBUTE_COUNT_LIMIT 1000
 #define DEFAULT_ATTRIBUTE_COUNT_LIMIT 128
 
+@implementation BugsnagPerformanceEnabledMetrics
+
+- (instancetype) initWithRendering:(BOOL)rendering cpu:(BOOL)cpu {
+    if ((self = [super init])) {
+        _rendering = rendering;
+        _cpu = cpu;
+    }
+    return self;
+}
+
+- (instancetype) init {
+    return [self initWithRendering:NO cpu:NO];
+}
+
+- (instancetype) clone {
+    return [[BugsnagPerformanceEnabledMetrics alloc] initWithRendering:self.rendering cpu:self.cpu];
+}
+
+@end
+
 @implementation BugsnagPerformanceConfiguration
 
 - (instancetype)initWithApiKey:(NSString *)apiKey {
@@ -34,7 +54,7 @@ using namespace bugsnag;
         _autoInstrumentAppStarts = YES;
         _autoInstrumentViewControllers = YES;
         _autoInstrumentNetworkRequests = YES;
-        _autoInstrumentRendering = NO;
+        _enabledMetrics = [BugsnagPerformanceEnabledMetrics new];
         _onSpanEndCallbacks = [NSMutableArray array];
         _attributeArrayLengthLimit = DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT;
         _attributeStringValueLimit = DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT;
@@ -46,6 +66,14 @@ using namespace bugsnag;
 #endif
     }
     return self;
+}
+
+- (void)setAutoInstrumentRendering:(BOOL)autoInstrumentRendering {
+    self.enabledMetrics.rendering = autoInstrumentRendering;
+}
+
+- (BOOL)autoInstrumentRendering {
+    return self.enabledMetrics.rendering;
 }
 
 static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInteger max, NSUInteger def) {
@@ -146,7 +174,7 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
         configuration.autoInstrumentNetworkRequests = [autoInstrumentNetworkRequests boolValue];
     }
     if (autoInstrumentRendering != nil) {
-        configuration.autoInstrumentRendering = [autoInstrumentRendering boolValue];
+        configuration.enabledMetrics.rendering = [autoInstrumentRendering boolValue];
     }
     if (samplingProbability != nil) {
         configuration.samplingProbability = samplingProbability;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -10,12 +10,33 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 
+@implementation BugsnagPerformanceSpanMetricsOptions
+
+- (instancetype)initWithRendering:(BSGTriState)rendering
+                              cpu:(BSGTriState)cpu {
+    if ((self = [super init])) {
+        _rendering = rendering;
+        _cpu = cpu;
+    }
+    return self;
+}
+
+- (instancetype)init {
+    return [self initWithRendering:BSGTriStateUnset cpu:BSGTriStateUnset];
+}
+
+- (instancetype)clone {
+    return [[BugsnagPerformanceSpanMetricsOptions alloc] initWithRendering:self.rendering
+                                                                       cpu:self.cpu];
+}
+
+@end
+
 @interface BugsnagPerformanceSpanOptions()
 @property(nonatomic,strong) NSDate *startTime_;
 @property(nonatomic,strong) BugsnagPerformanceSpanContext *parentContext_;
 @property(nonatomic) BOOL makeCurrentContext_;
-@property(nonatomic) BSGFirstClass firstClass_;
-@property(nonatomic) BSGInstrumentRendering instrumentRendering_;
+@property(nonatomic) BSGTriState firstClass_;
 @end
 
 @implementation BugsnagPerformanceSpanOptions
@@ -24,28 +45,27 @@
 @synthesize parentContext_ = _parentContext;
 @synthesize makeCurrentContext_ = _makeCurrentContext;
 @synthesize firstClass_ = _firstClass;
-@synthesize instrumentRendering_ = _instrumentRendering;
 
 - (instancetype)init {
     // These defaults must match the defaults in SpanOptions.h
     return [self initWithStartTime:nil
                      parentContext:nil
                 makeCurrentContext:true
-                        firstClass:BSGFirstClassUnset
-               instrumentRendering:BSGInstrumentRenderingUnset];
+                        firstClass:BSGTriStateUnset
+                    metricsOptions:[BugsnagPerformanceSpanMetricsOptions new]];
 }
 
 - (instancetype)initWithStartTime:(NSDate *)startTime
                     parentContext:(BugsnagPerformanceSpanContext *)parentContext
                makeCurrentContext:(BOOL)makeCurrentContext
-                       firstClass:(BSGFirstClass)firstClass
-              instrumentRendering:(BSGInstrumentRendering)instrumentRendering {
+                       firstClass:(BSGTriState)firstClass
+                   metricsOptions:(BugsnagPerformanceSpanMetricsOptions *)metricsOptions {
     if ((self = [super init])) {
         _startTime = startTime;
         _parentContext = parentContext;
         _makeCurrentContext = makeCurrentContext;
         _firstClass = firstClass;
-        _instrumentRendering = instrumentRendering;
+        _metricsOptions = metricsOptions;
     }
     return self;
 }
@@ -65,14 +85,14 @@
     return _makeCurrentContext;
 }
 
-- (BSGFirstClass)firstClass {
+- (BSGTriState)firstClass {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     return _firstClass;
 }
 
-- (BSGInstrumentRendering)instrumentRendering {
+- (BSGTriState)instrumentRendering {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    return _instrumentRendering;
+    return _metricsOptions.rendering;
 }
 
 - (instancetype)setStartTime:(NSDate *)startTime {
@@ -93,15 +113,15 @@
     return self;
 }
 
-- (instancetype)setFirstClass:(BSGFirstClass)firstClass {
+- (instancetype)setFirstClass:(BSGTriState)firstClass {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     _firstClass = firstClass;
     return self;
 }
 
-- (instancetype _Nonnull)setInstrumentRendering:(BSGInstrumentRendering)instrumentRendering {
+- (instancetype _Nonnull)setInstrumentRendering:(BSGTriState)instrumentRendering {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    _instrumentRendering = instrumentRendering;
+    _metricsOptions.rendering = instrumentRendering;
     return self;
 }
 
@@ -111,7 +131,7 @@
                                                       parentContext:_parentContext
                                                  makeCurrentContext:_makeCurrentContext
                                                          firstClass:_firstClass
-                                                instrumentRendering:_instrumentRendering];
+                                                     metricsOptions:[self.metricsOptions clone]];
 }
 
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -18,6 +18,16 @@ typedef BOOL (^ BugsnagPerformanceViewControllerInstrumentationCallback)(UIViewC
 typedef BOOL (^ BugsnagPerformanceSpanEndCallback)(BugsnagPerformanceSpan *span);
 
 OBJC_EXPORT
+@interface BugsnagPerformanceEnabledMetrics : NSObject
+
+@property(nonatomic) BOOL rendering; // (default NO)
+@property(nonatomic) BOOL cpu;       // (default NO)
+
+- (instancetype) clone;
+
+@end
+
+OBJC_EXPORT
 @interface BugsnagPerformanceConfiguration : NSObject
 
 - (instancetype)initWithApiKey:(NSString *)apiKey NS_DESIGNATED_INITIALIZER;
@@ -44,7 +54,9 @@ OBJC_EXPORT
 
 @property (nonatomic) BOOL autoInstrumentNetworkRequests;
 
-@property (nonatomic) BOOL autoInstrumentRendering;
+@property (nonatomic) BOOL autoInstrumentRendering DEPRECATED_ATTRIBUTE;
+
+@property(nonatomic,strong) BugsnagPerformanceEnabledMetrics *enabledMetrics;
 
 /**
  *  The version of the application

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -8,17 +8,46 @@
 
 #import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 
+typedef NS_ENUM(uint8_t, BSGTriState) {
+    BSGTriStateNo = 0,
+    BSGTriStateYes = 1,
+    BSGTriStateUnset = 2,
+};
+
+@interface BugsnagPerformanceSpanMetricsOptions : NSObject
+
+/**
+ * No = never include these metrics
+ * Yes = Always include these metrics, as long as the corresponding enabledMetrics configuration option is on
+ * Unset = Include metrics only if the span is first class, start and end times were not set when creating/closing
+ *       the span and the corresponding enabledMetrics configuration option is on
+ * Default: Unset
+ */
+@property(nonatomic) BSGTriState rendering;
+
+/**
+ * No = never include these metrics
+ * Yes = Always include these metrics, as long as the corresponding enabledMetrics configuration option is on
+ * Unset = Include metrics only if the span is first class and the corresponding enabledMetrics configuration option is on
+ * Default: Unset
+ */
+@property(nonatomic) BSGTriState cpu;
+
+- (_Nonnull instancetype)clone;
+
+@end
+
 typedef NS_ENUM(uint8_t, BSGFirstClass) {
-    BSGFirstClassNo = 0,
-    BSGFirstClassYes = 1,
-    BSGFirstClassUnset = 2,
+    BSGFirstClassNo __attribute__((deprecated)) = BSGTriStateNo,
+    BSGFirstClassYes __attribute__((deprecated)) = BSGTriStateYes,
+    BSGFirstClassUnset __attribute__((deprecated)) = BSGTriStateUnset,
 };
 
 // Affects whether or not a span should include rendering metrics
 typedef NS_ENUM(uint8_t, BSGInstrumentRendering) {
-    BSGInstrumentRenderingNo = 0, // Never include rendering metrics
-    BSGInstrumentRenderingYes = 1, // Always include rendering metrics, as long as the autoInstrumentRendering configuration option is on
-    BSGInstrumentRenderingUnset = 2, // Include rendering metrics only if the span is first class, start and end times were not set when creating/closing the span and the autoInstrumentRendering configuration option is on
+    BSGInstrumentRenderingNo __attribute__((deprecated)) = BSGTriStateNo, // Never include rendering metrics
+    BSGInstrumentRenderingYes __attribute__((deprecated)) = BSGTriStateYes, // Always include rendering metrics, as long as the autoInstrumentRendering configuration option is on
+    BSGInstrumentRenderingUnset __attribute__((deprecated)) = BSGTriStateUnset, // Include rendering metrics only if the span is first class, start and end times were not set when creating/closing the span and the autoInstrumentRendering configuration option is on
 };
 
 // Span options allow the user to affect how spans are created.
@@ -35,15 +64,17 @@ OBJC_EXPORT
 @property(nonatomic, readonly) BOOL makeCurrentContext;
 
 // If true, this span will be considered "first class" on the dashboard.
-@property(nonatomic, readonly) BSGFirstClass firstClass;
+@property(nonatomic, readonly) BSGTriState firstClass;
 
-@property(nonatomic, readonly) BSGInstrumentRendering instrumentRendering;
+@property(nonatomic, readonly) BSGTriState instrumentRendering DEPRECATED_ATTRIBUTE;
+
+@property(nonatomic, strong) BugsnagPerformanceSpanMetricsOptions * _Nonnull metricsOptions;
 
 - (instancetype _Nonnull)setStartTime:(NSDate * _Nullable)startTime;
 - (instancetype _Nonnull)setParentContext:(BugsnagPerformanceSpanContext * _Nullable)parentContext;
 - (instancetype _Nonnull)setMakeCurrentContext:(BOOL)makeCurrentContext;
-- (instancetype _Nonnull)setFirstClass:(BSGFirstClass)firstClass;
-- (instancetype _Nonnull)setInstrumentRendering:(BSGInstrumentRendering)instrumentRendering;
+- (instancetype _Nonnull)setFirstClass:(BSGTriState)firstClass;
+- (instancetype _Nonnull)setInstrumentRendering:(BSGTriState)instrumentRendering DEPRECATED_ATTRIBUTE;
 
 - (instancetype _Nonnull)clone;
 

--- a/Tests/BugsnagPerformanceTests/BatchTests.mm
+++ b/Tests/BugsnagPerformanceTests/BatchTests.mm
@@ -19,14 +19,15 @@ using namespace bugsnag;
 
 static BugsnagPerformanceSpan *newSpanData() {
     TraceId tid = {.value = 1};
-    return [[BugsnagPerformanceSpan alloc] initWithName:@"test" 
+    MetricsOptions metricsOptions;
+    return [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                 traceId:tid
                                                  spanId:1
                                                parentId:0
                                               startTime:0
-                                             firstClass:BSGFirstClassUnset
+                                             firstClass:BSGTriStateUnset
                                     attributeCountLimit:128
-                                    instrumentRendering:BSGInstrumentRenderingNo
+                                         metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
@@ -135,7 +135,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
-    XCTAssertFalse(config.autoInstrumentRendering);
+    XCTAssertFalse(config.enabledMetrics.rendering);
 }
 
 - (void)testLoadConfigDoesntTakeValuesFromBugsnagWhenAllValuesAreInPerformanceDictionary {
@@ -181,7 +181,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
-    XCTAssertTrue(config.autoInstrumentRendering);
+    XCTAssertTrue(config.enabledMetrics.rendering);
 }
 
 - (void)testLoadConfigDoesTakeValuesFromBugsnagWhenSomeValuesAreMissingInPerformanceDictionary {
@@ -212,7 +212,7 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertFalse(config.autoInstrumentAppStarts);
     XCTAssertFalse(config.autoInstrumentViewControllers);
     XCTAssertTrue(config.autoInstrumentNetworkRequests);
-    XCTAssertTrue(config.autoInstrumentRendering);
+    XCTAssertTrue(config.enabledMetrics.rendering);
 }
 
 - (void)testShouldSetIncludeApiKeyInTheDefaultEndpoint {

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -176,7 +176,9 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                   spanId:(SpanId) spanId
                                 parentId:(SpanId) parentId
                                startTime:(CFAbsoluteTime) startAbsTime
-                              firstClass:(BSGFirstClass) firstClass {
+                              firstClass:(BSGTriState) firstClass {
+    MetricsOptions metricsOptions;
+    metricsOptions.rendering = BSGTriStateNo;
     return [[BugsnagPerformanceSpan alloc] initWithName:name
                                                 traceId:traceId
                                                  spanId:spanId
@@ -184,7 +186,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                               startTime:startAbsTime
                                              firstClass:firstClass
                                     attributeCountLimit:128
-                                    instrumentRendering:BSGInstrumentRenderingNo
+                                         metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {}];
 }
@@ -198,7 +200,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:CFAbsoluteTimeGetCurrent()
-                             firstClass:BSGFirstClassYes]];
+                             firstClass:BSGTriStateYes]];
     auto json = encoder->encode(spans, @{});
     
     XCTAssertIsKindOfClass(json[@"resourceSpans"], [NSArray class]);
@@ -224,7 +226,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:CFAbsoluteTimeGetCurrent()
-                             firstClass:BSGFirstClassNo]];
+                             firstClass:BSGTriStateNo]];
     auto json = encoder->encode(spans, @{});
     
     XCTAssertIsKindOfClass(json[@"resourceSpans"], [NSArray class]);
@@ -250,7 +252,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:CFAbsoluteTimeGetCurrent()
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     auto json = encoder->encode(spans, @{});
     
     XCTAssertIsKindOfClass(json[@"resourceSpans"], [NSArray class]);
@@ -280,7 +282,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                                spanId:0xface
                                              parentId:0
                                             startTime:startTime
-                                           firstClass:BSGFirstClassUnset];
+                                           firstClass:BSGTriStateUnset];
     [span setEndAbsTime:startTime + 15];
     
     auto json = encoder->encode(span);
@@ -316,7 +318,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                                spanId:0xface
                                              parentId:0xcafe
                                             startTime:startTime
-                                           firstClass:BSGFirstClassUnset];
+                                           firstClass:BSGTriStateUnset];
     [span setEndAbsTime:startTime + 15];
     
     auto json = encoder->encode(span);
@@ -366,7 +368,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     auto resourceAttributes = @{};
     auto package = encoder->buildUploadPackage(spans, resourceAttributes, true);
 
@@ -389,7 +391,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.3];
 
     auto resourceAttributes = @{};
@@ -408,13 +410,13 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test2"
                                 traceId:tid
                                  spanId:2
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.3];
     [spans[1] updateSamplingProbability:0.1];
 
@@ -434,13 +436,13 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test2"
                                 traceId:tid
                                  spanId:2
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.5];
     [spans[1] updateSamplingProbability:0.5];
 
@@ -460,31 +462,31 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test2"
                                 traceId:tid
                                  spanId:2
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test3"
                                 traceId:tid
                                  spanId:3
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test4"
                                 traceId:tid
                                  spanId:4
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test5"
                                 traceId:tid
                                  spanId:5
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.3];
     [spans[1] updateSamplingProbability:0.1];
     [spans[2] updateSamplingProbability:0.3];
@@ -507,67 +509,67 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test1"
                                 traceId:tid
                                  spanId:2
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test2"
                                 traceId:tid
                                  spanId:3
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test3"
                                 traceId:tid
                                  spanId:4
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test4"
                                 traceId:tid
                                  spanId:5
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test5"
                                 traceId:tid
                                  spanId:6
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test6"
                                 traceId:tid
                                  spanId:7
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test7"
                                 traceId:tid
                                  spanId:8
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test8"
                                 traceId:tid
                                  spanId:9
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test9"
                                 traceId:tid
                                  spanId:10
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test10"
                                 traceId:tid
                                  spanId:11
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.0];
     [spans[1] updateSamplingProbability:0.1];
     [spans[2] updateSamplingProbability:0.2];
@@ -596,31 +598,31 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                  spanId:1
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test2"
                                 traceId:tid
                                  spanId:2
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test3"
                                 traceId:tid
                                  spanId:3
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test4"
                                 traceId:tid
                                  spanId:4
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans addObject:[self spanWithName:@"test5"
                                 traceId:tid
                                  spanId:5
                                parentId:0
                               startTime:0
-                             firstClass:BSGFirstClassUnset]];
+                             firstClass:BSGTriStateUnset]];
     [spans[0] updateSamplingProbability:0.3];
     [spans[1] updateSamplingProbability:0.1];
     [spans[2] updateSamplingProbability:0.3];

--- a/Tests/BugsnagPerformanceTests/SamplerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SamplerTests.mm
@@ -59,14 +59,15 @@ using namespace bugsnag;
     auto numSamplesTries = 1'000;
     auto count = 0;
     for (auto i = 0; i < numSamplesTries; i++) {
+        MetricsOptions metricsOptions;
         BugsnagPerformanceSpan *span = [[BugsnagPerformanceSpan alloc] initWithName:@"a"
                                                                             traceId:IdGenerator::generateTraceId()
                                                                              spanId:IdGenerator::generateSpanId()
                                                                            parentId:0
                                                                           startTime:0
-                                                                         firstClass:BSGFirstClassUnset
+                                                                         firstClass:BSGTriStateUnset
                                                                 attributeCountLimit:128
-                                                                instrumentRendering:BSGInstrumentRenderingNo
+                                                                     metricsOptions:metricsOptions
                                                                        onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                                                        onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
         }];

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -28,7 +28,7 @@ using namespace bugsnag;
     XCTAssertNil(objcOptions.parentContext);
     XCTAssertNil(objcOptions.startTime);
     XCTAssertTrue(objcOptions.makeCurrentContext);
-    XCTAssertEqual(objcOptions.firstClass, BSGFirstClassUnset);
+    XCTAssertEqual(objcOptions.firstClass, BSGTriStateUnset);
 }
 
 - (void)testConversionDefaults {
@@ -37,18 +37,20 @@ using namespace bugsnag;
     XCTAssertNil(cOptions.parentContext);
     XCTAssertTrue(isnan(cOptions.startTime));
     XCTAssertTrue(cOptions.makeCurrentContext);
-    XCTAssertEqual(cOptions.firstClass, BSGFirstClassUnset);
+    XCTAssertEqual(cOptions.firstClass, BSGTriStateUnset);
 }
 
 - (void)testConversion {
-    BugsnagPerformanceSpan *span = [[BugsnagPerformanceSpan alloc] initWithName:@"test" 
+    MetricsOptions metricsOptions;
+    metricsOptions.rendering = BSGTriStateNo;
+    BugsnagPerformanceSpan *span = [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                                         traceId:IdGenerator::generateTraceId()
                                                                          spanId:IdGenerator::generateSpanId()
                                                                        parentId:IdGenerator::generateSpanId()
                                                                       startTime:SpanOptions().startTime 
-                                                                     firstClass:BSGFirstClassNo
+                                                                     firstClass:BSGTriStateNo
                                                             attributeCountLimit:128
-                                                            instrumentRendering:BSGInstrumentRenderingNo
+                                                                 metricsOptions:metricsOptions
                                                                    onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                                                    onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];
@@ -56,13 +58,13 @@ using namespace bugsnag;
     objcOptions.startTime = [NSDate dateWithTimeIntervalSinceReferenceDate:1.0];
     objcOptions.parentContext = span;
     objcOptions.makeCurrentContext = true;
-    objcOptions.firstClass = BSGFirstClassNo;
+    objcOptions.firstClass = BSGTriStateNo;
     
     SpanOptions cOptions(objcOptions);
     XCTAssertEqual(1.0, cOptions.startTime);
     XCTAssertEqual(span, cOptions.parentContext);
     XCTAssertEqual(true, cOptions.makeCurrentContext);
-    XCTAssertEqual(BSGFirstClassNo, cOptions.firstClass);
+    XCTAssertEqual(BSGTriStateNo, cOptions.firstClass);
 }
 
 @end

--- a/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
@@ -17,14 +17,15 @@
 using namespace bugsnag;
 
 static BugsnagPerformanceSpan *createSpan(std::shared_ptr<SpanStackingHandler> handler) {
+    MetricsOptions metricsOptions;
     return [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                 traceId:IdGenerator::generateTraceId()
                                                  spanId:IdGenerator::generateSpanId()
                                                parentId:IdGenerator::generateSpanId()
                                               startTime:SpanOptions().startTime
-                                             firstClass:BSGFirstClassNo
+                                             firstClass:BSGTriStateNo
                                     attributeCountLimit:128
-                                    instrumentRendering:BSGInstrumentRenderingNo
+                                         metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull span) {
         handler->onSpanClosed(span.spanId);

--- a/Tests/BugsnagPerformanceTests/SpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanTests.mm
@@ -20,14 +20,16 @@ using namespace bugsnag;
 
 static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanLifecycleCallback onEnded) {
     TraceId tid = {.value = 1};
+    MetricsOptions metricsOptions;
+    metricsOptions.rendering = BSGTriStateNo;
     return [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                 traceId:tid
                                                  spanId:1
                                                parentId:0
                                               startTime:startTime
-                                             firstClass:BSGFirstClassUnset
+                                             firstClass:BSGTriStateUnset
                                     attributeCountLimit:128
-                                    instrumentRendering:BSGInstrumentRenderingNo
+                                         metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan *) {}
                                            onSpanClosed:onEnded];
 }
@@ -39,6 +41,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, CFAbsoluteTimeGetCurrent(), 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartNearPastEndUnset {
@@ -48,6 +52,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, CFAbsoluteTimeGetCurrent(), 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartUnsetEndNearPast {
@@ -57,6 +63,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, endTime, 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartUnsetEndNearFuture {
@@ -66,6 +74,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, endTime, 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartNearPastEndNearFuture {
@@ -75,6 +85,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, endTime, 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartFarPastEndUnset {
@@ -84,6 +96,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqualWithAccuracy(span.endAbsTime, CFAbsoluteTimeGetCurrent(), 0.001);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartFarPastEndNearPast {
@@ -93,6 +107,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartFarPastEndNearFuture {
@@ -102,6 +118,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartNowEndFarFuture {
@@ -111,6 +129,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartFarPastEndFarFuture {
@@ -120,6 +140,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartNearPastEndFarFuture {
@@ -129,6 +151,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartNearFutureEndFarFuture {
@@ -138,6 +162,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testStartEndDistantPast {
@@ -147,6 +173,8 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
     BugsnagPerformanceSpan *span = spanWithStartTime(startTime, ^(BugsnagPerformanceSpan *cbSpan) {foundSpan = cbSpan;});
     [span endWithAbsoluteTime:endTime];
     XCTAssertEqual(span.endAbsTime, endTime);
+    XCTAssertTrue(!isnan(span.actuallyStartedAt));
+    XCTAssertTrue(!isnan(span.actuallyEndedAt));
 }
 
 - (void)testAddRemoveAttributes {
@@ -270,15 +298,16 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
 }
 
 - (void)testTooManyAttributes {
+    MetricsOptions metricsOptions;
     TraceId tid = {.value = 1};
     auto span = [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                      traceId:tid
                                                       spanId:1
                                                     parentId:0
                                                    startTime:0
-                                                  firstClass:BSGFirstClassUnset
+                                                  firstClass:BSGTriStateUnset
                                          attributeCountLimit:5
-                                         instrumentRendering:BSGInstrumentRenderingNo
+                                              metricsOptions:metricsOptions
                                                 onSpanEndSet:^(BugsnagPerformanceSpan *) {}
                                                 onSpanClosed:^(BugsnagPerformanceSpan *) {}];
 

--- a/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
+++ b/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
@@ -19,14 +19,15 @@ using namespace bugsnag;
 @end
 
 static BugsnagPerformanceSpan *createSpan() {
+    MetricsOptions metricsOptions;
     return [[BugsnagPerformanceSpan alloc] initWithName:@"test"
                                                 traceId:IdGenerator::generateTraceId()
                                                  spanId:IdGenerator::generateSpanId()
                                                parentId:IdGenerator::generateSpanId()
                                               startTime:SpanOptions().startTime 
-                                             firstClass:BSGFirstClassNo
+                                             firstClass:BSGTriStateNo
                                     attributeCountLimit:128
-                                    instrumentRendering:BSGInstrumentRenderingNo
+                                         metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
                                            onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {
     }];

--- a/features/fixtures/ios/Scenarios/FrameMetricsAutoInstrumentRenderingOffScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsAutoInstrumentRenderingOffScenario.swift
@@ -13,7 +13,7 @@ class FrameMetricsAutoInstrumentRenderingOffScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = false
+        config.enabledMetrics.rendering = false
     }
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/FrameMetricsFronzenFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsFronzenFramesScenario.swift
@@ -13,7 +13,7 @@ class FrameMetricsFronzenFramesScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.enabledMetrics.rendering = true
         config.internal.autoTriggerExportOnBatchSize = 3
     }
     

--- a/features/fixtures/ios/Scenarios/FrameMetricsNoSlowFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsNoSlowFramesScenario.swift
@@ -13,7 +13,7 @@ class FrameMetricsNoSlowFramesScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.enabledMetrics.rendering = true
     }
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario.swift
@@ -13,12 +13,12 @@ class FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.enabledMetrics.rendering = true
     }
     
     override func run() {
         let options = BugsnagPerformanceSpanOptions()
-        options.setInstrumentRendering(.yes)
+        options.metricsOptions.rendering = (.yes)
         options.setFirstClass(.no)
         let span = BugsnagPerformance.startSpan(name: "FrameMetricsNonFirstClassSpanInstrumentRenderingOnScenario", options: options)
         

--- a/features/fixtures/ios/Scenarios/FrameMetricsSlowFramesScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsSlowFramesScenario.swift
@@ -13,7 +13,7 @@ class FrameMetricsSlowFramesScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.enabledMetrics.rendering = true
     }
     
     override func run() {

--- a/features/fixtures/ios/Scenarios/FrameMetricsSpanInstrumentRenderingOffScenario.swift
+++ b/features/fixtures/ios/Scenarios/FrameMetricsSpanInstrumentRenderingOffScenario.swift
@@ -13,12 +13,12 @@ class FrameMetricsSpanInstrumentRenderingOffScenario: Scenario {
     
     override func configure() {
         super.configure()
-        config.autoInstrumentRendering = true
+        config.enabledMetrics.rendering = true
     }
     
     override func run() {
         let options = BugsnagPerformanceSpanOptions()
-        options.setInstrumentRendering(.no)
+        options.metricsOptions.rendering = (.no)
         let span = BugsnagPerformance.startSpan(name: "FrameMetricsSpanInstrumentRenderingOffScenario", options: options)
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -15,6 +15,7 @@ die() {
 	exit $status
 }
 
+bundle install
 
 echo "--- Analyze"
 


### PR DESCRIPTION
This simplifies the interface and avoids needing yet another tri-state type when CPU metrics are added in the next PR.

This also introduces metrics config and option objects, which will hold all of the different metric types.

Note: There is some CPU configuration stuff in here (but no implementations). It makes it easier to just split by file in this case, even though it doesn't make semantic sense between PRs.

Deprecations:
* `BugsnagPerformanceConfiguration .autoInstrumentRendering` has been deprecated. Please use `BugsnagPerformanceConfiguration. enabledMetrics. rendering` instead.
* `BugsnagPerformanceSpanOptions.instrumentRendering` has been deprecated. Please use `BugsnagPerformanceSpanOptions.metricsOptions.rendering` instead.
* The `BSGFirstClass` type has been deprecated. Please use `BSGTriState` instead.
* The `BSGInstrumentRendering` type has been deprecated. Please use `BSGTriState` instead.

## Design

Added new `BugsnagPerformanceSpanMetricsOptions` object to `BugsnagPerformanceSpanOptions` which will hold current and future metrics configuration options when creating spans.

Added new `BugsnagPerformanceEnabledMetrics` object to `BugsnagPerformanceConfiguration`, which controls overall whether certain metrics are collected or not.

`BSGTriState` replaces `BSGFirstClass` and `BSGInstrumentRendering` types.
