### PR TITLE
Adjust all pre loaded view load child spans

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		967F6F1829C3783B0054EED8 /* BugsnagPerformanceConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */; };
 		968AA5FB2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 968AA5FA2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h */; };
 		968AA5FD2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm in Sources */ = {isa = PBXBuildFile; fileRef = 968AA5FC2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm */; };
+		96986DBF2D5EA1A300A44C34 /* BSGWeakViewControllerList.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96986DBE2D5EA1A300A44C34 /* BSGWeakViewControllerList.mm */; };
+		96986DC12D5EA1CF00A44C34 /* BSGSpanConditionsPool.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96986DC02D5EA1CF00A44C34 /* BSGSpanConditionsPool.mm */; };
 		96D415F329E6ADC500AEE435 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D415F229E6ADC500AEE435 /* AppDelegate.swift */; };
 		96D415F729E6ADC500AEE435 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D415F629E6ADC500AEE435 /* ViewController.swift */; };
 		96D415FA29E6ADC500AEE435 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 96D415F829E6ADC500AEE435 /* Main.storyboard */; };
@@ -342,6 +344,10 @@
 		967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
 		968AA5FA2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGPerformanceSharedSessionProxy.h; sourceTree = "<group>"; };
 		968AA5FC2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGPerformanceSharedSessionProxy.mm; sourceTree = "<group>"; };
+		96986DBD2D5EA18700A44C34 /* BSGWeakViewControllerList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGWeakViewControllerList.h; sourceTree = "<group>"; };
+		96986DBE2D5EA1A300A44C34 /* BSGWeakViewControllerList.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGWeakViewControllerList.mm; sourceTree = "<group>"; };
+		96986DC02D5EA1CF00A44C34 /* BSGSpanConditionsPool.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGSpanConditionsPool.mm; sourceTree = "<group>"; };
+		96986DC22D5EA1E500A44C34 /* BSGSpanConditionsPool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGSpanConditionsPool.h; sourceTree = "<group>"; };
 		96D415F029E6ADC500AEE435 /* BugsnagPerformanceTestsApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BugsnagPerformanceTestsApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		96D415F229E6ADC500AEE435 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		96D415F629E6ADC500AEE435 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -557,6 +563,10 @@
 				CB572EA829BB783200FD7A2A /* AppStateTracker.h */,
 				CB572EA929BB783200FD7A2A /* AppStateTracker.m */,
 				CBE8EA1C294B5E1500702950 /* Batch.h */,
+				96986DC22D5EA1E500A44C34 /* BSGSpanConditionsPool.h */,
+				96986DC02D5EA1CF00A44C34 /* BSGSpanConditionsPool.mm */,
+				96986DBD2D5EA18700A44C34 /* BSGWeakViewControllerList.h */,
+				96986DBE2D5EA1A300A44C34 /* BSGWeakViewControllerList.mm */,
 				967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */,
 				09FFD43E2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.h */,
 				09FFD43F2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm */,
@@ -565,6 +575,7 @@
 				CB78819B29E587CE00A58906 /* BugsnagPerformanceLibrary.h */,
 				CB78819A29E587CE00A58906 /* BugsnagPerformanceLibrary.mm */,
 				0122C23229019770002D243C /* BugsnagPerformanceSpan+Private.h */,
+				964B78552D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm */,
 				964B785E2D504FD800FF077D /* BugsnagPerformanceSpanCondition+Private.h */,
 				09DC62282C6A2EF6000AA8E1 /* BugsnagPerformanceSpanContext+Private.h */,
 				CBE0873029FA984C007455F2 /* BugsnagPerformanceViewType.mm */,
@@ -612,7 +623,6 @@
 				01A414CC2913C0F0003152A4 /* SpanAttributes.mm */,
 				96D4160D29F276FE00AEE435 /* SpanAttributesProvider.h */,
 				96D4160B29F276E400AEE435 /* SpanAttributesProvider.mm */,
-				964B78552D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm */,
 				0122C22329019770002D243C /* SpanKind.h */,
 				CB7FD935299D330500499E13 /* SpanOptions.h */,
 				96D55C7D2A1EA5A8006D1F29 /* SpanStackingHandler.h */,
@@ -1254,6 +1264,7 @@
 				964B78562D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm in Sources */,
 				CBEC51DD2976F1F9009C0CE3 /* RetryQueue.mm in Sources */,
 				01A414CE2913C0F0003152A4 /* SpanAttributes.mm in Sources */,
+				96986DBF2D5EA1A300A44C34 /* BSGWeakViewControllerList.mm in Sources */,
 				CB34771E29068C350033759C /* NSURLSession+Instrumentation.mm in Sources */,
 				CBE8EA1B294B5AB800702950 /* Worker.mm in Sources */,
 				CB78819C29E587CE00A58906 /* BugsnagPerformanceLibrary.mm in Sources */,
@@ -1276,6 +1287,7 @@
 				09D59E1B2BDFE0D900199E1B /* NetworkHeaderInjector.mm in Sources */,
 				CB04969C2915194E0097E526 /* OtlpUploader.mm in Sources */,
 				CBE0873229FA984C007455F2 /* BugsnagPerformanceViewType.mm in Sources */,
+				96986DC12D5EA1CF00A44C34 /* BSGSpanConditionsPool.mm in Sources */,
 				CBE0872929F806C2007455F2 /* NSURLSessionTask+Instrumentation.mm in Sources */,
 				CBB48A3D295EE1E10044E9AC /* ObjCUtils.mm in Sources */,
 				0921F02C2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m in Sources */,

--- a/Sources/BugsnagPerformance/Private/BSGSpanConditionsPool.h
+++ b/Sources/BugsnagPerformance/Private/BSGSpanConditionsPool.h
@@ -1,0 +1,25 @@
+//
+//  BSGSpanConditionsPool.h
+//  BugsnagPerformance
+//
+//  Created by Robert B on 13/02/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanCondition.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BSGSpanConditionsPool: NSObject
+
+@property (nonatomic, readonly) NSArray *conditions;
+
++ (instancetype)pool;
+
+- (void)add:(BugsnagPerformanceSpanCondition *)condition;
+- (void)clear;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/BSGSpanConditionsPool.mm
+++ b/Sources/BugsnagPerformance/Private/BSGSpanConditionsPool.mm
@@ -1,0 +1,75 @@
+//
+//  BSGSpanConditionsPool.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Robert B on 13/02/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import "BSGSpanConditionsPool.h"
+#import <BugsnagPerformance/BugsnagPerformanceSpanCondition.h>
+
+@interface BSGSpanConditionsPool ()
+
+@property (nonatomic, strong) NSMutableArray<BugsnagPerformanceSpanCondition *> *conditions_;
+
+@end
+
+@implementation BSGSpanConditionsPool
+
++ (instancetype)pool {
+    return [[self alloc] init];
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _conditions_ = [NSMutableArray new];
+    }
+    return self;
+}
+
+- (void)add:(BugsnagPerformanceSpanCondition *)condition {
+    @synchronized (self) {
+        if ([condition upgrade] != nil) {
+            [self.conditions_ addObject:condition];
+        }
+    }
+}
+
+- (void)forEach:(void (^)(BugsnagPerformanceSpanCondition *))block {
+    @synchronized (self) {
+        for (BugsnagPerformanceSpanCondition *condition in self.conditions_) {
+            block(condition);
+        }
+    }
+}
+
+- (NSArray *)conditions {
+    @synchronized (self) {
+        return [self.conditions_ copy];
+    }
+}
+
+- (void)clear {
+    @synchronized (self) {
+        for (BugsnagPerformanceSpanCondition *condition in self.conditions_) {
+            if (condition.isActive) {
+                [condition cancel];
+            }
+        }
+        self.conditions_ = [NSMutableArray new];
+    }
+}
+
+- (void)dealloc
+{
+    for (BugsnagPerformanceSpanCondition *condition in self.conditions_) {
+        if (condition.isActive) {
+            [condition cancel];
+        }
+    }
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/BSGWeakViewControllerList.h
+++ b/Sources/BugsnagPerformance/Private/BSGWeakViewControllerList.h
@@ -1,0 +1,87 @@
+//
+//  BSGWeakViewControllerList.h
+//  BugsnagPerformance
+//
+//  Created by Robert B on 13/02/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <mutex>
+
+@interface BSGWeakViewControllerPointer: NSObject
+
+// We use a weak wrapper because NSPointerArray.weakObjectsPointerArray's compact method is broken.
+@property(nonatomic,readonly,weak) UIViewController *viewController;
+
++ (instancetype)pointerWithViewController:(UIViewController *)viewController;
+
+@end
+
+namespace bugsnag {
+
+class BSGWeakViewControllerList {
+public:
+    BSGWeakViewControllerList()
+    : viewControllers_([NSMutableArray new])
+    {}
+
+    void add(UIViewController *viewController) noexcept {
+        auto ptr = [BSGWeakViewControllerPointer pointerWithViewController:viewController];
+        std::lock_guard<std::mutex> guard(mutex_);
+        [viewControllers_ addObject:ptr];
+    }
+    
+    void remove(UIViewController *viewController) noexcept {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto newViewControllers = [NSMutableArray arrayWithCapacity:viewControllers_.count];
+        for (BSGWeakViewControllerPointer *ptr in viewControllers_) {
+            if (viewController != ptr.viewController) {
+                [newViewControllers addObject:ptr];
+            }
+        }
+        viewControllers_ = newViewControllers;
+    }
+
+    void compact() noexcept {
+        std::lock_guard<std::mutex> guard(mutex_);
+        bool canCompact = false;
+        for (BSGWeakViewControllerPointer *ptr in viewControllers_) {
+            UIViewController *viewController = ptr.viewController;
+            if (viewController == nil) {
+                canCompact = true;
+                break;
+            }
+        }
+        if (canCompact) {
+            auto newViewControllers = [NSMutableArray arrayWithCapacity:viewControllers_.count];
+            for (BSGWeakViewControllerPointer *ptr in viewControllers_) {
+                UIViewController *viewController = ptr.viewController;
+                if (viewController != nil) {
+                    [newViewControllers addObject:ptr];
+                }
+            }
+            viewControllers_ = newViewControllers;
+        }
+    }
+    
+    void forEach(void (^block)(UIViewController *)) {
+        for (BSGWeakViewControllerPointer *pointer in viewControllers_) {
+            auto viewController = pointer.viewController;
+            if (viewController != nil) {
+                block(viewController);
+            }
+        }
+    }
+
+    NSUInteger count() noexcept {
+        std::lock_guard<std::mutex> guard(mutex_);
+        return viewControllers_.count;
+    }
+
+private:
+    std::mutex mutex_;
+    NSMutableArray<BSGWeakViewControllerPointer *> *viewControllers_;
+};
+
+}

--- a/Sources/BugsnagPerformance/Private/BSGWeakViewControllerList.mm
+++ b/Sources/BugsnagPerformance/Private/BSGWeakViewControllerList.mm
@@ -1,0 +1,25 @@
+//
+//  BSGWeakViewControllerList.m
+//  BugsnagPerformance-iOS
+//
+//  Created by Robert B on 13/02/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import "BSGWeakViewControllerList.h"
+#import <UIKit/UIKit.h>
+
+@implementation BSGWeakViewControllerPointer
+
+- (instancetype) initWithViewController:(UIViewController *)viewController {
+    if ((self = [super init])) {
+        _viewController = viewController;
+    }
+    return self;
+}
+
++ (instancetype) pointerWithViewController:(UIViewController *)viewController {
+    return [[BSGWeakViewControllerPointer alloc] initWithViewController:viewController];
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -63,7 +63,7 @@ public:
 
     void endViewLoadSpan(UIViewController *controller, NSDate *endTime) noexcept;
 
-    void onSpanStarted() noexcept;
+    void onSpanStarted(BugsnagPerformanceSpan *span) noexcept;
 
     void setOnViewLoadSpanStarted(std::function<void(NSString *)> onViewLoadSpanStarted) noexcept {
         tracer_->setOnViewLoadSpanStarted(onViewLoadSpanStarted);

--- a/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
@@ -12,6 +12,7 @@
 #import "../Instrumentation/AppStartupInstrumentation.h"
 #import "../Instrumentation/NetworkInstrumentation.h"
 #import "../Instrumentation/ViewLoadInstrumentation.h"
+#import <BugsnagPerformance/BugsnagPerformanceSpan.h>
 
 namespace bugsnag {
 
@@ -38,6 +39,7 @@ public:
     void willCallMainFunction() noexcept { appStartupInstrumentation_->willCallMainFunction(); }
     CFAbsoluteTime appStartDuration() noexcept { return appStartupInstrumentation_->appStartDuration(); }
     CFAbsoluteTime timeSinceAppFirstBecameActive() noexcept { return appStartupInstrumentation_->timeSinceAppFirstBecameActive(); }
+    void didStartSpan(BugsnagPerformanceSpan *span) noexcept { viewLoadInstrumentation_->didStartSpan(span); };
 
 private:
     Instrumentation() = delete;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -8,6 +8,7 @@
 #import <UIKit/UIKit.h>
 #import "../PhasedStartup.h"
 #import "../Tracer.h"
+#import "../BSGWeakViewControllerList.h"
 
 #import <vector>
 
@@ -33,6 +34,7 @@ public:
     , tracer_(tracer)
     , spanAttributesProvider_(spanAttributesProvider)
     , earlySpans_([NSMutableArray new])
+    , viewControllers_(std::make_shared<BSGWeakViewControllerList>())
     {}
 
     void earlyConfigure(BSGEarlyConfiguration *config) noexcept;
@@ -40,6 +42,8 @@ public:
     void configure(BugsnagPerformanceConfiguration *config) noexcept;
     void preStartSetup() noexcept {};
     void start() noexcept {}
+    
+    void didStartSpan(BugsnagPerformanceSpan *) noexcept;
     
 private:
     static std::vector<const char *> imagesToInstrument() noexcept;
@@ -72,6 +76,7 @@ private:
     bool isClassObserved(Class cls) noexcept;
     void adjustSpanIfPreloaded(BugsnagPerformanceSpan *span, ViewLoadInstrumentationState *instrumentationState, NSDate *viewWillAppearStartTime, UIViewController *viewController) noexcept;
     NSString *nameForViewController(UIViewController *viewController) noexcept;
+    bool shouldBlockSpanForViewLoad(BugsnagPerformanceSpan *span, UIViewController *viewController);
 
     bool isEnabled_{true};
     bool swizzleViewLoadPreMain_{true};
@@ -82,6 +87,7 @@ private:
     std::atomic<bool> isEarlySpanPhase_{true};
     std::recursive_mutex earlySpansMutex_;
     NSMutableArray<BugsnagPerformanceSpan *> * _Nullable earlySpans_;
+    std::shared_ptr<BSGWeakViewControllerList> viewControllers_;
     std::recursive_mutex vcInitMutex_;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -34,7 +34,7 @@ public:
            std::shared_ptr<Batch> batch,
            FrameMetricsCollector *frameMetricsCollector,
            std::shared_ptr<ConditionTimeoutExecutor> conditionTimeoutExecutor,
-           void (^onSpanStarted)()) noexcept;
+           void (^onSpanStarted)(BugsnagPerformanceSpan *)) noexcept;
     ~Tracer() {};
 
     void earlyConfigure(BSGEarlyConfiguration *) noexcept;
@@ -98,7 +98,7 @@ private:
     std::shared_ptr<WeakSpansList> potentiallyOpenSpans_;
 
     std::shared_ptr<Batch> batch_;
-    void (^onSpanStarted_)(){ ^(){} };
+    void (^onSpanStarted_)(BugsnagPerformanceSpan *){ ^(BugsnagPerformanceSpan *){} };
     std::function<void(NSString *)> onViewLoadSpanStarted_{ [](NSString *){} };
 
     void createFrozenFrameSpan(NSTimeInterval startTime, NSTimeInterval endTime, BugsnagPerformanceSpanContext *parentContext) noexcept;

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -23,7 +23,7 @@ Tracer::Tracer(std::shared_ptr<SpanStackingHandler> spanStackingHandler,
                std::shared_ptr<Batch> batch,
                FrameMetricsCollector *frameMetricsCollector,
                std::shared_ptr<ConditionTimeoutExecutor> conditionTimeoutExecutor,
-               void (^onSpanStarted)()) noexcept
+               void (^onSpanStarted)(BugsnagPerformanceSpan *)) noexcept
 : spanStackingHandler_(spanStackingHandler)
 , sampler_(sampler)
 , prewarmSpans_([NSMutableArray new])
@@ -149,7 +149,7 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGTriState defaultFirstC
     }
     [span internalSetMultipleAttributes:SpanAttributes::get()];
     potentiallyOpenSpans_->add(span);
-    onSpanStarted_();
+    onSpanStarted_(span);
     return span;
 }
 

--- a/Tests/BugsnagPerformanceTests/TracerTests.mm
+++ b/Tests/BugsnagPerformanceTests/TracerTests.mm
@@ -31,7 +31,7 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
     sampler->setProbability(1.0);
     auto batch = std::make_shared<Batch>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(BugsnagPerformanceSpan *){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -55,7 +55,7 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(BugsnagPerformanceSpan *){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -79,7 +79,7 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(BugsnagPerformanceSpan *){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -103,7 +103,7 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(BugsnagPerformanceSpan *){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -124,7 +124,7 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(BugsnagPerformanceSpan *){});
     SpanOptions spanOptions;
     auto span = tracer->startNetworkSpan(@"GET", spanOptions);
     XCTAssertEqual(span.kind, SPAN_KIND_CLIENT);

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -250,7 +250,7 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentPreLoadedViewLoadScenario
     Given I run "AutoInstrumentPreLoadedViewLoadScenario"
-    And I wait for 18 spans
+    And I wait for 28 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoad/UIKit]/Fixture.ViewController"
@@ -271,6 +271,16 @@ Feature: Automatic instrumentation spans
     * a span field "name" equals "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
     * a span field "name" equals "[ViewLoadPhase/Subview layout]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
     * a span field "name" equals "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span field "name" equals "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController (pre-loaded)"
+    * a span field "name" equals "[ViewLoadPhase/loadView]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewDidLoad]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewWillAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span field "name" equals "[ViewLoadPhase/View appearing]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewDidAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span field "name" equals "[ViewLoadPhase/Subview layout]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span field "name" equals "SubViewController_ChildSpan"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -284,6 +294,24 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+    * a span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (pre-loaded)" started at the same time as a span named "[ViewLoadPhase/loadView]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoadPhase/loadView]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" started at the same time as a span named "[ViewLoadPhase/viewDidLoad]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoadPhase/viewDidLoad]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" started at the same time as a span named "[ViewLoadPhase/viewWillAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoadPhase/viewWillAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" started before a span named "[ViewLoadPhase/View appearing]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoadPhase/View appearing]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" started before a span named "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" started before a span named "[ViewLoadPhase/Subview layout]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoadPhase/Subview layout]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" started before a span named "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" started before a span named "[ViewLoadPhase/viewDidAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (pre-loaded)" started before a span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController (pre-loaded)"
+    * a span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController (pre-loaded)" started at the same time as a span named "[ViewLoadPhase/loadView]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span named "[ViewLoadPhase/loadView]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController" started at the same time as a span named "[ViewLoadPhase/viewDidLoad]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span named "[ViewLoadPhase/viewDidLoad]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController" started at the same time as a span named "[ViewLoadPhase/viewWillAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span named "[ViewLoadPhase/viewWillAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController" started before a span named "[ViewLoadPhase/View appearing]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span named "[ViewLoadPhase/View appearing]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController" started before a span named "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span named "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController" started before a span named "[ViewLoadPhase/Subview layout]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span named "[ViewLoadPhase/Subview layout]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController" started before a span named "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span named "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController" started before a span named "[ViewLoadPhase/viewDidAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController"
+    * a span named "[ViewLoadPhase/viewDidLoad]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_SubViewController" started at the same time as a span named "SubViewController_ChildSpan"
 
   Scenario: ViewDidLoadDoesntTriggerScenario
     Given I run "ViewDidLoadDoesntTriggerScenario"

--- a/features/fixtures/ios/Scenarios/AutoInstrumentPreLoadedViewLoadScenario.swift
+++ b/features/fixtures/ios/Scenarios/AutoInstrumentPreLoadedViewLoadScenario.swift
@@ -34,9 +34,37 @@ class AutoInstrumentPreLoadedViewLoadScenario_ViewController: UIViewController {
     
     override func loadView() {
         let label = UILabel()
+        let containerView = UIView()
+        label.backgroundColor = .white
+        label.textAlignment = .center
+        label.text = String(describing: type(of: self))
+        containerView.addSubview(label)
+        view = containerView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let viewController = AutoInstrumentPreLoadedViewLoadScenario_SubViewController()
+        add(childViewController: viewController, to: view)
+    }
+}
+
+class AutoInstrumentPreLoadedViewLoadScenario_SubViewController: UIViewController {
+    
+    override func loadView() {
+        let label = UILabel()
         label.backgroundColor = .white
         label.textAlignment = .center
         label.text = String(describing: type(of: self))
         view = label
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let span = BugsnagPerformance.startSpan(name: "SubViewController_ChildSpan")
+        DispatchQueue.global().async {
+            Thread.sleep(forTimeInterval: 0.1)
+            span.end()
+        }
     }
 }

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -296,6 +296,13 @@ Then('a span named {string} started before a span named {string}') do |name1, na
   Maze.check.true(first_span['startTimeUnixNano'].to_i < second_span['startTimeUnixNano'].to_i)
 end
 
+Then('a span named {string} started at the same time as a span named {string}') do |name1, name2|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  first_span = spans.find { |span| span['name'] == name1 }
+  second_span = spans.find { |span| span['name'] == name2 }
+  Maze.check.true(first_span['startTimeUnixNano'].to_i == second_span['startTimeUnixNano'].to_i)
+end
+
 Then('a span named {string} ended before a span named {string} started') do |name1, name2|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   first_span = spans.find { |span| span['name'] == name1 }


### PR DESCRIPTION
## Goal

Some children of Pre-loaded spans display the warning message: “This span started before the start of the trace.”. This is due to their start and end times not being properly adjusted.

## Design

Use Conditions mechanism to block all direct and indirect child spans of the spans created by ViewLoad Instrumentation. Then as soon as the parent ViewLoad span is marked as pre loaded, timestamps for the spans are adjusted to the viewWillAppear startTime.

## Testing

E2E tests