### PR TITLE
REVERTED: View load spans are now not first class by default, and don't set the current context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* REVERTED: View load spans are now not first class by default, and don't set the current context.
+  [392](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/392)
+
 ## 1.11.1 (2025-01-20)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 
 ### Bug fixes
 
-* REVERTED: View load spans are now not first class by default, and don't set the current context.
+* Fixes ViewLoadSpans not setting context or being first class (reverts #369).
   [392](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/392)
 
 ## 1.11.1 (2025-01-20)

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'bugsnag-maze-runner', '~>9.0'
 gem 'cocoapods'
-gem 'xcpretty'
+gem 'xcpretty', '~>0.4.0'
 
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'integration/v8'
 

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -251,8 +251,6 @@ BugsnagPerformanceSpan *
 Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
                           NSString *className,
                           SpanOptions options) noexcept {
-    // Always override this on a view load span
-    options.makeCurrentContext = false;
     NSString *type = getBugsnagPerformanceViewTypeName(viewType);
     onViewLoadSpanStarted_(className);
     NSString *name = [NSString stringWithFormat:@"[ViewLoad/%@]/%@", type, className];
@@ -261,7 +259,7 @@ Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
             options.firstClass = BSGFirstClassNo;
         }
     }
-    auto span = startSpan(name, options, BSGFirstClassNo);
+    auto span = startSpan(name, options, BSGFirstClassYes);
     if (willDiscardPrewarmSpans_) {
         markPrewarmSpan(span);
     }

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -81,7 +81,7 @@ Feature: Manual creation of spans
     * a span field "name" equals "[ViewLoad/SwiftUI]/ManualView"
     * a span string attribute "bugsnag.view.name" equals "ManualView"
     * a span string attribute "bugsnag.view.type" equals "SwiftUI"
-    * every span bool attribute "bugsnag.span.first_class" is false
+    * every span bool attribute "bugsnag.span.first_class" is true
     * every span field "kind" equals 1
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
@@ -116,7 +116,7 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "view_load"
-    * every span bool attribute "bugsnag.span.first_class" is false
+    * every span bool attribute "bugsnag.span.first_class" is true
 
   Scenario: Manually start a network span
     Given I run "ManualNetworkSpanScenario"

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+bundle install
+
 declare "${@}"
 
 xcresult=$(date '+BugsnagTests-%Y-%m-%d-%H-%M-%S.xcresult')


### PR DESCRIPTION
## Goal

Reverted the change that was causing ViewLoad spans to not show up on the Dashboard

## Testing

E2E Tests