### PR TITLE
Fixed issue where bugsnag.app_start.first_view_name was missing for app start spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fixed issue where bugsnag.app_start.first_view_name was missing for app start spans.
+  [404](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/404)
+
 ## 1.11.2 (2025-02-17)
 
 ### Bug fixes

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.h
@@ -82,5 +82,6 @@ private:
     void beginPreMainSpan() noexcept;
     void beginPostMainSpan() noexcept;
     void beginUIInitSpan() noexcept;
+    bool isAppStartInProgress() noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/AppStartupInstrumentation.mm
@@ -162,7 +162,12 @@ AppStartupInstrumentation::onAppDidFinishLaunching() noexcept {
 
 void
 AppStartupInstrumentation::didStartViewLoadSpan(NSString *name) noexcept {
-    firstViewName_ = name;
+    if (firstViewName_ == nil) {
+        firstViewName_ = name;
+        if (isAppStartInProgress()) {
+            [appStartSpan_ internalSetMultipleAttributes:spanAttributesProvider_->appStartSpanAttributes(firstViewName_, isColdLaunch_)];
+        }
+    }
 }
 
 void
@@ -248,6 +253,11 @@ AppStartupInstrumentation::beginUIInitSpan() noexcept {
     options.parentContext = appStartSpan_;
     uiInitSpan_ = tracer_->startAppStartSpan(name, options);
     [uiInitSpan_ internalSetMultipleAttributes:spanAttributesProvider_->appStartPhaseSpanAttributes(@"UI init")];
+}
+
+bool
+AppStartupInstrumentation::isAppStartInProgress() noexcept {
+    return appStartSpan_ != nil && (appStartSpan_.isValid || appStartSpan_.isBlocked);
 }
 
 #pragma mark -

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -21,6 +21,7 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.phase" equals "UI init"
     * a span string attribute "bugsnag.span.category" equals "app_start"
     * a span string attribute "bugsnag.span.category" equals "app_start_phase"
+    * a span string attribute "bugsnag.app_start.first_view_name" equals "Fixture.ViewController"
     * every span bool attribute "bugsnag.span.first_class" does not exist
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"


### PR DESCRIPTION
## Goal

Make sure `bugsnag.app_start.first_view_name` is populated for app start spans.

## Design

The attribute used to be set at app start span in pre-main which was too early for a ViewLoad to have started

## Changeset

`bugsnag.app_start.first_view_name` is now updated when the first view is loaded after the app start span has started

## Testing

E2E test