### PR TITLE
Do not use Maze.driver directly

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,6 +58,7 @@ steps:
         artifact_paths:
           - features/fixtures/ios/output/bb_ipa_url.txt
           - features/fixtures/ios/output/bs_ipa_url.txt
+          - features/fixtures/ios/output/Fixture.ipa
 
       - label: "XcFramework Fixture"
         key: ios_xcframework_fixture

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', '~>9.23.2'
+gem 'bugsnag-maze-runner', '~>9.0'
 gem 'cocoapods'
 gem 'xcpretty', '~>0.4.0'
 

--- a/features/steps/hooks.rb
+++ b/features/steps/hooks.rb
@@ -13,7 +13,8 @@ Maze.hooks.after do |scenario|
     if scenario.failed? || Maze.config.farm == :local
       FileUtils.makedirs(path)
       File.open(File.join(path, 'syslog.log'), 'wb') do |file|
-        Maze.driver.get_log('syslog').each { |entry| file.puts entry.message }
+        manager = Maze::Api::Appium::DeviceManager.new
+        manager.get_log('syslog').each { |entry| file.puts entry.message }
       end
     end
   end


### PR DESCRIPTION
## Goal

Change the e2e tests to use the new Maze Runner Appium API, meaning that we detect and report driver failures.

## Changeset

I've also added the test fixture as a Buildkite artifact for convenience of locally running tests.

## Testing

Covered by CI - I also ran a test locally to force a failure, checking that the syslog was retrieved as expected by the code that's been changed.