### PR TITLE
Add missing MARKETING_VERSION to BugsnagPerformance-iOS

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -694,7 +694,6 @@
 				CB0AD75C29641B59002A3FB6 /* BatchTests.mm */,
 				CB0AD76B296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm */,
 				964B785A2D4C20C000FF077D /* BugsnagPerformanceSpanConditionTests.mm */,
-				0122C25F29019C05002D243C /* BugsnagPerformanceTests.mm */,
 				09E313032BF363020081F219 /* CrossTalkTests.mm */,
 				CBEC51C8296ED98F009C0CE3 /* FileBasedTest.h */,
 				CBEC51C9296ED98F009C0CE3 /* FileBasedTest.m */,
@@ -1655,6 +1654,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagPerformance;
 				PRODUCT_NAME = BugsnagPerformance;
 				SDKROOT = iphoneos;
@@ -1684,6 +1684,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagPerformance;
 				PRODUCT_NAME = BugsnagPerformance;
 				SDKROOT = iphoneos;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Added missing MARKETING_VERSION build setting to BugsnagPerformance-iOS. This is required for generating CFBundleShortVersionString in some situations.
+  [418](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/418)
+
 * Fixed issue where bugsnag.app_start.first_view_name was missing for app start spans.
   [404](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/404)
 


### PR DESCRIPTION
## Goal

`MARKETING_VERSION` is required in order to generate a correct `Info.plist` in some situations, and has until now been missing from the `BugsnagPerformance-iOS` target. This PR adds the setting so that it matches the other targets in the project.

The removal of the `BugsnagPerformanceTests.mm` entry is just Xcode auto-cleaning the project file.
