### PR TITLE
Fixed issue where API Key override not was not reflected in endpoint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fixed issue where API Key override not was not reflected in `endpoint` when using `BugsnagPerformanceConfiguration`.
+  [423](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/423)
+
 * Added missing MARKETING_VERSION build setting to BugsnagPerformance-iOS. This is required for generating CFBundleShortVersionString in some situations.
   [418](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/418)
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -24,6 +24,8 @@ using namespace bugsnag;
 #define MAX_ATTRIBUTE_COUNT_LIMIT 1000
 #define DEFAULT_ATTRIBUTE_COUNT_LIMIT 128
 
+#define DEFAULT_URL_FORMAT @"https://%@.otlp.bugsnag.com/v1/traces"
+
 @implementation BugsnagPerformanceEnabledMetrics
 
 + (instancetype) withAllEnabled {
@@ -53,13 +55,17 @@ using namespace bugsnag;
 
 @end
 
+@interface BugsnagPerformanceConfiguration ()
+@property (nonatomic) BOOL didSetCustomEndpoint;
+@end
+
 @implementation BugsnagPerformanceConfiguration
 
 - (instancetype)initWithApiKey:(NSString *)apiKey {
     if ((self = [super init])) {
         _internal = [BSGInternalConfiguration new];
         _apiKey = [apiKey copy];
-        _endpoint = nsurlWithString([NSString stringWithFormat: @"https://%@.otlp.bugsnag.com/v1/traces", apiKey], nil);
+        _endpoint = nsurlWithString([NSString stringWithFormat: DEFAULT_URL_FORMAT, apiKey], nil);
         _autoInstrumentAppStarts = YES;
         _autoInstrumentViewControllers = YES;
         _autoInstrumentNetworkRequests = YES;
@@ -68,6 +74,7 @@ using namespace bugsnag;
         _attributeArrayLengthLimit = DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT;
         _attributeStringValueLimit = DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT;
         _attributeCountLimit = DEFAULT_ATTRIBUTE_COUNT_LIMIT;
+        _didSetCustomEndpoint = NO;
 #if defined(DEBUG) && DEBUG
         _releaseStage = @"development";
 #else
@@ -114,6 +121,20 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
                                          MIN_ATTRIBUTE_COUNT_LIMIT,
                                          MAX_ATTRIBUTE_COUNT_LIMIT,
                                          DEFAULT_ATTRIBUTE_COUNT_LIMIT);
+}
+
+- (void)setApiKey:(NSString *)apiKey {
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+    _apiKey = apiKey;
+    if (!_didSetCustomEndpoint) {
+        _endpoint = nsurlWithString([NSString stringWithFormat: DEFAULT_URL_FORMAT, apiKey], nil);
+    }
+}
+
+- (void)setEndpoint:(NSURL *)endpoint {
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+    _endpoint = endpoint;
+    _didSetCustomEndpoint = YES;
 }
 
 + (instancetype)loadConfig {

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
@@ -220,6 +220,52 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertEqualObjects(config.endpoint.absoluteString, @"https://0123456789abcdef0123456789abcdef.otlp.bugsnag.com/v1/traces");
 }
 
+- (void)testUpdatingAPIKeyInLoadedConfigAlsoUpdatesTheEndpoint {
+    auto config = [BugsnagPerformanceConfiguration loadConfigWithInfoDictionary:@{
+        @"bugsnag": @{
+            @"performance": @{
+                @"apiKey": performanceApiKey,
+                @"appVersion": performanceAppVersion,
+                @"bundleVersion": performanceBundleVersion,
+            }
+        }
+    }];
+    [config setApiKey:@"0123456789abcdef0123456789abcdef"];
+    XCTAssertEqualObjects(config.apiKey, @"0123456789abcdef0123456789abcdef");
+    XCTAssertEqualObjects(config.endpoint.absoluteString, @"https://0123456789abcdef0123456789abcdef.otlp.bugsnag.com/v1/traces");
+}
+
+- (void)testUpdatingAPIKeyInConfigAlsoUpdatesTheEndpoint {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:performanceApiKey];
+    [config setApiKey:@"0123456789abcdef0123456789abcdef"];
+    XCTAssertEqualObjects(config.apiKey, @"0123456789abcdef0123456789abcdef");
+    XCTAssertEqualObjects(config.endpoint.absoluteString, @"https://0123456789abcdef0123456789abcdef.otlp.bugsnag.com/v1/traces");
+}
+
+- (void)testUpdatingAPIKeyInLoadedConfigDoesntUpdateTheEndpointIfACustomEndpointIsSet {
+    auto config = [BugsnagPerformanceConfiguration loadConfigWithInfoDictionary:@{
+        @"bugsnag": @{
+            @"performance": @{
+                @"apiKey": performanceApiKey,
+                @"appVersion": performanceAppVersion,
+                @"bundleVersion": performanceBundleVersion,
+                @"endpoint": performanceEndpoint,
+            }
+        }
+    }];
+    [config setApiKey:@"0123456789abcdef0123456789abcdef"];
+    XCTAssertEqualObjects(config.apiKey, @"0123456789abcdef0123456789abcdef");
+    XCTAssertEqualObjects(config.endpoint.absoluteString, performanceEndpoint);
+}
+
+- (void)testUpdatingAPIKeyInConfigDoesntUpdateTheEndpointIfACustomEndpointIsSet {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:performanceApiKey];
+    config.endpoint = [NSURL URLWithString:performanceEndpoint];
+    [config setApiKey:@"0123456789abcdef0123456789abcdef"];
+    XCTAssertEqualObjects(config.apiKey, @"0123456789abcdef0123456789abcdef");
+    XCTAssertEqualObjects(config.endpoint.absoluteString, performanceEndpoint);
+}
+
 - (void)testLimits {
 #define MIN_ATTRIBUTE_COUNT_LIMIT (uint64_t)1
 #define MAX_ATTRIBUTE_COUNT_LIMIT (uint64_t)500


### PR DESCRIPTION
## Goal

Provided that no custom endpoint was set, the default endpoint has to be updated each time API key changes

## Testing

Unit Tests