### PR TITLE
Made span names in E2E Tests more informative

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-Sources       @robert-smartbear @kstenerud
+Sources       @robert-smartbear @DariaKunoichi

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -305,7 +305,7 @@ Feature: Manual creation of spans
     And I wait for 1 span
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "SetAttributesScenario"
     * a span string attribute "a" equals "xyz"
     * every span bool attribute "b" does not exist
     * every span bool attribute "d" does not exist
@@ -322,7 +322,7 @@ Feature: Manual creation of spans
     And I wait for 1 span
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "SetAttributesWithLimitsScenario"
     * a span string attribute "a" equals "1234567890*** 1 CHARS TRUNCATED"
     * a span array attribute "b" contains the integer value 1 at index 0
     * a span array attribute "b" contains the integer value 2 at index 1
@@ -334,7 +334,7 @@ Feature: Manual creation of spans
     And I wait for 1 span
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "SetAttributeCountLimitScenario"
     * every span string attribute "a" does not exist
 
   Scenario: Set OnEnd
@@ -342,7 +342,7 @@ Feature: Manual creation of spans
     And I wait for exactly 1 span
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "OnEndCallbackScenario"
 
   Scenario: Frame metrics - no slow frames
     Given I run "FrameMetricsNoSlowFramesScenario"

--- a/features/default/metrics.feature
+++ b/features/default/metrics.feature
@@ -4,13 +4,14 @@ Feature: Spans with collected metrics
     Given I load scenario "RenderingMetricsScenario"
     And I configure bugsnag "renderingMetrics" to "true"
     And I set the sampling probability to "1.0"
+    And I configure scenario "variant_name" to "NoSlow"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * every span field "name" equals "MySpan"
+    * every span field "name" equals "RenderingMetricsScenarioNoSlow"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -25,6 +26,7 @@ Feature: Spans with collected metrics
     Given I load scenario "RenderingMetricsScenario"
     And I configure bugsnag "renderingMetrics" to "true"
     And I configure scenario "spanStartTime" to "early"
+    And I configure scenario "variant_name" to "EarlyStart"
     And I set the sampling probability to "1.0"
     And I start bugsnag
     And I run the loaded scenario
@@ -32,7 +34,7 @@ Feature: Spans with collected metrics
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * every span field "name" equals "MySpan"
+    * every span field "name" equals "RenderingMetricsScenarioEarlyStart"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -134,13 +136,14 @@ Feature: Spans with collected metrics
     And I configure scenario "run_delay" to "0"
     And I configure scenario "work_duration" to "0"
     And I configure scenario "span_duration" to "0"
+    And I configure scenario "variant_name" to "DefaultSettingsCPUMetricsDisabled"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "CPUMetricsScenarioDefaultSettingsCPUMetricsDisabled"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -164,13 +167,14 @@ Feature: Spans with collected metrics
     And I configure scenario "work_duration" to "0"
     And I configure scenario "span_duration" to "0"
     And I configure scenario "opts_metrics_cpu" to "yes"
+    And I configure scenario "variant_name" to "NoMetrics"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "CPUMetricsScenarioNoMetrics"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -194,13 +198,14 @@ Feature: Spans with collected metrics
     And I configure scenario "work_duration" to "0"
     And I configure scenario "span_duration" to "0"
     And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "FirstClass"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "CPUMetricsScenarioFirstClass"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -224,13 +229,14 @@ Feature: Spans with collected metrics
     And I configure scenario "work_duration" to "0"
     And I configure scenario "span_duration" to "0"
     And I configure scenario "opts_first_class" to "no"
+    And I configure scenario "variant_name" to "NonFirstClass"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "CPUMetricsScenarioNonFirstClass"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -255,13 +261,14 @@ Feature: Spans with collected metrics
     And I configure scenario "span_duration" to "0"
     And I configure scenario "opts_first_class" to "no"
     And I configure scenario "opts_metrics_cpu" to "yes"
+    And I configure scenario "variant_name" to "NonFirstClassWithMetrics"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "CPUMetricsScenarioNonFirstClassWithMetrics"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -285,13 +292,14 @@ Feature: Spans with collected metrics
     And I configure scenario "work_duration" to "0"
     And I configure scenario "span_duration" to "1.5"
     And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "LongerSpanDuration"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "CPUMetricsScenarioLongerSpanDuration"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -315,13 +323,14 @@ Feature: Spans with collected metrics
     And I configure scenario "work_duration" to "0"
     And I configure scenario "span_duration" to "1.5"
     And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "GenerateSpanLater"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "CPUMetricsScenarioGenerateSpanLater"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -349,13 +358,14 @@ Feature: Spans with collected metrics
     And I configure scenario "work_on_thread" to "main"
     And I configure scenario "span_duration" to "1.5"
     And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "MainThreadHeavyWork"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "CPUMetricsScenarioMainThreadHeavyWork"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -381,13 +391,14 @@ Feature: Spans with collected metrics
     And I configure scenario "work_on_thread" to "main"
     And I configure scenario "span_duration" to "1.5"
     And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "BgThreadHeavyWork"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "CPUMetricsScenarioBgThreadHeavyWork"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -410,13 +421,14 @@ Feature: Spans with collected metrics
     Given I load scenario "MemoryMetricsScenario"
     And I configure scenario "run_delay" to "0"
     And I configure scenario "span_duration" to "0"
+    And I configure scenario "variant_name" to "DefaultSettings"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "MemoryMetricsScenarioDefaultSettings"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -437,13 +449,14 @@ Feature: Spans with collected metrics
     And I configure scenario "run_delay" to "0"
     And I configure scenario "span_duration" to "0"
     And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "FirstClass"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "MemoryMetricsScenarioFirstClass"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -464,13 +477,14 @@ Feature: Spans with collected metrics
     And I configure scenario "run_delay" to "0"
     And I configure scenario "span_duration" to "0"
     And I configure scenario "opts_first_class" to "no"
+    And I configure scenario "variant_name" to "NonFirstClass"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "MemoryMetricsScenarioNonFirstClass"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -492,13 +506,14 @@ Feature: Spans with collected metrics
     And I configure scenario "span_duration" to "0"
     And I configure scenario "opts_first_class" to "no"
     And I configure scenario "opts_metrics_memory" to "yes"
+    And I configure scenario "variant_name" to "NonFirstClassEnabled"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "MemoryMetricsScenarioNonFirstClassEnabled"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -519,13 +534,14 @@ Feature: Spans with collected metrics
     And I configure scenario "run_delay" to "0"
     And I configure scenario "span_duration" to "1.5"
     And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "LongerDuration"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "MemoryMetricsScenarioLongerDuration"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -546,13 +562,14 @@ Feature: Spans with collected metrics
     And I configure scenario "run_delay" to "1.1"
     And I configure scenario "span_duration" to "1.5"
     And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "GenerateLater"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
-    * a span field "name" equals "MySpan"
+    * a span field "name" equals "MemoryMetricsScenarioGenerateLater"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1

--- a/features/fixtures/ios/Scenarios/CPUMetricsScenario.swift
+++ b/features/fixtures/ios/Scenarios/CPUMetricsScenario.swift
@@ -31,7 +31,7 @@ class CPUMetricsScenario: Scenario {
         let opts = BugsnagPerformanceSpanOptions()
         opts.setFirstClass(toTriState(string: scenarioConfig["opts_first_class"]))
         opts.metricsOptions.cpu = toTriState(string: scenarioConfig["opts_metrics_cpu"])
-        let span = BugsnagPerformance.startSpan(name: "MySpan", options: opts)
+        let span = BugsnagPerformance.startSpan(name: spanName, options: opts)
         let spanDuration = toDouble(string: scenarioConfig["span_duration"])
         DispatchQueue.main.asyncAfter(deadline: .now() + spanDuration) {
             span.end();

--- a/features/fixtures/ios/Scenarios/MemoryMetricsScenario.swift
+++ b/features/fixtures/ios/Scenarios/MemoryMetricsScenario.swift
@@ -20,7 +20,7 @@ class MemoryMetricsScenario: Scenario {
         let opts = BugsnagPerformanceSpanOptions()
         opts.setFirstClass(toTriState(string: scenarioConfig["opts_first_class"]))
         opts.metricsOptions.memory = toTriState(string: scenarioConfig["opts_metrics_memory"])
-        let span = BugsnagPerformance.startSpan(name: "MySpan", options: opts)
+        let span = BugsnagPerformance.startSpan(name: spanName, options: opts)
         let spanDuration = toDouble(string: scenarioConfig["span_duration"])
         DispatchQueue.main.asyncAfter(deadline: .now() + spanDuration) {
             span.end();

--- a/features/fixtures/ios/Scenarios/OnEndCallbackScenario.swift
+++ b/features/fixtures/ios/Scenarios/OnEndCallbackScenario.swift
@@ -39,7 +39,7 @@ class OnEndCallbackScenario: Scenario {
     }
 
     override func run() {
-        BugsnagPerformance.startSpan(name: "MySpan").end()
+        BugsnagPerformance.startSpan(name: "OnEndCallbackScenario").end()
         BugsnagPerformance.startSpan(name: "drop_me").end()
         BugsnagPerformance.startSpan(name: "drop_me_too").end()
     }

--- a/features/fixtures/ios/Scenarios/RenderingMetricsScenario.swift
+++ b/features/fixtures/ios/Scenarios/RenderingMetricsScenario.swift
@@ -120,7 +120,7 @@ class RenderingMetricsScenario: Scenario {
         let opts = BugsnagPerformanceSpanOptions()
         opts.setFirstClass(toTriState(string: scenarioConfig["opts.firstClass"]))
         opts.metricsOptions.rendering = toTriState(string: scenarioConfig["opts.metrics.rendering"])
-        span = BugsnagPerformance.startSpan(name: "MySpan", options: opts)
+        span = BugsnagPerformance.startSpan(name: spanName, options: opts)
         logError("### startSpan(): Span = \(String(describing: span))")
     }
 

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -229,4 +229,6 @@ class Scenario: NSObject {
             fatalError("\(String(describing: string)): Unknown tri-state value")
         }
     }
+    
+    var spanName: String { "\(String(describing: type(of: self)).replacingOccurrences(of: "Fixture", with: ""))\(scenarioConfig["variant_name"] ?? "")" }
 }

--- a/features/fixtures/ios/Scenarios/SetAttributeCountLimitScenario.swift
+++ b/features/fixtures/ios/Scenarios/SetAttributeCountLimitScenario.swift
@@ -16,7 +16,7 @@ class SetAttributeCountLimitScenario: Scenario {
     }
 
     override func run() {
-        let span = BugsnagPerformance.startSpan(name: "MySpan")
+        let span = BugsnagPerformance.startSpan(name: "SetAttributeCountLimitScenario")
         span.setAttribute("a", withValue: "12345678901")
         span.end()
     }

--- a/features/fixtures/ios/Scenarios/SetAttributesScenario.swift
+++ b/features/fixtures/ios/Scenarios/SetAttributesScenario.swift
@@ -11,7 +11,7 @@ import BugsnagPerformance
 class SetAttributesScenario: Scenario {
     
     override func run() {
-        let span = BugsnagPerformance.startSpan(name: "MySpan")
+        let span = BugsnagPerformance.startSpan(name: "SetAttributesScenario")
         span.setAttribute("a", withValue: "xyz")
         span.setAttribute("b", withValue: "abc")
         span.setAttribute("b", withValue: nil)

--- a/features/fixtures/ios/Scenarios/SetAttributesWithLimitsScenario.swift
+++ b/features/fixtures/ios/Scenarios/SetAttributesWithLimitsScenario.swift
@@ -17,7 +17,7 @@ class SetAttributesWithLimitsScenario: Scenario {
     }
 
     override func run() {
-        let span = BugsnagPerformance.startSpan(name: "MySpan")
+        let span = BugsnagPerformance.startSpan(name: "SetAttributesWithLimitsScenario")
         span.setAttribute("a", withValue: "12345678901")
         span.setAttribute("b", withValue: [1, 2, 3, 4])
         span.end()


### PR DESCRIPTION
## Goal

Viewing spans created in some E2E tests on Dashboard is confusing because they are grouped under name "MySpan"

## Design

Changed span names in E2E tests so they include the scenario name and variant name (in case a scenario is reused in multiple tests)

## Testing

E2E Tests