### PR TITLE
Fixed issue where ViewControllers were kept in memory for up to 10 seconds after being dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fixed issue where ViewControllers were kept in memory for up to 10 seconds after being dismissed.
+  [428](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/428)
+
 ## 1.12.0 (2025-04-24)
 
 ### Bug fixes

--- a/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/ViewLoadInstrumentation.h
@@ -14,14 +14,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ViewLoadInstrumentationState : NSObject
-@property (nonatomic) BOOL loadViewPhaseSpanCreated;
-@property (nonatomic) BOOL viewDidLoadPhaseSpanCreated;
-@property (nonatomic) BOOL viewWillAppearPhaseSpanCreated;
-@property (nonatomic) BOOL viewDidAppearPhaseSpanCreated;
-@property (nonatomic) BOOL viewWillLayoutSubviewsPhaseSpanCreated;
-@property (nonatomic) BOOL viewDidLayoutSubviewsPhaseSpanCreated;
-@property (nonatomic) BOOL isMarkedAsPreloaded;
-@property (nonatomic, nullable, strong) NSDate *viewDidLoadEndTime;
 @end
 
 namespace bugsnag {
@@ -59,12 +51,12 @@ private:
     void onViewDidAppear(UIViewController *viewController) noexcept;
     void onViewWillDisappear(UIViewController *viewController) noexcept;
     void endOverallSpan(UIViewController *viewController) noexcept;
-    void endViewAppearingSpan(UIViewController *viewController, CFAbsoluteTime atTime) noexcept;
+    void endViewAppearingSpan(ViewLoadInstrumentationState *instrumentationState, CFAbsoluteTime atTime) noexcept;
     void endSubviewsLayoutSpan(UIViewController *viewController) noexcept;
     BugsnagPerformanceSpan *startViewLoadPhaseSpan(UIViewController *viewController, NSString *phase) noexcept;
 
-    static void setOverallSpan(UIViewController *viewController, BugsnagPerformanceSpan * _Nullable span) noexcept;
-    static BugsnagPerformanceSpan *getOverallSpan(UIViewController *viewController) noexcept;
+    static void setInstrumentationState(UIViewController *viewController, ViewLoadInstrumentationState * _Nullable state) noexcept;
+    static ViewLoadInstrumentationState *getInstrumentationState(UIViewController *viewController) noexcept;
 
     void markEarlySpan(BugsnagPerformanceSpan *span) noexcept;
     void endEarlySpanPhase() noexcept;

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -286,8 +286,11 @@ Feature: Automatic instrumentation spans
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
 
-  Scenario: ViewDidLoadDoesntTriggerScenario
-    Given I run "ViewDidLoadDoesntTriggerScenario"
+  Scenario: View load doesn't trigger and the ViewController is kept alive
+    Given I load scenario "ViewDidLoadDoesntTriggerScenario"
+    And I configure scenario "keep_view_controller_alive" to "true"
+    And I start bugsnag
+    And I run the loaded scenario
     And I wait for 17 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
@@ -308,6 +311,48 @@ Feature: Automatic instrumentation spans
     * a span field "name" equals "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
     * a span field "name" equals "[ViewLoadPhase/Subview layout]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
     * a span field "name" equals "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
+    * no span field "name" equals "ViewDidLoadDoesntTriggerScenarioOnDeinitSpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "bugsnag.span.category" equals "view_load"
+    * a span string attribute "bugsnag.view.name" equals "Fixture.ViewController"
+    * a span string attribute "bugsnag.view.name" equals "Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * a span string attribute "bugsnag.view.type" equals "UIKit"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+
+  Scenario: View load doesn't trigger and the ViewController is not kept alive
+    Given I load scenario "ViewDidLoadDoesntTriggerScenario"
+    And I configure scenario "keep_view_controller_alive" to "false"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 18 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "[ViewLoad/UIKit]/Fixture.ViewController"
+    * a span field "name" equals "[ViewLoadPhase/loadView]/Fixture.ViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewDidLoad]/Fixture.ViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewWillAppear]/Fixture.ViewController"
+    * a span field "name" equals "[ViewLoadPhase/View appearing]/Fixture.ViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewDidAppear]/Fixture.ViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.ViewController"
+    * a span field "name" equals "[ViewLoadPhase/Subview layout]/Fixture.ViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.ViewController"
+    * a span field "name" equals "[ViewLoad/UIKit]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
+    * a span field "name" equals "[ViewLoadPhase/loadView]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewDidLoad]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewWillAppear]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
+    * a span field "name" equals "[ViewLoadPhase/View appearing]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
+    * a span field "name" equals "[ViewLoadPhase/Subview layout]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
+    * a span field "name" equals "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.ViewDidLoadDoesntTriggerScenario_ViewController"
+    * a span field "name" equals "ViewDidLoadDoesntTriggerScenarioOnDeinitSpan"
+    * a span named "ViewDidLoadDoesntTriggerScenarioOnDeinitSpan" duration is equal or less than 1.0
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -315,6 +315,13 @@ Then('a span named {string} ended after a span named {string}') do |name1, name2
   Maze.check.true(first_span['endTimeUnixNano'].to_i > second_span['endTimeUnixNano'].to_i)
 end
 
+Then('a span named {string} duration is equal or less than {float}') do |name, maxDuration|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  span = spans.find { |span| span['name'] == name }
+  duration = (span['endTimeUnixNano'].to_i - span['startTimeUnixNano'].to_i)/1000000000
+  Maze.check.true(duration <= maxDuration)
+end
+
 When('I wait for exactly {int} span(s)') do |span_count|
   assert_received_exactly_spans span_count, Maze::Server.list_for('traces')
 end


### PR DESCRIPTION
## Goal

ViewControllers were kept in memory for up to 10 seconds after being dismissed.

## Design

Removed a strong reference holding ViewControllers for additional time. Added handling for when ViewControllers are deallocated before the 10 seconds timeout

## Testing

E2E tests