### PR TITLE
Fixed a potential data race warning in SystemInfoSampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fixed a potential data race warning in `SystemInfoSampler`.
+  [431](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/431)
+
 ## 1.12.1 (2025-05-06)
 
 ### Bug fixes

--- a/Sources/BugsnagPerformance/Private/SystemInfoSampler.h
+++ b/Sources/BugsnagPerformance/Private/SystemInfoSampler.h
@@ -91,7 +91,8 @@ private:
     void recordSample();
 
 private:
-    std::mutex mutex_;
+    std::mutex samplesMutex_;
+    std::mutex recordMutex_;
     BSGPSystemInfo systemInfo_;
     FixedLengthDequeue<SystemInfoSampleData> samples_;
 


### PR DESCRIPTION
## Goal

Thread Sanitizer detects a potential data race between Sampler thread and the main thread in `SystemInfoSampler.config` method

## Design

Added a mutex that helps synchronise Sampler thread and main thread when they access SystemInfoSampler properties

## Testing

Manual testing