### PR TITLE
Fixed bugsnag.sampling.p attribute reporting to accurately reflect current sample rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 
 ### Bug fixes
 
+* Fixed issue where a very small percentage of spans could be sent even though samplingProbability was set to 0.0.
+  [432](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/432)
+
+* All spans now get their sampling probability value properly initially set and updated.
+  [432](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/432)
+
 * Fixed a potential data race warning in `SystemInfoSampler`.
   [431](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/431)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changelog
 * Fixed issue where a very small percentage of spans could be sent even though samplingProbability was set to 0.0.
   [432](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/432)
 
-* All spans now get their sampling probability value properly initially set and updated.
+* Fixed bugsnag.sampling.p attribute reporting to accurately reflect current sample rate.
   [432](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/432)
 
 * Fixed a potential data race warning in `SystemInfoSampler`.

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -76,6 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
                     parentId:(SpanId) parentId
                    startTime:(CFAbsoluteTime) startTime
                   firstClass:(BSGTriState) firstClass
+         samplingProbability:(double) samplingProbability
          attributeCountLimit:(NSUInteger)attributeCountLimit
               metricsOptions:(MetricsOptions) metricsOptions
                 onSpanEndSet:(SpanLifecycleCallback) onSpanEndSet

--- a/Sources/BugsnagPerformance/Private/Sampler.h
+++ b/Sources/BugsnagPerformance/Private/Sampler.h
@@ -47,7 +47,14 @@ public:
         } else {
             idUpperBound = uint64_t(p * double(UINT64_MAX));
         }
-        return span.traceIdHi <= idUpperBound;
+        auto isSampled = p > 0.0 && span.traceIdHi <= idUpperBound;
+        if (isSampled) {
+            [span forceMutate:^{
+                [span updateSamplingProbability:p];
+            }];
+        }
+        
+        return isSampled;
     }
 
 private:

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -64,7 +64,6 @@ void Tracer::reprocessEarlySpans(void) {
             continue;
         }
         [span forceMutate:^() {
-            [span updateSamplingProbability:sampler_->getProbability()];
             callOnSpanEndCallbacks(span);
         }];
         if (span.state == SpanStateAborted) {
@@ -135,6 +134,7 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGTriState defaultFirstC
                                                                        parentId:parentSpan.spanId
                                                                       startTime:options.startTime
                                                                      firstClass:firstClass
+                                                            samplingProbability:sampler_->getProbability()
                                                             attributeCountLimit:attributeCountLimit_
                                                                  metricsOptions:options.metricsOptions
                                                                    onSpanEndSet:onSpanEndSet
@@ -176,8 +176,6 @@ void Tracer::onSpanClosed(BugsnagPerformanceSpan *span) {
         [span abortUnconditionally];
         return;
     }
-
-    [span updateSamplingProbability:sampler_->getProbability()];
 
     if (span != nil && span.state == SpanStateEnded) {
         callOnSpanEndCallbacks(span);

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -34,6 +34,7 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
                     parentId:(SpanId) parentId
                    startTime:(CFAbsoluteTime) startAbsTime
                   firstClass:(BSGTriState) firstClass
+         samplingProbability:(double) samplingProbability
          attributeCountLimit:(NSUInteger)attributeCountLimit
               metricsOptions:(MetricsOptions)metricsOptions
                 onSpanEndSet:(SpanLifecycleCallback) onSpanEndSet
@@ -53,7 +54,7 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
         _onSpanClosed = onSpanClosed;
         _onSpanBlocked = onSpanBlocked;
         _kind = SPAN_KIND_INTERNAL;
-        _samplingProbability = 1;
+        _samplingProbability = samplingProbability;
         _state = SpanStateOpen;
         _attributeCountLimit = attributeCountLimit;
         _attributes = [[NSMutableDictionary alloc] init];

--- a/Tests/BugsnagPerformanceTests/BatchTests.mm
+++ b/Tests/BugsnagPerformanceTests/BatchTests.mm
@@ -26,6 +26,7 @@ static BugsnagPerformanceSpan *newSpanData() {
                                                parentId:0
                                               startTime:0
                                              firstClass:BSGTriStateUnset
+                                    samplingProbability:1.0
                                     attributeCountLimit:128
                                          metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}

--- a/Tests/BugsnagPerformanceTests/CrossTalkTests.mm
+++ b/Tests/BugsnagPerformanceTests/CrossTalkTests.mm
@@ -225,6 +225,7 @@ static id hostMissingCrossTalkAPI = nil;
                                                                        parentId:0
                                                                       startTime:0
                                                                      firstClass:BSGTriStateUnset
+                                                            samplingProbability:1.0
                                                             attributeCountLimit:128
                                                                  metricsOptions:metricsOptions
                                                                    onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
@@ -257,6 +258,7 @@ static id hostMissingCrossTalkAPI = nil;
                                                                        parentId:0
                                                                       startTime:0
                                                                      firstClass:BSGTriStateUnset
+                                                            samplingProbability:1.0
                                                             attributeCountLimit:128
                                                                  metricsOptions:metricsOptions
                                                                    onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -185,6 +185,7 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
                                                parentId:parentId
                                               startTime:startAbsTime
                                              firstClass:firstClass
+                                    samplingProbability:1.0
                                     attributeCountLimit:128
                                          metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}

--- a/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanOptionsTests.mm
@@ -50,6 +50,7 @@ using namespace bugsnag;
                                                                        parentId:IdGenerator::generateSpanId()
                                                                       startTime:SpanOptions().startTime 
                                                                      firstClass:BSGTriStateNo
+                                                            samplingProbability:1.0
                                                             attributeCountLimit:128
                                                                  metricsOptions:metricsOptions
                                                                    onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}

--- a/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
@@ -24,6 +24,7 @@ static BugsnagPerformanceSpan *createSpan(std::shared_ptr<SpanStackingHandler> h
                                                parentId:IdGenerator::generateSpanId()
                                               startTime:SpanOptions().startTime
                                              firstClass:BSGTriStateNo
+                                    samplingProbability:1.0
                                     attributeCountLimit:128
                                          metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}

--- a/Tests/BugsnagPerformanceTests/SpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanTests.mm
@@ -35,6 +35,7 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
                                                parentId:0
                                               startTime:startTime
                                              firstClass:BSGTriStateUnset
+                                    samplingProbability:1.0
                                     attributeCountLimit:128
                                          metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan *) {}
@@ -314,6 +315,7 @@ static BugsnagPerformanceSpan *spanWithStartTime(CFAbsoluteTime startTime, SpanL
                                                     parentId:0
                                                    startTime:0
                                                   firstClass:BSGTriStateUnset
+                                         samplingProbability:1.0
                                          attributeCountLimit:5
                                               metricsOptions:metricsOptions
                                                 onSpanEndSet:^(BugsnagPerformanceSpan *) {}

--- a/Tests/BugsnagPerformanceTests/TracerTests.mm
+++ b/Tests/BugsnagPerformanceTests/TracerTests.mm
@@ -131,4 +131,20 @@ static BugsnagPerformanceConfiguration *newConfig() {
     XCTAssertEqualObjects(span.name, @"[HTTP/GET]");
 }
 
+- (void)testStartSpan {
+    auto expectedSamplingProbability = 0.4;
+    auto stackingHandler = std::make_shared<SpanStackingHandler>();
+    auto sampler = std::make_shared<Sampler>();
+    sampler->setProbability(expectedSamplingProbability);
+    auto batch = std::make_shared<Batch>();
+    auto frameMetricsCollector = [FrameMetricsCollector new];
+    auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    SpanOptions spanOptions;
+    auto span = tracer->startSpan(@"TestSpan", spanOptions, BSGTriStateYes);
+    XCTAssertEqual(span.kind, SPAN_KIND_INTERNAL);
+    XCTAssertEqualObjects(span.name, @"TestSpan");
+    XCTAssertEqual(span.samplingProbability, expectedSamplingProbability);
+}
+
 @end

--- a/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
+++ b/Tests/BugsnagPerformanceTests/WeakSpansListTests.mm
@@ -26,6 +26,7 @@ static BugsnagPerformanceSpan *createSpan() {
                                                parentId:IdGenerator::generateSpanId()
                                               startTime:SpanOptions().startTime 
                                              firstClass:BSGTriStateNo
+                                    samplingProbability:1.0
                                     attributeCountLimit:128
                                          metricsOptions:metricsOptions
                                            onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}


### PR DESCRIPTION
Setting sampling probability to 0.0 prevents all spans form being sent

## Goal

Currently `samplingProbability` of a Span is `1.0` by default and it's only updated when the Span is closed.
It should be set to the current Sampler `samplingProbability`, then updated twice: when the Span is ended and when it's in a batch where spans are being selected to be sent out.

Also, setting `samplingProbability` to 0.0 should ensure that no spans are being sent.

## Changeset

- Added `samplingProbability` to `BugsnagPerformanceSpan` private constructor
- Added updating `samplingProbability` to `Sampler.sampled` for spans that pass the sampling
- Removed redundant `samplingProbability` updates on Spans
- Added an explicit check for `samplingProbability` 0.0 in `Sampler.sampled`

## Testing

Unit tests