### PR TITLE
Allow easy cross-layer span parenting

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -109,6 +109,10 @@
 		96D55C812A1EB5F4006D1F29 /* SpanStackingHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 96D55C7D2A1EA5A8006D1F29 /* SpanStackingHandler.h */; };
 		96D55C832A1EBA35006D1F29 /* SpanActivityState.h in Headers */ = {isa = PBXBuildFile; fileRef = 96D55C822A1EBA35006D1F29 /* SpanActivityState.h */; };
 		96D55C882A1EE26A006D1F29 /* SpanStackingHandlerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96D55C872A1EE26A006D1F29 /* SpanStackingHandlerTests.mm */; };
+		96F1292B2DCCB9B900A6FB2B /* BugsnagPerformanceRemoteSpanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 96F1292A2DCCB9B900A6FB2B /* BugsnagPerformanceRemoteSpanContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		96F1292D2DCD141700A6FB2B /* BugsnagPerformanceRemoteSpanContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96F1292C2DCD141700A6FB2B /* BugsnagPerformanceRemoteSpanContext.mm */; };
+		96F1292F2DCD1BE200A6FB2B /* BugsnagPerformanceRemoteSpanContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F1292E2DCD1BE200A6FB2B /* BugsnagPerformanceRemoteSpanContextTests.m */; };
+		96F129312DCD325E00A6FB2B /* BugsnagPerformanceSpanTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96F129302DCD325E00A6FB2B /* BugsnagPerformanceSpanTests.mm */; };
 		CB04969729150D860097E526 /* OtlpPackage.h in Headers */ = {isa = PBXBuildFile; fileRef = CB04969529150D860097E526 /* OtlpPackage.h */; };
 		CB04969829150D860097E526 /* OtlpPackage.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB04969629150D860097E526 /* OtlpPackage.mm */; };
 		CB04969B2915194E0097E526 /* OtlpUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = CB0496992915194E0097E526 /* OtlpUploader.h */; };
@@ -368,6 +372,10 @@
 		96D55C7F2A1EA5C6006D1F29 /* SpanStackingHandler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SpanStackingHandler.mm; sourceTree = "<group>"; };
 		96D55C822A1EBA35006D1F29 /* SpanActivityState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpanActivityState.h; sourceTree = "<group>"; };
 		96D55C872A1EE26A006D1F29 /* SpanStackingHandlerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SpanStackingHandlerTests.mm; sourceTree = "<group>"; };
+		96F1292A2DCCB9B900A6FB2B /* BugsnagPerformanceRemoteSpanContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceRemoteSpanContext.h; sourceTree = "<group>"; };
+		96F1292C2DCD141700A6FB2B /* BugsnagPerformanceRemoteSpanContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceRemoteSpanContext.mm; sourceTree = "<group>"; };
+		96F1292E2DCD1BE200A6FB2B /* BugsnagPerformanceRemoteSpanContextTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagPerformanceRemoteSpanContextTests.m; sourceTree = "<group>"; };
+		96F129302DCD325E00A6FB2B /* BugsnagPerformanceSpanTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceSpanTests.mm; sourceTree = "<group>"; };
 		CB04969529150D860097E526 /* OtlpPackage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OtlpPackage.h; sourceTree = "<group>"; };
 		CB04969629150D860097E526 /* OtlpPackage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OtlpPackage.mm; sourceTree = "<group>"; };
 		CB0496992915194E0097E526 /* OtlpUploader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OtlpUploader.h; sourceTree = "<group>"; };
@@ -539,6 +547,7 @@
 				0122C21929019770002D243C /* BugsnagPerformanceConfiguration.h */,
 				CB0AD76929657381002A3FB6 /* BugsnagPerformanceErrors.h */,
 				0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */,
+				96F1292A2DCCB9B900A6FB2B /* BugsnagPerformanceRemoteSpanContext.h */,
 				0122C21729019770002D243C /* BugsnagPerformanceSpan.h */,
 				964B784F2D39D36900FF077D /* BugsnagPerformanceSpanCondition.h */,
 				0987F2772C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.h */,
@@ -556,6 +565,7 @@
 				0122C21C29019770002D243C /* BugsnagPerformanceConfiguration.mm */,
 				CB0AD7672965734F002A3FB6 /* BugsnagPerformanceErrors.m */,
 				0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */,
+				96F1292C2DCD141700A6FB2B /* BugsnagPerformanceRemoteSpanContext.mm */,
 				0122C21E29019770002D243C /* BugsnagPerformanceSpan.mm */,
 				0987F2782C32D4AD00777FD8 /* BugsnagPerformanceSpanContext.mm */,
 				CB7FD931299D2F7700499E13 /* BugsnagPerformanceSpanOptions.m */,
@@ -579,6 +589,7 @@
 				CB78819B29E587CE00A58906 /* BugsnagPerformanceLibrary.h */,
 				CB78819A29E587CE00A58906 /* BugsnagPerformanceLibrary.mm */,
 				0122C23229019770002D243C /* BugsnagPerformanceSpan+Private.h */,
+				964B78552D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm */,
 				964B785E2D504FD800FF077D /* BugsnagPerformanceSpanCondition+Private.h */,
 				09DC62282C6A2EF6000AA8E1 /* BugsnagPerformanceSpanContext+Private.h */,
 				CBE0873029FA984C007455F2 /* BugsnagPerformanceViewType.mm */,
@@ -628,7 +639,6 @@
 				01A414CC2913C0F0003152A4 /* SpanAttributes.mm */,
 				96D4160D29F276FE00AEE435 /* SpanAttributesProvider.h */,
 				96D4160B29F276E400AEE435 /* SpanAttributesProvider.mm */,
-				964B78552D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm */,
 				0122C22329019770002D243C /* SpanKind.h */,
 				CB7FD935299D330500499E13 /* SpanOptions.h */,
 				96D55C7D2A1EA5A8006D1F29 /* SpanStackingHandler.h */,
@@ -693,7 +703,9 @@
 			children = (
 				CB0AD75C29641B59002A3FB6 /* BatchTests.mm */,
 				CB0AD76B296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm */,
+				96F1292E2DCD1BE200A6FB2B /* BugsnagPerformanceRemoteSpanContextTests.m */,
 				964B785A2D4C20C000FF077D /* BugsnagPerformanceSpanConditionTests.mm */,
+				96F129302DCD325E00A6FB2B /* BugsnagPerformanceSpanTests.mm */,
 				09E313032BF363020081F219 /* CrossTalkTests.mm */,
 				CBEC51C8296ED98F009C0CE3 /* FileBasedTest.h */,
 				CBEC51C9296ED98F009C0CE3 /* FileBasedTest.m */,
@@ -711,11 +723,11 @@
 				CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */,
 				96D55C872A1EE26A006D1F29 /* SpanStackingHandlerTests.mm */,
 				CB2B8A9A2A0924A50054FBBE /* SpanTests.mm */,
+				098FC87A2D3FD095001B627D /* TestHelpers.h */,
 				CB747D20299E5458003CA1B4 /* TimeTests.mm */,
 				09509B742ADFE9A900A358EC /* TracerTests.mm */,
 				09B473092B2313570024CF11 /* WeakSpansListTests.mm */,
 				CB0AD75A295F27DD002A3FB6 /* WorkerTests.mm */,
-				098FC87A2D3FD095001B627D /* TestHelpers.h */,
 			);
 			path = BugsnagPerformanceTests;
 			sourceTree = "<group>";
@@ -887,6 +899,7 @@
 				098FC8542D37A08D001B627D /* SystemInfoSampler.h in Headers */,
 				CBEC51C0296DB312009C0CE3 /* JSON.h in Headers */,
 				09B473072B23087D0024CF11 /* WeakSpansList.h in Headers */,
+				96F1292B2DCCB9B900A6FB2B /* BugsnagPerformanceRemoteSpanContext.h in Headers */,
 				09F23A8C2CE351ED00F0D769 /* BugsnagSwiftTools.h in Headers */,
 				0921F02B2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h in Headers */,
 				964B785F2D504FD800FF077D /* BugsnagPerformanceSpanCondition+Private.h in Headers */,
@@ -1196,6 +1209,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96F129312DCD325E00A6FB2B /* BugsnagPerformanceSpanTests.mm in Sources */,
 				CBEC51E129793B1E009C0CE3 /* RetryQueueTests.mm in Sources */,
 				01A58C11290931A5006E4DF7 /* SamplerTests.mm in Sources */,
 				CBEC51C5296ED8BA009C0CE3 /* PersistentStateTests.mm in Sources */,
@@ -1220,6 +1234,7 @@
 				962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */,
 				CB747D1F299E4984003CA1B4 /* SpanOptionsTests.mm in Sources */,
 				CB0AD76C296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm in Sources */,
+				96F1292F2DCD1BE200A6FB2B /* BugsnagPerformanceRemoteSpanContextTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1255,6 +1270,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96F1292D2DCD141700A6FB2B /* BugsnagPerformanceRemoteSpanContext.mm in Sources */,
 				CB0AD7682965734F002A3FB6 /* BugsnagPerformanceErrors.m in Sources */,
 				0122C24E29019770002D243C /* OtlpTraceEncoding.mm in Sources */,
 				098FC8472D2EB8E8001B627D /* BSGPSystemInfo.mm in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+### Enhancements
+
+* Introduced `BugsnagPerformanceRemoteSpanContext` to allow cross-layer parenting of spans, along with easy encoding of `traceparent` headers.
+  [433](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/433)
+
 ### Bug fixes
 
 * Fixed issue where a very small percentage of spans could be sent even though samplingProbability was set to 0.0.

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -66,6 +66,10 @@ public:
     void endViewLoadSpan(UIViewController *controller, NSDate *endTime) noexcept;
 
     void onSpanStarted() noexcept;
+    
+    BugsnagPerformanceSpanContext *currentContext() noexcept {
+        return spanStackingHandler_->currentSpan();
+    }
 
     void setOnViewLoadSpanStarted(std::function<void(NSString *)> onViewLoadSpanStarted) noexcept {
         tracer_->setOnViewLoadSpanStarted(onViewLoadSpanStarted);

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanContext+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanContext+Private.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagPerformanceSpanContext ()
 
+- (NSString *)encodedAsTraceParentWithSampled:(BOOL)sampled;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/NetworkHeaderInjector.mm
+++ b/Sources/BugsnagPerformance/Private/NetworkHeaderInjector.mm
@@ -21,9 +21,7 @@ NSString *NetworkHeaderInjector::generateTraceParent(BugsnagPerformanceSpan *spa
         return nil;
     }
     // Sampled status assumes that the current P value won't change soon.
-    return [NSString stringWithFormat:@"00-%016llx%016llx-%016llx-0%d",
-            span.traceIdHi, span.traceIdLo,
-            span.spanId, sampler_->sampled(span)];
+    return [span encodedAsTraceParentWithSampled:sampler_->sampled(span)];
 }
 
 @protocol RequestSetter <NSObject>

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -63,4 +63,8 @@ using namespace bugsnag;
     BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->reportNetworkSpan(task, metrics);
 }
 
++ (BugsnagPerformanceSpanContext *)currentContext {
+    return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->currentContext();
+}
+
 @end

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceRemoteSpanContext.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceRemoteSpanContext.mm
@@ -16,7 +16,7 @@ static const int kTraceParentComponentSpanId = 2;
 @implementation BugsnagPerformanceRemoteSpanContext
 
 + (nullable instancetype)contextWithTraceParentString:(NSString *)traceParentString {
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9]{2}$" options:0 error:nil];
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9]{2}$" options:0 error:nil];
     NSRange allStringRange = NSMakeRange(0, [traceParentString length]);
     NSRange rangeOfFirstMatch = [regex rangeOfFirstMatchInString:traceParentString options:0 range:allStringRange];
     if (!NSEqualRanges(rangeOfFirstMatch, allStringRange)) {

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceRemoteSpanContext.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceRemoteSpanContext.mm
@@ -1,0 +1,42 @@
+//
+//  BugsnagPerformanceRemoteSpanContext.mm
+//  BugsnagPerformance-iOS
+//
+//  Created by Robert B on 07/05/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformanceRemoteSpanContext.h>
+#import "../Private/Utils.h"
+
+static const int kTraceParentComponentTraceId = 1;
+static const int kTraceParentComponentSpanId = 2;
+
+@implementation BugsnagPerformanceRemoteSpanContext
+
++ (nullable instancetype)contextWithTraceParentString:(NSString *)traceParentString {
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9]{2}$" options:0 error:nil];
+    NSRange allStringRange = NSMakeRange(0, [traceParentString length]);
+    NSRange rangeOfFirstMatch = [regex rangeOfFirstMatchInString:traceParentString options:0 range:allStringRange];
+    if (!NSEqualRanges(rangeOfFirstMatch, allStringRange)) {
+        BSGLogError(@"Could not decode traceparent string %@ because it is not in correct format", traceParentString);
+        return nil;
+    }
+    
+    auto components = [traceParentString componentsSeparatedByString:@"-"];
+    auto traceIdString = components[kTraceParentComponentTraceId];
+    auto traceIdHiString = [traceIdString substringToIndex:16];
+    auto traceIdLoString = [traceIdString substringFromIndex:16];
+    auto spanIdString = components[kTraceParentComponentSpanId];
+    
+    uint64_t traceIdHi = 0;
+    [[NSScanner scannerWithString:traceIdHiString] scanHexLongLong:&traceIdHi];
+    uint64_t traceIdLo = 0;
+    [[NSScanner scannerWithString:traceIdLoString] scanHexLongLong:&traceIdLo];
+    SpanId spanId = 0;
+    [[NSScanner scannerWithString:spanIdString] scanHexLongLong:&spanId];
+    return [[BugsnagPerformanceRemoteSpanContext alloc] initWithTraceId:{.hi = traceIdHi, .lo = traceIdLo } spanId:spanId];
+}
+
+@end

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -8,6 +8,7 @@
 #import "../Private/BugsnagPerformanceSpan+Private.h"
 #import "../Private/Utils.h"
 #import "../Private/SpanOptions.h"
+#import "../Private/Sampler.h"
 
 using namespace bugsnag;
 
@@ -233,6 +234,10 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
 
 - (BOOL)isValid {
     return self.state == SpanStateOpen;
+}
+
+- (NSString *)encodedAsTraceParent {
+    return [self encodedAsTraceParentWithSampled: Sampler::calculateIsSampled(self.traceId, self.samplingProbability)];
 }
 
 - (void)setAttribute:(NSString *)attributeName withValue:(id)value {

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanContext.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanContext.mm
@@ -22,6 +22,14 @@
     return [self initWithTraceId:TraceId{.hi=traceIdHi, .lo=traceIdLo} spanId:spanId];
 }
 
+- (NSString *)encodedAsTraceParent {
+    return [self encodedAsTraceParentWithSampled:YES];
+}
+
+- (NSString *)encodedAsTraceParentWithSampled:(BOOL)sampled {
+    return [NSString stringWithFormat:@"00-%016llx%016llx-%016llx-0%d", self.traceIdHi, self.traceIdLo, self.spanId, sampled];
+}
+
 - (uint64_t) traceIdHi {
     return self.traceId.hi;
 }

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -13,6 +13,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
 #import <BugsnagPerformance/BugsnagPerformanceNetworkRequestInfo.h>
 #import <BugsnagPerformance/BugsnagPerformanceTrackedViewContainer.h>
+#import <BugsnagPerformance/BugsnagPerformanceRemoteSpanContext.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,6 +31,8 @@ OBJC_EXPORT
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name NS_SWIFT_NAME(startSpan(name:));
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name options:(BugsnagPerformanceSpanOptions *)options NS_SWIFT_NAME(startSpan(name:options:));
+
++ (BugsnagPerformanceSpanContext *)currentContext;
 
 @end
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceRemoteSpanContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceRemoteSpanContext.h
@@ -1,0 +1,20 @@
+//
+//  BugsnagPerformanceRemoteSpanContext.h
+//  BugsnagPerformance
+//
+//  Created by Robert B on 07/05/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+OBJC_EXPORT
+@interface BugsnagPerformanceRemoteSpanContext: BugsnagPerformanceSpanContext
+
++ (nullable instancetype)contextWithTraceParentString:(NSString *)traceParentString;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanContext.h
@@ -32,6 +32,8 @@ OBJC_EXPORT
 
 - (instancetype) initWithTraceIdHi:(uint64_t)traceIdHi traceIdLo:(uint64_t)traceIdLo spanId:(SpanId)spanId;
 
+- (NSString *)encodedAsTraceParent;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceRemoteSpanContextTests.m
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceRemoteSpanContextTests.m
@@ -1,0 +1,78 @@
+//
+//  BugsnagPerformanceRemoteSpanContextTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Robert B on 07/05/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformance.h>
+
+@interface BugsnagPerformanceRemoteSpanContextTests : XCTestCase
+
+@end
+
+@implementation BugsnagPerformanceRemoteSpanContextTests
+
+- (void)testContextWithTraceParentStringReturnsNilIfTheStringIsEmpty {
+    XCTAssertNil([BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:@""]);
+}
+
+- (void)testContextWithTraceParentStringReturnsNilIfTheStringDoesntContainEnoughComponents {
+    XCTAssertNil([BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:@"0-0-0"]);
+}
+
+- (void)testContextWithTraceParentStringReturnsNilIfTheIdsArentTooShort {
+    XCTAssertNil([BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:@"0-032432414-0324234-0"]);
+}
+
+- (void)testContextWithTraceParentStringReturnsNilIfTheIdsArentHex {
+    XCTAssertNil([BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:@"00-a053e37f6d56591zc15a2c13c3c6ttfq-eeb87b8b7cdz2185-01"]);
+}
+
+- (void)testContextWithTraceParentStringReturnsNilIfTheIdsContainUppercaseLetters {
+    XCTAssertNil([BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:@"00-A053E37F6D56591BC15A2C13C3C688F3-EEB87B8B7CDE2185-01"]);
+}
+
+
+- (void)testContextWithTraceParentStringReturnsAContextForAllZeros {
+    BugsnagPerformanceSpanContext *context = [BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:@"00-00000000000000000000000000000000-0000000000000000-00"];
+    TraceId traceId = {.hi = 0, .lo = 0};
+    XCTAssertNotNil(context);
+    XCTAssertEqual(context.traceId.hi, traceId.hi);
+    XCTAssertEqual(context.traceId.lo, traceId.lo);
+    XCTAssertEqual(context.traceId.value, traceId.value);
+    XCTAssertEqual(context.spanId, 0);
+}
+
+- (void)testContextWithTraceParentStringReturnsAContextForMaxValue {
+    BugsnagPerformanceSpanContext *context = [BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:@"00-ffffffffffffffffffffffffffffffff-ffffffffffffffff-00"];
+    TraceId traceId = {.hi = UINT64_MAX, .lo = UINT64_MAX};
+    XCTAssertNotNil(context);
+    XCTAssertEqual(context.traceId.hi, traceId.hi);
+    XCTAssertEqual(context.traceId.lo, traceId.lo);
+    XCTAssertEqual(context.traceId.value, traceId.value);
+    XCTAssertEqual(context.spanId, UINT64_MAX);
+}
+
+- (void)testContextWithTraceParentStringReturnsAContextForValues {
+    BugsnagPerformanceSpanContext *context = [BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:@"00-a053e37f6d56591bc15a2c13c3c688f3-eeb87b8b7cde2185-01"];
+    TraceId traceId = {.hi = 11552827605570181403U, .lo = 13932496860624619763U};
+    SpanId spanId = 17201634615767212421U;
+    XCTAssertNotNil(context);
+    XCTAssertEqual(context.traceId.hi, traceId.hi);
+    XCTAssertEqual(context.traceId.lo, traceId.lo);
+    XCTAssertEqual(context.traceId.value, traceId.value);
+    XCTAssertEqual(context.spanId, spanId);
+}
+
+- (void)testContextWithTraceParentEncodesToTheSameTraceParent {
+    NSString *traceparentString = @"00-a053e37f6d56591bc15a2c13c3c688f3-eeb87b8b7cde2185-01";
+    BugsnagPerformanceSpanContext *context = [BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:traceparentString];
+    XCTAssertNotNil(context);
+    XCTAssertEqualObjects([context encodedAsTraceParent], traceparentString);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceSpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceSpanTests.mm
@@ -1,0 +1,69 @@
+//
+//  BugsnagPerformanceSpanTests.m
+//  BugsnagPerformance-iOSTests
+//
+//  Created by Robert B on 08/05/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformance.h>
+#import "../../Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h"
+#import "BugsnagPerformanceSpan+Private.h"
+
+static BugsnagPerformanceSpan *createSpan(TraceId traceId, SpanId spanId, double samplingProbability) {
+    MetricsOptions metricsOptions;
+    return [[BugsnagPerformanceSpan alloc] initWithName:@"test"
+                                                traceId:traceId
+                                                 spanId:spanId
+                                               parentId:0
+                                              startTime:SpanOptions().startTime
+                                             firstClass:BSGTriStateNo
+                                    samplingProbability:samplingProbability
+                                    attributeCountLimit:128
+                                         metricsOptions:metricsOptions
+                                           onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
+                                           onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {}
+                                          onSpanBlocked:^BugsnagPerformanceSpanCondition * _Nullable(BugsnagPerformanceSpan * _Nonnull, NSTimeInterval) { return nil; }];
+}
+
+@interface BugsnagPerformanceSpanTests : XCTestCase
+
+@end
+
+@implementation BugsnagPerformanceSpanTests
+
+- (void)testEncodeAsTraceParentWhenSampled {
+    TraceId traceId = {.hi = 11552827605570181403U, .lo = 13932496860624619763U};
+    SpanId spanId = 17201634615767212421U;
+    
+    BugsnagPerformanceSpan *span = createSpan(traceId, spanId, 0.9);
+    XCTAssertEqualObjects([span encodedAsTraceParent], @"00-a053e37f6d56591bc15a2c13c3c688f3-eeb87b8b7cde2185-01");
+}
+
+- (void)testEncodeAsTraceParentWhenNotSampled {
+    TraceId traceId = {.hi = 11552827605570181403U, .lo = 13932496860624619763U};
+    SpanId spanId = 17201634615767212421U;
+    
+    BugsnagPerformanceSpan *span = createSpan(traceId, spanId, 0.0);
+    XCTAssertEqualObjects([span encodedAsTraceParent], @"00-a053e37f6d56591bc15a2c13c3c688f3-eeb87b8b7cde2185-00");
+}
+
+- (void)testEncodeAsTraceParentWhenSamplingSetToTrue {
+    TraceId traceId = {.hi = 11552827605570181403U, .lo = 13932496860624619763U};
+    SpanId spanId = 17201634615767212421U;
+    
+    BugsnagPerformanceSpan *span = createSpan(traceId, spanId, 0.9);
+    XCTAssertEqualObjects([span encodedAsTraceParentWithSampled:YES], @"00-a053e37f6d56591bc15a2c13c3c688f3-eeb87b8b7cde2185-01");
+}
+
+- (void)testEncodeAsTraceParentWhenSamplingSetToFalse {
+    TraceId traceId = {.hi = 11552827605570181403U, .lo = 13932496860624619763U};
+    SpanId spanId = 17201634615767212421U;
+    
+    BugsnagPerformanceSpan *span = createSpan(traceId, spanId, 0.9);
+    XCTAssertEqualObjects([span encodedAsTraceParentWithSampled:NO], @"00-a053e37f6d56591bc15a2c13c3c688f3-eeb87b8b7cde2185-00");
+}
+
+@end

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -494,3 +494,19 @@ Feature: Manual creation of spans
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * a span named "SpanConditionsMultipleConditionsScenarioSpan3" ended after a span named "SpanConditionsMultipleConditionsScenarioSpan2"
     * a span named "SpanConditionsMultipleConditionsScenarioSpan1" ended after a span named "SpanConditionsMultipleConditionsScenarioSpan3"
+
+  Scenario: Manually start and end a span with remote parent context
+    Given I run "ManualSpanWithRemoteContextParentScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "ManualSpanWithRemoteContextParentScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" equals "a053e37f6d56592bc15a2c13c3c688ff"
+    * every span field "parentSpanId" equals "eeb87b8b7cde2185"
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span string attribute "bugsnag.span.category" equals "custom"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -57,8 +57,8 @@
 		09F025092BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */; };
 		09F025152BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */; };
 		09F23AC12CF0CBB500F0D769 /* AutoInstrumentGenericViewLoadScenario2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F23AC02CF0CBB500F0D769 /* AutoInstrumentGenericViewLoadScenario2.swift */; };
-		09F3F5302D6F17B300BAA0A3 /* RenderingMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F3F52F2D6F17B300BAA0A3 /* RenderingMetricsScenario.swift */; };
 		09F3F5282D6C728300BAA0A3 /* MemoryMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F3F5272D6C728300BAA0A3 /* MemoryMetricsScenario.swift */; };
+		09F3F5302D6F17B300BAA0A3 /* RenderingMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F3F52F2D6F17B300BAA0A3 /* RenderingMetricsScenario.swift */; };
 		960EECE92B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960EECE82B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift */; };
 		96284DCE2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96284DCD2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift */; };
 		964735CB2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964735CA2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */; };
@@ -77,6 +77,7 @@
 		96D528CC2C72B14300FEA2E2 /* AppDataOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */; };
 		96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */; };
 		96D528D02C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */; };
+		96F129352DCE0CFE00A6FB2B /* ManualSpanWithRemoteContextParentScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F129342DCE0CFE00A6FB2B /* ManualSpanWithRemoteContextParentScenario.swift */; };
 		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
@@ -153,8 +154,8 @@
 		09F025082BA08817007D9F73 /* AutoInstrumentNetworkNullURLScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkNullURLScenario.swift; sourceTree = "<group>"; };
 		09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDidLoadDoesntTriggerScenario.swift; sourceTree = "<group>"; };
 		09F23AC02CF0CBB500F0D769 /* AutoInstrumentGenericViewLoadScenario2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentGenericViewLoadScenario2.swift; sourceTree = "<group>"; };
-		09F3F52F2D6F17B300BAA0A3 /* RenderingMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderingMetricsScenario.swift; sourceTree = "<group>"; };
 		09F3F5272D6C728300BAA0A3 /* MemoryMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryMetricsScenario.swift; sourceTree = "<group>"; };
+		09F3F52F2D6F17B300BAA0A3 /* RenderingMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderingMetricsScenario.swift; sourceTree = "<group>"; };
 		960EECE82B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentGenericViewLoadScenario.swift; sourceTree = "<group>"; };
 		96284DCD2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentPreLoadedViewLoadScenario.swift; sourceTree = "<group>"; };
 		964735CA2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkSharedSessionInvalidateScenario.swift; sourceTree = "<group>"; };
@@ -173,6 +174,7 @@
 		96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataOverrideScenario.swift; sourceTree = "<group>"; };
 		96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityOneScenario.swift; sourceTree = "<group>"; };
 		96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityZeroScenario.swift; sourceTree = "<group>"; };
+		96F129342DCE0CFE00A6FB2B /* ManualSpanWithRemoteContextParentScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanWithRemoteContextParentScenario.swift; sourceTree = "<group>"; };
 		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackSetToNilScenario.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
@@ -325,6 +327,7 @@
 				093EE63C2C32E5B900632B30 /* ManualParentSpanScenario.swift */,
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
+				96F129342DCE0CFE00A6FB2B /* ManualSpanWithRemoteContextParentScenario.swift */,
 				CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */,
 				098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */,
 				01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */,
@@ -337,6 +340,7 @@
 				CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */,
 				CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */,
 				967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */,
+				09F3F52F2D6F17B300BAA0A3 /* RenderingMetricsScenario.swift */,
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
@@ -347,7 +351,6 @@
 				96986D9F2D50654500A44C34 /* SpanConditionsMultipleConditionsScenario.swift */,
 				96986D9D2D5060E600A44C34 /* SpanConditionsSimpleConditionScenario.swift */,
 				09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */,
-				09F3F52F2D6F17B300BAA0A3 /* RenderingMetricsScenario.swift */,
 				098FC87B2D40EAB8001B627D /* CPUMetricsScenario.swift */,
 			);
 			path = Scenarios;
@@ -515,6 +518,7 @@
 				094F41E62C4A84D6008162A4 /* SetAttributesScenario.swift in Sources */,
 				09637A412B060E7C00F4F776 /* CommandReaderThread.swift in Sources */,
 				CBC90CE029CDD02800280884 /* FirstClassYesScenario.swift in Sources */,
+				96F129352DCE0CFE00A6FB2B /* ManualSpanWithRemoteContextParentScenario.swift in Sources */,
 				09F025072BA08804007D9F73 /* ObjCURLSession.m in Sources */,
 				0988B5392CAD36C500D131B1 /* InfraCheckMinimalBugsnagScenario.swift in Sources */,
 				CBC90CDE29CDCFF700280884 /* FirstClassNoScenario.swift in Sources */,

--- a/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */; };
 		96D528D02C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */; };
 		96E0B34B2CD0E21C008AEB9C /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E0B34A2CD0E21C008AEB9C /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */; };
+		96F129332DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F129322DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift */; };
 		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
@@ -188,6 +189,7 @@
 		96D528CD2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityOneScenario.swift; sourceTree = "<group>"; };
 		96D528CF2C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSamplingProbabilityZeroScenario.swift; sourceTree = "<group>"; };
 		96E0B34A2CD0E21C008AEB9C /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkSharedSessionInvalidateScenario.swift; sourceTree = "<group>"; };
+		96F129322DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderingMetricsScenario.swift; sourceTree = "<group>"; };
 		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackSetToNilScenario.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 				CBE615F629A4C1F0000E72D8 /* ParentSpanScenario.swift */,
 				CBE43A9829A8EFA3000B4205 /* ProbabilityExpiryScenario.swift */,
 				967F6F1929C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift */,
+				96F129322DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift */,
 				CBF62108291A4F47004BEE0B /* RetryScenario.swift */,
 				01A58C1429096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift */,
 				01FE4DC428E1AF9600D1F239 /* Scenario.swift */,
@@ -473,6 +476,7 @@
 				CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */,
 				093EE63D2C32E5B900632B30 /* ManualParentSpanScenario.swift in Sources */,
 				01FE4DA928E1AEBD00D1F239 /* AppDelegate.swift in Sources */,
+				96F129332DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift in Sources */,
 				096EE5EF2B3C2B3E006059CE /* AutoInstrumentSwiftUIDeferredScenario.swift in Sources */,
 				CBAAE2592912601D006D4AA0 /* BatchingScenario.swift in Sources */,
 				96284DCE2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/ManualSpanWithRemoteContextParentScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualSpanWithRemoteContextParentScenario.swift
@@ -1,0 +1,24 @@
+//
+//  ManualSpanWithRemoteContextParentScenario.swift
+//  Fixture
+//
+//  Created by Robert B on 08/05/2025.
+//
+
+import Bugsnag
+import BugsnagPerformance
+
+@objcMembers
+class ManualSpanWithRemoteContextParentScenario: Scenario {
+
+    override func run() {
+        let context = BugsnagPerformanceRemoteSpanContext(traceParentString: "00-a053e37f6d56592bc15a2c13c3c688ff-eeb87b8b7cde2185-01")
+        let opts = BugsnagPerformanceSpanOptions()
+        opts.setParentContext(context)
+        let span = BugsnagPerformance.startSpan(
+            name: "ManualSpanWithRemoteContextParentScenario",
+            options: opts
+        )
+        span.end()
+    }
+}


### PR DESCRIPTION
## Goal

Allow easy cross-layer span parenting so that spans can be nested under spans from remote servers or non-native app layers (such as JavaScript in a WebView).

## Design

Introduced the new `BugsnagPerformanceRemoteSpanContext` class that encapsulates encoding & parsing of `BugsnagPerformanceSpanContexts` in the `traceparent` header format. The encoding can be applied to any `BugsnagPerformanceSpanContext` object, and the strings can be parsed into `BugsnagPerformanceRemoteSpanContext` objects.

## Testing

Unit tests and E2E tests