### PR TITLE
onSpanStart callbacks

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
@@ -56,6 +56,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic,readwrite) BSGInternalConfiguration *internal;
 
+@property (nonatomic) NSMutableArray<BugsnagPerformanceSpanStartCallback> *onSpanStartCallbacks;
+
 @property (nonatomic) NSMutableArray<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks;
 
 @end

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -40,6 +40,7 @@ public:
     void earlyConfigure(BSGEarlyConfiguration *) noexcept;
     void earlySetup() noexcept {}
     void configure(BugsnagPerformanceConfiguration *config) noexcept {
+        onSpanStartCallbacks_ = config.onSpanStartCallbacks;
         onSpanEndCallbacks_ = config.onSpanEndCallbacks;
         attributeCountLimit_ = config.attributeCountLimit;
         enabledMetrics_ = [config.enabledMetrics clone];
@@ -90,6 +91,7 @@ private:
     std::mutex prewarmSpansMutex_;
     NSMutableArray<BugsnagPerformanceSpan *> *prewarmSpans_;
     NSMutableArray<BugsnagPerformanceSpan *> *blockedSpans_;
+    NSArray<BugsnagPerformanceSpanStartCallback> *onSpanStartCallbacks_;
     NSArray<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks_;
     NSUInteger attributeCountLimit_{128};
 
@@ -109,5 +111,6 @@ private:
     void reprocessEarlySpans(void);
     void processFrameMetrics(BugsnagPerformanceSpan *span) noexcept;
     bool shouldInstrumentRendering(BugsnagPerformanceSpan *span) noexcept;
+    void callOnSpanStartCallbacks(BugsnagPerformanceSpan *span);
 };
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -149,6 +149,9 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGTriState defaultFirstC
     }
     [span internalSetMultipleAttributes:SpanAttributes::get()];
     potentiallyOpenSpans_->add(span);
+    
+    callOnSpanStartCallbacks(span);
+    
     onSpanStarted_();
     return span;
 }
@@ -233,6 +236,20 @@ BugsnagPerformanceSpanCondition *Tracer::onSpanBlocked(BugsnagPerformanceSpan *s
     this->conditionTimeoutExecutor_->sheduleTimeout(condition, timeout);
     BSGLogTrace(@"Tracer::onSpanBlocked: Blocked span %@ with timeout %f", span.name, timeout);
     return condition;
+}
+
+void Tracer::callOnSpanStartCallbacks(BugsnagPerformanceSpan *span) {
+    if(span == nil) {
+        return;
+    }
+
+    for (BugsnagPerformanceSpanEndCallback callback: onSpanStartCallbacks_) {
+        @try {
+            callback(span);
+        } @catch(NSException *e) {
+            BSGLogError(@"Tracer::callOnSpanStartCallbacks: span onStart callback threw exception: %@", e);
+        }
+    }
 }
 
 void Tracer::callOnSpanEndCallbacks(BugsnagPerformanceSpan *span) {
@@ -384,7 +401,7 @@ Tracer::onPrewarmPhaseEnded(void) noexcept {
     [prewarmSpans_ removeAllObjects];
 }
 
-bool 
+bool
 Tracer::shouldInstrumentRendering(BugsnagPerformanceSpan *span) noexcept {
     switch (span.metricsOptions.rendering) {
         case BSGTriStateYes:
@@ -393,7 +410,7 @@ Tracer::shouldInstrumentRendering(BugsnagPerformanceSpan *span) noexcept {
             return false;
         case BSGTriStateUnset:
             return enabledMetrics_.rendering &&
-            !span.wasStartOrEndTimeProvided && 
+            !span.wasStartOrEndTimeProvided &&
             span.firstClass == BSGTriStateYes;
     }
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -70,6 +70,7 @@ using namespace bugsnag;
         _autoInstrumentViewControllers = YES;
         _autoInstrumentNetworkRequests = YES;
         _enabledMetrics = [BugsnagPerformanceEnabledMetrics new];
+        _onSpanStartCallbacks = [NSMutableArray array];
         _onSpanEndCallbacks = [NSMutableArray array];
         _attributeArrayLengthLimit = DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT;
         _attributeStringValueLimit = DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT;
@@ -265,6 +266,10 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
 - (BOOL)shouldSendReports {
     return self.enabledReleaseStages.count == 0 ||
            [self.enabledReleaseStages containsObject:self.releaseStage ?: @""];
+}
+
+- (void) addOnSpanStartCallback:(BugsnagPerformanceSpanStartCallback) callback {
+    [self.onSpanStartCallbacks addObject:callback];
 }
 
 - (void) addOnSpanEndCallback:(BugsnagPerformanceSpanEndCallback) callback {

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef BOOL (^ BugsnagPerformanceViewControllerInstrumentationCallback)(UIViewController *viewController);
 
+typedef void (^ BugsnagPerformanceSpanStartCallback)(BugsnagPerformanceSpan *span);
+
 typedef BOOL (^ BugsnagPerformanceSpanEndCallback)(BugsnagPerformanceSpan *span);
 
 OBJC_EXPORT
@@ -38,6 +40,15 @@ OBJC_EXPORT
 + (instancetype)loadConfig;
 
 - (BOOL) validate:(NSError * __autoreleasing _Nullable *)error NS_SWIFT_NAME(validate());
+
+/**
+ * Add a callback that get called whenever a span is started.
+ * This callback can be used to setup the span before it is
+ * used (such as setting attributes). These callbacks are considered to be "inside" the span, so
+ * any time taken to run the callback is counted towards the span's duration.
+ *
+ */
+- (void) addOnSpanStartCallback:(BugsnagPerformanceSpanStartCallback) callback;
 
 /**
  * Add a callback that get called whenever a span ends.

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -337,6 +337,15 @@ Feature: Manual creation of spans
     * a span field "name" equals "SetAttributeCountLimitScenario"
     * every span string attribute "a" does not exist
 
+  Scenario: Set OnStart
+    Given I run "OnStartCallbackScenario"
+    And I wait for exactly 1 span
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "OnStartCallbackScenario"
+    * a span bool attribute "start_callback_1" is true
+    * a span bool attribute "start_callback_2" is true
+
   Scenario: Set OnEnd
     Given I run "OnEndCallbackScenario"
     And I wait for exactly 1 span

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */; };
 		CBEC89452A4ED0590088A3CE /* MaxPayloadSizeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
+		DADB14F92DE08A030006F44F /* OnStartCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -198,6 +199,7 @@
 		CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkMultiple.swift; sourceTree = "<group>"; };
 		CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxPayloadSizeScenario.swift; sourceTree = "<group>"; };
 		CBF62108291A4F47004BEE0B /* RetryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryScenario.swift; sourceTree = "<group>"; };
+		DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnStartCallbackScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -275,6 +277,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
 				099331FB2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift */,
@@ -530,6 +533,7 @@
 				0921F02E2A69262300C764EB /* AutoInstrumentNetworkCallbackScenario.swift in Sources */,
 				01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */,
 				09DC622A2C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift in Sources */,
+				DADB14F92DE08A030006F44F /* OnStartCallbackScenario.swift in Sources */,
 				CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */; };
 		CBEC89452A4ED0590088A3CE /* MaxPayloadSizeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
+		DADB14F72DDF852B0006F44F /* OnStartCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -213,6 +214,7 @@
 		CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkMultiple.swift; sourceTree = "<group>"; };
 		CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxPayloadSizeScenario.swift; sourceTree = "<group>"; };
 		CBF62108291A4F47004BEE0B /* RetryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryScenario.swift; sourceTree = "<group>"; };
+		DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnStartCallbackScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -292,6 +294,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
 				099331FB2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift */,
@@ -487,6 +490,7 @@
 				96986DA62D506B8F00A44C34 /* SpanConditionsSimpleConditionScenario.swift in Sources */,
 				09E0455F2C94662B003882D3 /* SetAttributesWithLimitsScenario.swift in Sources */,
 				01E3F99128F46B6700003F44 /* ManualViewLoadScenario.swift in Sources */,
+				DADB14F72DDF852B0006F44F /* OnStartCallbackScenario.swift in Sources */,
 				96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */,
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/OnStartCallbackScenario.swift
+++ b/features/fixtures/ios/Scenarios/OnStartCallbackScenario.swift
@@ -1,0 +1,39 @@
+//
+//  OnStartCallbackScenario.swift
+//  Fixture
+//
+//  Created by Yousif Ahmed on 22/05/2025.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class OnStartCallbackScenario: Scenario {
+
+    override func setInitialBugsnagConfiguration() {
+        super.setInitialBugsnagConfiguration()
+
+        bugsnagPerfConfig.add(onSpanStartCallback: { (span: BugsnagPerformanceSpan) in
+            span.setAttribute("start_callback_1", withValue: true)
+        })
+
+        bugsnagPerfConfig.add(onSpanStartCallback: { (span: BugsnagPerformanceSpan) in
+            self.errorGenerator.throwObjCException()
+        })
+
+        bugsnagPerfConfig.add(onSpanStartCallback: { (span: BugsnagPerformanceSpan) in
+            // Swift is actually auto-compiling in a catch-and-convert-to-NSError
+            // whenever a Swift throw crosses the Swift-ObjC membrane. But we do this
+            // anyway just in case something changes and this starts to break.
+            self.errorGenerator.throwSwiftException()
+        })
+
+        bugsnagPerfConfig.add(onSpanStartCallback: { (span: BugsnagPerformanceSpan) in
+            span.setAttribute("start_callback_2", withValue: true)
+        })
+    }
+
+    override func run() {
+        BugsnagPerformance.startSpan(name: "OnStartCallbackScenario").end()
+    }
+}


### PR DESCRIPTION
## Goal

Introduce a new `onSpanStart` callback to complete the "span lifecycle callbacks" set (alongside the existing`onSpanEnd` callback).

## Design

The configured `onSpanStart` callbacks will be triggered for every span started after `BugsnagPerformance.start` is called. Each new span is fully configured and its core attributes are set before each OnSpanStartCallback is invoked (allowing them to inspect the span, and add new attributes if required).

Unlike `onSpanEnd` callbacks, the start callbacks have no return value and cannot block a span from being started. Any exceptions thrown within an `onSpanStart` callback are caught and logged.

## Testing

Added a new e2e test scenario to test that callbacks are applied and exceptions are handled gracefully
