### PR TITLE
Set default endpoints based on API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Set default endpoints based on API key [#441](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/441)
+
 ## 1.13.0 (2025-05-12)
 
 ### Bug fixes

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -29,6 +29,7 @@ using namespace bugsnag;
 #define HUB_API_PREFIX @"00000"
 
 static inline NSURL *DefaultEndpointForKey(NSString *apiKey) {
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
     NSString *fmt = [apiKey hasPrefix:HUB_API_PREFIX]
         ? DEFAULT_HUB_URL_FORMAT
         : DEFAULT_URL_FORMAT;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -25,6 +25,15 @@ using namespace bugsnag;
 #define DEFAULT_ATTRIBUTE_COUNT_LIMIT 128
 
 #define DEFAULT_URL_FORMAT @"https://%@.otlp.bugsnag.com/v1/traces"
+#define DEFAULT_HUB_URL_FORMAT @"https://%@.otlp.insighthub.smartbear.com/v1/traces"
+#define HUB_API_PREFIX @"00000"
+
+static inline NSURL *DefaultEndpointForKey(NSString *apiKey) {
+    NSString *fmt = [apiKey hasPrefix:HUB_API_PREFIX]
+        ? DEFAULT_HUB_URL_FORMAT
+        : DEFAULT_URL_FORMAT;
+    return nsurlWithString([NSString stringWithFormat:fmt, apiKey], nil);
+}
 
 @implementation BugsnagPerformanceEnabledMetrics
 
@@ -65,7 +74,7 @@ using namespace bugsnag;
     if ((self = [super init])) {
         _internal = [BSGInternalConfiguration new];
         _apiKey = [apiKey copy];
-        _endpoint = nsurlWithString([NSString stringWithFormat: DEFAULT_URL_FORMAT, apiKey], nil);
+        _endpoint = DefaultEndpointForKey(apiKey);
         _autoInstrumentAppStarts = YES;
         _autoInstrumentViewControllers = YES;
         _autoInstrumentNetworkRequests = YES;
@@ -126,9 +135,9 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
 
 - (void)setApiKey:(NSString *)apiKey {
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    _apiKey = apiKey;
+    _apiKey = [apiKey copy];
     if (!_didSetCustomEndpoint) {
-        _endpoint = nsurlWithString([NSString stringWithFormat: DEFAULT_URL_FORMAT, apiKey], nil);
+        _endpoint = DefaultEndpointForKey(apiKey);
     }
 }
 

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceConfigurationTests.mm
@@ -63,6 +63,31 @@ static NSArray *const bugsnagEnabledReleaseStages = @[bugsnagReleaseStage1, bugs
     XCTAssertNil(error);
 }
 
+- (void)testShouldSetIncludeApiKeyInTheHubEndpoint {
+    NSString *hubKey = @"00000abcdef1234567890abcdef12345";
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:hubKey];
+    XCTAssertEqualObjects(config.endpoint.absoluteString,
+        @"https://00000abcdef1234567890abcdef12345.otlp.insighthub.smartbear.com/v1/traces");
+}
+
+- (void)testUpdatingAPIKeyUpdatesEndpointToHubURL {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
+    XCTAssertEqualObjects(config.endpoint.absoluteString,
+        @"https://0123456789abcdef0123456789abcdef.otlp.bugsnag.com/v1/traces");
+    NSString *hubKey = @"00000abcdef1234567890abcdef12345";
+    [config setApiKey:hubKey];
+    XCTAssertEqualObjects(config.apiKey, hubKey);
+    XCTAssertEqualObjects(config.endpoint.absoluteString,
+        @"https://00000abcdef1234567890abcdef12345.otlp.insighthub.smartbear.com/v1/traces");
+}
+
+- (void)testCustomEndpointStillOverridesHubLogic {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"00000abcdef1234567890abcdef12345"];
+    config.endpoint = [NSURL URLWithString:@"https://perf.example.com/traces"];
+    [config setApiKey:@"00000ffffeeee11112222333344445555"];
+    XCTAssertEqualObjects(config.endpoint.absoluteString, @"https://perf.example.com/traces");
+}
+
 - (void)testShouldNotPassValidationWithValidApiKeyAndInvalidCustomEndpoint {
     auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"0123456789abcdef0123456789abcdef"];
     config.endpoint = (NSURL *_Nonnull)[NSURL URLWithString:@"x"];


### PR DESCRIPTION
## Goal

Set default endpoints based on API key. If no custom endpoint is configured, payloads should be sent to `*.insighthub.smartbear.com` if the API key starts with `00000`.

## Testing

Added unit tests