### PR TITLE
Introduced BugsnagPerformancePlugin

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		963726D02DEAB36B00C739E6 /* BSGPrioritizedStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = 963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.mm */; };
 		963726D72DEFB2CC00C739E6 /* BSGPrioritizedStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726D62DEFB2BE00C739E6 /* BSGPrioritizedStoreTests.m */; };
 		963726DA2DEFBA5A00C739E6 /* BSGCompositeSpanControlProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726D92DEFBA5200C739E6 /* BSGCompositeSpanControlProviderTests.m */; };
+		963726E42DF19D7F00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 963726E32DF19D7B00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h */; };
 		964B78502D39D36900FF077D /* BugsnagPerformanceSpanCondition.h in Headers */ = {isa = PBXBuildFile; fileRef = 964B784F2D39D36900FF077D /* BugsnagPerformanceSpanCondition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		964B78522D47D26F00FF077D /* ConditionTimeoutExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 964B78512D47D26F00FF077D /* ConditionTimeoutExecutor.h */; };
 		964B78562D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm in Sources */ = {isa = PBXBuildFile; fileRef = 964B78552D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm */; };
@@ -372,6 +373,7 @@
 		963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGPrioritizedStore.mm; sourceTree = "<group>"; };
 		963726D62DEFB2BE00C739E6 /* BSGPrioritizedStoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGPrioritizedStoreTests.m; sourceTree = "<group>"; };
 		963726D92DEFBA5200C739E6 /* BSGCompositeSpanControlProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGCompositeSpanControlProviderTests.m; sourceTree = "<group>"; };
+		963726E32DF19D7B00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceSpanControlProvider+Private.h"; sourceTree = "<group>"; };
 		964B784F2D39D36900FF077D /* BugsnagPerformanceSpanCondition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanCondition.h; sourceTree = "<group>"; };
 		964B78512D47D26F00FF077D /* ConditionTimeoutExecutor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConditionTimeoutExecutor.h; sourceTree = "<group>"; };
 		964B78552D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceSpanCondition.mm; sourceTree = "<group>"; };
@@ -630,6 +632,7 @@
 				964B78552D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm */,
 				964B785E2D504FD800FF077D /* BugsnagPerformanceSpanCondition+Private.h */,
 				09DC62282C6A2EF6000AA8E1 /* BugsnagPerformanceSpanContext+Private.h */,
+				963726E32DF19D7B00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h */,
 				CBE0873029FA984C007455F2 /* BugsnagPerformanceViewType.mm */,
 				CBE0873129FA984C007455F2 /* BugsnagPerformanceViewType+Private.h */,
 				09F23A8A2CE351ED00F0D769 /* BugsnagSwiftTools.h */,
@@ -927,6 +930,7 @@
 				960EECF32B24CA24009FAA11 /* BugsnagPerformanceTrackedViewContainer.h in Headers */,
 				966634D52C8A3647004A934D /* FrameMetricsSnapshot.h in Headers */,
 				CB34772029068C350033759C /* BSGURLSessionPerformanceProxy.h in Headers */,
+				963726E42DF19D7F00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h in Headers */,
 				0122C24C29019770002D243C /* NetworkInstrumentation.h in Headers */,
 				963726C12DEA4E5700C739E6 /* BugsnagPerformancePriority.h in Headers */,
 				CB7FD930299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h in Headers */,

--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -96,6 +96,10 @@
 		963726D02DEAB36B00C739E6 /* BSGPrioritizedStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = 963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.mm */; };
 		963726D72DEFB2CC00C739E6 /* BSGPrioritizedStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726D62DEFB2BE00C739E6 /* BSGPrioritizedStoreTests.m */; };
 		963726DA2DEFBA5A00C739E6 /* BSGCompositeSpanControlProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726D92DEFBA5200C739E6 /* BSGCompositeSpanControlProviderTests.m */; };
+		963726DD2DF0B43500C739E6 /* BugsnagPerformancePluginContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 963726DC2DF0B43500C739E6 /* BugsnagPerformancePluginContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		963726DE2DF0B43500C739E6 /* BugsnagPerformancePlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 963726DB2DF0B43500C739E6 /* BugsnagPerformancePlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		963726E02DF0B4AD00C739E6 /* BugsnagPerformancePluginContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726DF2DF0B4AD00C739E6 /* BugsnagPerformancePluginContext.m */; };
+		963726E22DF101E700C739E6 /* BugsnagPerformancePluginContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 963726E12DF101DF00C739E6 /* BugsnagPerformancePluginContext+Private.h */; };
 		963726E42DF19D7F00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 963726E32DF19D7B00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h */; };
 		964B78502D39D36900FF077D /* BugsnagPerformanceSpanCondition.h in Headers */ = {isa = PBXBuildFile; fileRef = 964B784F2D39D36900FF077D /* BugsnagPerformanceSpanCondition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		964B78522D47D26F00FF077D /* ConditionTimeoutExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 964B78512D47D26F00FF077D /* ConditionTimeoutExecutor.h */; };
@@ -373,6 +377,10 @@
 		963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGPrioritizedStore.mm; sourceTree = "<group>"; };
 		963726D62DEFB2BE00C739E6 /* BSGPrioritizedStoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGPrioritizedStoreTests.m; sourceTree = "<group>"; };
 		963726D92DEFBA5200C739E6 /* BSGCompositeSpanControlProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGCompositeSpanControlProviderTests.m; sourceTree = "<group>"; };
+		963726DB2DF0B43500C739E6 /* BugsnagPerformancePlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformancePlugin.h; sourceTree = "<group>"; };
+		963726DC2DF0B43500C739E6 /* BugsnagPerformancePluginContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformancePluginContext.h; sourceTree = "<group>"; };
+		963726DF2DF0B4AD00C739E6 /* BugsnagPerformancePluginContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagPerformancePluginContext.m; sourceTree = "<group>"; };
+		963726E12DF101DF00C739E6 /* BugsnagPerformancePluginContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformancePluginContext+Private.h"; sourceTree = "<group>"; };
 		963726E32DF19D7B00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceSpanControlProvider+Private.h"; sourceTree = "<group>"; };
 		964B784F2D39D36900FF077D /* BugsnagPerformanceSpanCondition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanCondition.h; sourceTree = "<group>"; };
 		964B78512D47D26F00FF077D /* ConditionTimeoutExecutor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConditionTimeoutExecutor.h; sourceTree = "<group>"; };
@@ -577,6 +585,8 @@
 				0122C21929019770002D243C /* BugsnagPerformanceConfiguration.h */,
 				CB0AD76929657381002A3FB6 /* BugsnagPerformanceErrors.h */,
 				0921F0292A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h */,
+				963726DB2DF0B43500C739E6 /* BugsnagPerformancePlugin.h */,
+				963726DC2DF0B43500C739E6 /* BugsnagPerformancePluginContext.h */,
 				963726C02DEA4E5700C739E6 /* BugsnagPerformancePriority.h */,
 				96F1292A2DCCB9B900A6FB2B /* BugsnagPerformanceRemoteSpanContext.h */,
 				0122C21729019770002D243C /* BugsnagPerformanceSpan.h */,
@@ -599,6 +609,7 @@
 				0122C21C29019770002D243C /* BugsnagPerformanceConfiguration.mm */,
 				CB0AD7672965734F002A3FB6 /* BugsnagPerformanceErrors.m */,
 				0921F02A2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.m */,
+				963726DF2DF0B4AD00C739E6 /* BugsnagPerformancePluginContext.m */,
 				963726C72DEAB1FC00C739E6 /* BugsnagPerformancePriority.m */,
 				96F1292C2DCD141700A6FB2B /* BugsnagPerformanceRemoteSpanContext.mm */,
 				0122C21E29019770002D243C /* BugsnagPerformanceSpan.mm */,
@@ -626,6 +637,7 @@
 				CBE8EA15294B528100702950 /* BugsnagPerformanceImpl.mm */,
 				CB78819B29E587CE00A58906 /* BugsnagPerformanceLibrary.h */,
 				CB78819A29E587CE00A58906 /* BugsnagPerformanceLibrary.mm */,
+				963726E12DF101DF00C739E6 /* BugsnagPerformancePluginContext+Private.h */,
 				963726C92DEAB23E00C739E6 /* BugsnagPerformancePriority+Private.h */,
 				963726CB2DEAB25200C739E6 /* BugsnagPerformancePriority+Private.m */,
 				0122C23229019770002D243C /* BugsnagPerformanceSpan+Private.h */,
@@ -931,6 +943,8 @@
 				966634D52C8A3647004A934D /* FrameMetricsSnapshot.h in Headers */,
 				CB34772029068C350033759C /* BSGURLSessionPerformanceProxy.h in Headers */,
 				963726E42DF19D7F00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h in Headers */,
+				963726DD2DF0B43500C739E6 /* BugsnagPerformancePluginContext.h in Headers */,
+				963726DE2DF0B43500C739E6 /* BugsnagPerformancePlugin.h in Headers */,
 				0122C24C29019770002D243C /* NetworkInstrumentation.h in Headers */,
 				963726C12DEA4E5700C739E6 /* BugsnagPerformancePriority.h in Headers */,
 				CB7FD930299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h in Headers */,
@@ -983,6 +997,7 @@
 				015836C129125E7A002F54C8 /* ResourceAttributes.h in Headers */,
 				CBE8EA1A294B5AB800702950 /* Worker.h in Headers */,
 				CBE8EA16294B528100702950 /* BugsnagPerformanceImpl.h in Headers */,
+				963726E22DF101E700C739E6 /* BugsnagPerformancePluginContext+Private.h in Headers */,
 				967F6F1829C3783B0054EED8 /* BugsnagPerformanceConfiguration+Private.h in Headers */,
 				0122C24129019770002D243C /* IdGenerator.h in Headers */,
 				CBEBE59A29F671A800BF0B4F /* Instrumentation.h in Headers */,
@@ -1360,6 +1375,7 @@
 				CB34771E29068C350033759C /* NSURLSession+Instrumentation.mm in Sources */,
 				CBE8EA1B294B5AB800702950 /* Worker.mm in Sources */,
 				CB78819C29E587CE00A58906 /* BugsnagPerformanceLibrary.mm in Sources */,
+				963726E02DF0B4AD00C739E6 /* BugsnagPerformancePluginContext.m in Sources */,
 				098FC8552D37A08D001B627D /* SystemInfoSampler.mm in Sources */,
 				963726C82DEAB1FC00C739E6 /* BugsnagPerformancePriority.m in Sources */,
 				0122C23C29019770002D243C /* BugsnagPerformanceConfiguration.mm in Sources */,

--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -101,11 +101,14 @@
 		963726E02DF0B4AD00C739E6 /* BugsnagPerformancePluginContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726DF2DF0B4AD00C739E6 /* BugsnagPerformancePluginContext.m */; };
 		963726E22DF101E700C739E6 /* BugsnagPerformancePluginContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 963726E12DF101DF00C739E6 /* BugsnagPerformancePluginContext+Private.h */; };
 		963726E42DF19D7F00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 963726E32DF19D7B00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h */; };
+		963726E62DF1DFC300C739E6 /* BSGPluginManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 963726E52DF1DFBA00C739E6 /* BSGPluginManager.h */; };
+		963726E82DF1DFD100C739E6 /* BSGPluginManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726E72DF1DFCB00C739E6 /* BSGPluginManager.m */; };
 		964B78502D39D36900FF077D /* BugsnagPerformanceSpanCondition.h in Headers */ = {isa = PBXBuildFile; fileRef = 964B784F2D39D36900FF077D /* BugsnagPerformanceSpanCondition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		964B78522D47D26F00FF077D /* ConditionTimeoutExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 964B78512D47D26F00FF077D /* ConditionTimeoutExecutor.h */; };
 		964B78562D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm in Sources */ = {isa = PBXBuildFile; fileRef = 964B78552D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm */; };
 		964B785B2D4C20C000FF077D /* BugsnagPerformanceSpanConditionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 964B785A2D4C20C000FF077D /* BugsnagPerformanceSpanConditionTests.mm */; };
 		964B785F2D504FD800FF077D /* BugsnagPerformanceSpanCondition+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 964B785E2D504FD800FF077D /* BugsnagPerformanceSpanCondition+Private.h */; };
+		965FBD152DF24D3300D6BACB /* Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 965FBD142DF24D3100D6BACB /* Logging.h */; };
 		966634D12C8909BB004A934D /* FrameMetricsCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 966634D02C8909BB004A934D /* FrameMetricsCollector.h */; };
 		966634D32C8909D9004A934D /* FrameMetricsCollector.mm in Sources */ = {isa = PBXBuildFile; fileRef = 966634D22C8909D9004A934D /* FrameMetricsCollector.mm */; };
 		966634D52C8A3647004A934D /* FrameMetricsSnapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 966634D42C8A3640004A934D /* FrameMetricsSnapshot.h */; };
@@ -382,11 +385,14 @@
 		963726DF2DF0B4AD00C739E6 /* BugsnagPerformancePluginContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagPerformancePluginContext.m; sourceTree = "<group>"; };
 		963726E12DF101DF00C739E6 /* BugsnagPerformancePluginContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformancePluginContext+Private.h"; sourceTree = "<group>"; };
 		963726E32DF19D7B00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceSpanControlProvider+Private.h"; sourceTree = "<group>"; };
+		963726E52DF1DFBA00C739E6 /* BSGPluginManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGPluginManager.h; sourceTree = "<group>"; };
+		963726E72DF1DFCB00C739E6 /* BSGPluginManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGPluginManager.m; sourceTree = "<group>"; };
 		964B784F2D39D36900FF077D /* BugsnagPerformanceSpanCondition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanCondition.h; sourceTree = "<group>"; };
 		964B78512D47D26F00FF077D /* ConditionTimeoutExecutor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConditionTimeoutExecutor.h; sourceTree = "<group>"; };
 		964B78552D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceSpanCondition.mm; sourceTree = "<group>"; };
 		964B785A2D4C20C000FF077D /* BugsnagPerformanceSpanConditionTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceSpanConditionTests.mm; sourceTree = "<group>"; };
 		964B785E2D504FD800FF077D /* BugsnagPerformanceSpanCondition+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceSpanCondition+Private.h"; sourceTree = "<group>"; };
+		965FBD142DF24D3100D6BACB /* Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Logging.h; sourceTree = "<group>"; };
 		966634D02C8909BB004A934D /* FrameMetricsCollector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameMetricsCollector.h; sourceTree = "<group>"; };
 		966634D22C8909D9004A934D /* FrameMetricsCollector.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FrameMetricsCollector.mm; sourceTree = "<group>"; };
 		966634D42C8A3640004A934D /* FrameMetricsSnapshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameMetricsSnapshot.h; sourceTree = "<group>"; };
@@ -626,6 +632,8 @@
 				CB572EA829BB783200FD7A2A /* AppStateTracker.h */,
 				CB572EA929BB783200FD7A2A /* AppStateTracker.m */,
 				CBE8EA1C294B5E1500702950 /* Batch.h */,
+				963726E52DF1DFBA00C739E6 /* BSGPluginManager.h */,
+				963726E72DF1DFCB00C739E6 /* BSGPluginManager.m */,
 				963726CD2DEAB33D00C739E6 /* BSGPrioritizedStore.h */,
 				963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.mm */,
 				098FC8452D2EB8E8001B627D /* BSGPSystemInfo.h */,
@@ -662,6 +670,7 @@
 				0122C22929019770002D243C /* Instrumentation */,
 				CBEC51BE296DB311009C0CE3 /* JSON.h */,
 				CBEC51BF296DB311009C0CE3 /* JSON.mm */,
+				965FBD142DF24D3100D6BACB /* Logging.h */,
 				098FC8772D3E8D43001B627D /* Metrics.h */,
 				09D59E182BDFE0D900199E1B /* NetworkHeaderInjector.h */,
 				09D59E192BDFE0D900199E1B /* NetworkHeaderInjector.mm */,
@@ -948,6 +957,7 @@
 				0122C24C29019770002D243C /* NetworkInstrumentation.h in Headers */,
 				963726C12DEA4E5700C739E6 /* BugsnagPerformancePriority.h in Headers */,
 				CB7FD930299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h in Headers */,
+				965FBD152DF24D3300D6BACB /* Logging.h in Headers */,
 				CB7881A129E698BF00A58906 /* PhasedStartup.h in Headers */,
 				01A414D12913C238003152A4 /* Reachability.h in Headers */,
 				01EAF980291AAF19007AC627 /* Utils.h in Headers */,
@@ -992,6 +1002,7 @@
 				963726CE2DEAB34B00C739E6 /* BSGPrioritizedStore.h in Headers */,
 				01A414CD2913C0F0003152A4 /* SpanAttributes.h in Headers */,
 				0122C25129019770002D243C /* Tracer.h in Headers */,
+				963726E62DF1DFC300C739E6 /* BSGPluginManager.h in Headers */,
 				CBB48A3C295EE1E10044E9AC /* ObjCUtils.h in Headers */,
 				96D55C812A1EB5F4006D1F29 /* SpanStackingHandler.h in Headers */,
 				015836C129125E7A002F54C8 /* ResourceAttributes.h in Headers */,
@@ -1381,6 +1392,7 @@
 				0122C23C29019770002D243C /* BugsnagPerformanceConfiguration.mm in Sources */,
 				963726D02DEAB36B00C739E6 /* BSGPrioritizedStore.mm in Sources */,
 				CBEBE59229F2783C00BF0B4F /* Swizzle.mm in Sources */,
+				963726E82DF1DFD100C739E6 /* BSGPluginManager.m in Sources */,
 				CBA22C972A0137230066A2C1 /* EarlyConfiguration.mm in Sources */,
 				963726C52DEAB14D00C739E6 /* BSGCompositeSpanControlProvider.m in Sources */,
 				09FFD4412BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm in Sources */,

--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -93,7 +93,7 @@
 		963726CA2DEAB24900C739E6 /* BugsnagPerformancePriority+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 963726C92DEAB23E00C739E6 /* BugsnagPerformancePriority+Private.h */; };
 		963726CC2DEAB25600C739E6 /* BugsnagPerformancePriority+Private.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726CB2DEAB25200C739E6 /* BugsnagPerformancePriority+Private.m */; };
 		963726CE2DEAB34B00C739E6 /* BSGPrioritizedStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 963726CD2DEAB33D00C739E6 /* BSGPrioritizedStore.h */; };
-		963726D02DEAB36B00C739E6 /* BSGPrioritizedStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.m */; };
+		963726D02DEAB36B00C739E6 /* BSGPrioritizedStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = 963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.mm */; };
 		963726D72DEFB2CC00C739E6 /* BSGPrioritizedStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726D62DEFB2BE00C739E6 /* BSGPrioritizedStoreTests.m */; };
 		963726DA2DEFBA5A00C739E6 /* BSGCompositeSpanControlProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 963726D92DEFBA5200C739E6 /* BSGCompositeSpanControlProviderTests.m */; };
 		964B78502D39D36900FF077D /* BugsnagPerformanceSpanCondition.h in Headers */ = {isa = PBXBuildFile; fileRef = 964B784F2D39D36900FF077D /* BugsnagPerformanceSpanCondition.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -369,7 +369,7 @@
 		963726C92DEAB23E00C739E6 /* BugsnagPerformancePriority+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformancePriority+Private.h"; sourceTree = "<group>"; };
 		963726CB2DEAB25200C739E6 /* BugsnagPerformancePriority+Private.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "BugsnagPerformancePriority+Private.m"; sourceTree = "<group>"; };
 		963726CD2DEAB33D00C739E6 /* BSGPrioritizedStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGPrioritizedStore.h; sourceTree = "<group>"; };
-		963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGPrioritizedStore.m; sourceTree = "<group>"; };
+		963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGPrioritizedStore.mm; sourceTree = "<group>"; };
 		963726D62DEFB2BE00C739E6 /* BSGPrioritizedStoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGPrioritizedStoreTests.m; sourceTree = "<group>"; };
 		963726D92DEFBA5200C739E6 /* BSGCompositeSpanControlProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGCompositeSpanControlProviderTests.m; sourceTree = "<group>"; };
 		964B784F2D39D36900FF077D /* BugsnagPerformanceSpanCondition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanCondition.h; sourceTree = "<group>"; };
@@ -614,7 +614,7 @@
 				CB572EA929BB783200FD7A2A /* AppStateTracker.m */,
 				CBE8EA1C294B5E1500702950 /* Batch.h */,
 				963726CD2DEAB33D00C739E6 /* BSGPrioritizedStore.h */,
-				963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.m */,
+				963726CF2DEAB36600C739E6 /* BSGPrioritizedStore.mm */,
 				098FC8452D2EB8E8001B627D /* BSGPSystemInfo.h */,
 				098FC8442D2EB8E8001B627D /* BSGPSystemInfo.mm */,
 				967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */,
@@ -1359,7 +1359,7 @@
 				098FC8552D37A08D001B627D /* SystemInfoSampler.mm in Sources */,
 				963726C82DEAB1FC00C739E6 /* BugsnagPerformancePriority.m in Sources */,
 				0122C23C29019770002D243C /* BugsnagPerformanceConfiguration.mm in Sources */,
-				963726D02DEAB36B00C739E6 /* BSGPrioritizedStore.m in Sources */,
+				963726D02DEAB36B00C739E6 /* BSGPrioritizedStore.mm in Sources */,
 				CBEBE59229F2783C00BF0B4F /* Swizzle.mm in Sources */,
 				CBA22C972A0137230066A2C1 /* EarlyConfiguration.mm in Sources */,
 				963726C52DEAB14D00C739E6 /* BSGCompositeSpanControlProvider.m in Sources */,

--- a/BugsnagPerformanceTestsApp/AppDelegate.swift
+++ b/BugsnagPerformanceTestsApp/AppDelegate.swift
@@ -2,7 +2,7 @@
 //  AppDelegate.swift
 //  BugsnagPerformanceTestsApp
 //
-//  Created by Robert B on 12/04/2023.
+//  Created by Robert Bartoszewski on 12/04/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/BugsnagPerformanceTestsApp/ViewController.swift
+++ b/BugsnagPerformanceTestsApp/ViewController.swift
@@ -2,7 +2,7 @@
 //  ViewController.swift
 //  BugsnagPerformanceTestsApp
 //
-//  Created by Robert B on 12/04/2023.
+//  Created by Robert Bartoszewski on 12/04/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/BSGPluginManager.h
+++ b/Sources/BugsnagPerformance/Private/BSGPluginManager.h
@@ -1,0 +1,29 @@
+//
+//  BSGPluginManager.h
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 05/06/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformancePlugin.h>
+#import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
+#import "BSGPrioritizedStore.h"
+#import "SpanControl/BSGCompositeSpanControlProvider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BSGPluginManager : NSObject
+
+- (instancetype)initWithConfiguration:(BugsnagPerformanceConfiguration *)configuration
+                    compositeProvider:(BSGCompositeSpanControlProvider *)compositeProvider
+                 onSpanStartCallbacks:(BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> *)onSpanStartCallbacks
+                   onSpanEndCallbacks:(BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> *)onSpanEndCallbacks;
+
+- (void)installPlugins:(NSArray<id<BugsnagPerformancePlugin>> *)plugins;
+- (void)startPlugins;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/BSGPluginManager.m
+++ b/Sources/BugsnagPerformance/Private/BSGPluginManager.m
@@ -1,0 +1,72 @@
+//
+//  BSGPluginManager.m
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 05/06/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import "BSGPluginManager.h"
+#import "BugsnagPerformancePluginContext+Private.h"
+#import "Logging.h"
+
+@interface BSGPluginManager ()
+
+@property (nonatomic, strong) BugsnagPerformanceConfiguration *configuration;
+@property (nonatomic, strong) BSGCompositeSpanControlProvider *compositeProvider;
+@property (nonatomic, strong) BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> *onSpanStartCallbacks;
+@property (nonatomic, strong) BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks;
+@property (nonatomic, strong) NSMutableArray<id<BugsnagPerformancePlugin>> *installedPlugins;
+
+@end
+
+@implementation BSGPluginManager
+
+- (instancetype)initWithConfiguration:(BugsnagPerformanceConfiguration *)configuration
+                    compositeProvider:(BSGCompositeSpanControlProvider *)compositeProvider
+                 onSpanStartCallbacks:(BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> *)onSpanStartCallbacks
+                   onSpanEndCallbacks:(BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> *)onSpanEndCallbacks
+{
+    self = [super init];
+    if (self) {
+        _configuration = configuration;
+        _compositeProvider = compositeProvider;
+        _onSpanStartCallbacks = onSpanStartCallbacks;
+        _onSpanEndCallbacks = onSpanEndCallbacks;
+        _installedPlugins = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)installPlugins:(NSArray<id<BugsnagPerformancePlugin>> *)plugins {
+    [self.compositeProvider batchAddProviders:^(AddSpanControlProviderBlock compositeProviderAddBlock) {
+        [self.onSpanStartCallbacks batchAddObjects:^(BSGPrioritizedStoreAddBlock onSpanStartCallbacksAddBlock) {
+            [self.onSpanEndCallbacks batchAddObjects:^(BSGPrioritizedStoreAddBlock onSpanEndCallbacksAddBlock) {
+                for (id<BugsnagPerformancePlugin> plugin in plugins) {
+                    @try {
+                        BugsnagPerformancePluginContext *context = [[BugsnagPerformancePluginContext alloc] initWithConfiguration:self.configuration
+                                                                                                      addSpanControlProviderBlock:compositeProviderAddBlock
+                                                                                                                addSpanStartBlock:onSpanStartCallbacksAddBlock
+                                                                                                                  addSpanEndBlock:onSpanEndCallbacksAddBlock];
+                        [plugin installWithContext:context];
+                        [self.installedPlugins addObject:plugin];
+                    } @catch(NSException *e) {
+                        BSGLogError(@"BSGPluginManager::installPlugins: plugin install threw exception: %@", e);
+                    }
+                }
+            }];
+        }];
+    }];
+}
+
+- (void)startPlugins {
+    for (id<BugsnagPerformancePlugin> plugin in self.installedPlugins) {
+        @try {
+            [plugin start];
+        } @catch(NSException *e) {
+            BSGLogError(@"BSGPluginManager::startPlugins: plugin start threw exception: %@", e);
+        }
+    }
+}
+
+@end

--- a/Sources/BugsnagPerformance/Private/BSGPluginManager.m
+++ b/Sources/BugsnagPerformance/Private/BSGPluginManager.m
@@ -39,24 +39,25 @@
 }
 
 - (void)installPlugins:(NSArray<id<BugsnagPerformancePlugin>> *)plugins {
-    [self.compositeProvider batchAddProviders:^(AddSpanControlProviderBlock compositeProviderAddBlock) {
-        [self.onSpanStartCallbacks batchAddObjects:^(BSGPrioritizedStoreAddBlock onSpanStartCallbacksAddBlock) {
-            [self.onSpanEndCallbacks batchAddObjects:^(BSGPrioritizedStoreAddBlock onSpanEndCallbacksAddBlock) {
-                for (id<BugsnagPerformancePlugin> plugin in plugins) {
-                    @try {
+    for (id<BugsnagPerformancePlugin> plugin in plugins) {
+        @try {
+            [self.compositeProvider batchAddProviders:^(AddSpanControlProviderBlock compositeProviderAddBlock) {
+                [self.onSpanStartCallbacks batchAddObjects:^(BSGPrioritizedStoreAddBlock onSpanStartCallbacksAddBlock) {
+                    [self.onSpanEndCallbacks batchAddObjects:^(BSGPrioritizedStoreAddBlock onSpanEndCallbacksAddBlock) {
                         BugsnagPerformancePluginContext *context = [[BugsnagPerformancePluginContext alloc] initWithConfiguration:self.configuration
                                                                                                       addSpanControlProviderBlock:compositeProviderAddBlock
                                                                                                                 addSpanStartBlock:onSpanStartCallbacksAddBlock
                                                                                                                   addSpanEndBlock:onSpanEndCallbacksAddBlock];
                         [plugin installWithContext:context];
-                        [self.installedPlugins addObject:plugin];
-                    } @catch(NSException *e) {
-                        BSGLogError(@"BSGPluginManager::installPlugins: plugin install threw exception: %@", e);
-                    }
-                }
+                    }];
+                }];
             }];
-        }];
-    }];
+            [self.installedPlugins addObject:plugin];
+        } @catch(NSException *e) {
+            BSGLogError(@"BSGPluginManager::installPlugins: plugin install threw exception: %@",
+                        e);
+        }
+    }
 }
 
 - (void)startPlugins {

--- a/Sources/BugsnagPerformance/Private/BSGPrioritizedStore.h
+++ b/Sources/BugsnagPerformance/Private/BSGPrioritizedStore.h
@@ -8,6 +8,8 @@
 
 #import <BugsnagPerformance/BugsnagPerformancePriority.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface BSGPrioritizedStore<__covariant ObjectType> : NSObject
 
 typedef void (^ BSGPrioritizedStoreAddBlock)(ObjectType object, BugsnagPerformancePriority priority);
@@ -19,3 +21,5 @@ typedef void (^ BSGPrioritizedStoreBatchBlock)(BSGPrioritizedStoreAddBlock addBl
 - (void)batchAddObjects:(BSGPrioritizedStoreBatchBlock)batchBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/BSGPrioritizedStore.mm
+++ b/Sources/BugsnagPerformance/Private/BSGPrioritizedStore.mm
@@ -65,11 +65,18 @@
         __block __weak BSGPrioritizedStore *weakSelf = self;
         __block BOOL batchingInProgress = YES;
         batchBlock(^void (id object, BugsnagPerformancePriority priority) {
+            __strong BSGPrioritizedStore *strongSelf = weakSelf;
             if (!batchingInProgress) {
                 BSGLogWarning(@"Ignoring an attempt to add an element after batching has finished");
                 return;
             }
-            [weakSelf.store addObject:[BSGPrioritizedStoreEntry entryWithObject:object priority:priority]];
+            for (BSGPrioritizedStoreEntry *entry in strongSelf.store) {
+                if ([entry.object isEqual:object]) {
+                    BSGLogWarning(@"Ignoring an attempt to add a duplicate element");
+                    return;
+                }
+            }
+            [strongSelf.store addObject:[BSGPrioritizedStoreEntry entryWithObject:object priority:priority]];
         });
         batchingInProgress = NO;
         [self sortStore];

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
@@ -2,7 +2,7 @@
 //  BugsnagPerformanceConfiguration+Private.h
 //  BugsnagPerformance
 //
-//  Created by Robert B on 16/03/2023.
+//  Created by Robert Bartoszewski on 16/03/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
@@ -60,6 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSMutableArray<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks;
 
+@property (nonatomic) NSMutableArray<id<BugsnagPerformancePlugin>> *plugins;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -10,7 +10,6 @@
 
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
-#import <BugsnagPerformance/BugsnagPerformanceSpanControlProvider.h>
 
 #import "BugsnagPerformanceSpan+Private.h"
 #import "OtlpUploader.h"
@@ -30,6 +29,8 @@
 #import "FrameRateMetrics/FrameMetricsCollector.h"
 #import "ConditionTimeoutExecutor.h"
 #import "SystemInfoSampler.h"
+#import "SpanControl/BSGCompositeSpanControlProvider.h"
+#import "BSGPluginManager.h"
 
 #import <mutex>
 
@@ -94,6 +95,9 @@ private:
     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector_;
     FrameMetricsCollector *frameMetricsCollector_;
     std::shared_ptr<ConditionTimeoutExecutor> conditionTimeoutExecutor_;
+    BSGCompositeSpanControlProvider *spanControlProvider_;
+    BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> *spanStartCallbacks_;
+    BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> *spanEndCallbacks_;
     std::shared_ptr<Tracer> tracer_;
     std::unique_ptr<RetryQueue> retryQueue_;
     AppStateTracker *appStateTracker_;
@@ -104,9 +108,9 @@ private:
     std::shared_ptr<ResourceAttributes> resourceAttributes_;
     BugsnagPerformanceNetworkRequestCallback networkRequestCallback_;
     OtlpTraceEncoding traceEncoding_;
-    id<BugsnagPerformanceSpanControlProvider> spanControlProvider_;
 
     BugsnagPerformanceConfiguration *configuration_;
+    BSGPluginManager *pluginManager_;
     std::shared_ptr<OtlpUploader> uploader_;
     std::mutex viewControllersToSpansMutex_;
     CFAbsoluteTime probabilityExpiry_{0};

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -18,7 +18,6 @@
 #import "FrameRateMetrics/FrameMetricsCollector.h"
 #import "ConditionTimeoutExecutor.h"
 #import "BugsnagPerformanceSpan+Private.h"
-#import "SpanControl/BSGCompositeSpanControlProvider.h"
 
 using namespace bugsnag;
 
@@ -50,7 +49,9 @@ BugsnagPerformanceImpl::BugsnagPerformanceImpl(std::shared_ptr<Reachability> rea
 , frameMetricsCollector_([FrameMetricsCollector new])
 , conditionTimeoutExecutor_(std::make_shared<ConditionTimeoutExecutor>())
 , spanControlProvider_([BSGCompositeSpanControlProvider new])
-, tracer_(std::make_shared<Tracer>(spanStackingHandler_, sampler_, batch_, frameMetricsCollector_, conditionTimeoutExecutor_, ^{this->onSpanStarted();}))
+, spanStartCallbacks_([BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new])
+, spanEndCallbacks_([BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new])
+, tracer_(std::make_shared<Tracer>(spanStackingHandler_, sampler_, batch_, frameMetricsCollector_, conditionTimeoutExecutor_, spanStartCallbacks_, spanEndCallbacks_, ^{this->onSpanStarted();}))
 , retryQueue_(std::make_unique<RetryQueue>([persistence_->bugsnagPerformanceDir() stringByAppendingPathComponent:@"retry-queue"]))
 , appStateTracker_(appStateTracker)
 , viewControllersToSpans_([NSMapTable mapTableWithKeyOptions:NSMapTableWeakMemory | NSMapTableObjectPointerPersonality
@@ -129,6 +130,19 @@ void BugsnagPerformanceImpl::configure(BugsnagPerformanceConfiguration *config) 
     probabilityValueExpiresAfterSeconds_ = config.internal.probabilityValueExpiresAfterSeconds;
     probabilityRequestsPauseForSeconds_ = config.internal.probabilityRequestsPauseForSeconds;
     maxPackageContentLength_ = config.internal.maxPackageContentLength;
+    for(BugsnagPerformanceSpanStartCallback callback in config.onSpanStartCallbacks) {
+        [spanStartCallbacks_ addObject:callback priority:BugsnagPerformancePriorityMedium];
+    }
+    for(BugsnagPerformanceSpanEndCallback callback in config.onSpanEndCallbacks) {
+        [spanEndCallbacks_ addObject:callback priority:BugsnagPerformancePriorityMedium];
+    }
+    
+    pluginManager_ = [[BSGPluginManager alloc] initWithConfiguration:config
+                                                   compositeProvider:spanControlProvider_
+                                                onSpanStartCallbacks:spanStartCallbacks_
+                                                  onSpanEndCallbacks:spanEndCallbacks_];
+    
+    [pluginManager_ installPlugins:config.plugins];
     
     auto networkRequestCallback = config.networkRequestCallback;
     if (networkRequestCallback != nullptr) {
@@ -266,7 +280,13 @@ void BugsnagPerformanceImpl::start() noexcept {
 #pragma mark Tasks
 
 NSArray<Task> *BugsnagPerformanceImpl::buildInitialTasks() noexcept {
-    return @[];
+    __block auto blockThis = this;
+    return @[
+        ^bool() {
+            [blockThis->pluginManager_ startPlugins];
+            return true;
+        },
+    ];
 }
 
 NSArray<Task> *BugsnagPerformanceImpl::buildRecurringTasks() noexcept {

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformancePluginContext+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformancePluginContext+Private.h
@@ -7,11 +7,18 @@
 //
 
 #import <BugsnagPerformance/BugsnagPerformancePluginContext.h>
+#import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
+#import "SpanControl/BSGCompositeSpanControlProvider.h"
 
 typedef void (^ AddStartSpanCallbackBlock)(BugsnagPerformanceSpanStartCallback object, BugsnagPerformancePriority priority);
 
 typedef void (^ AddEndSpanCallbackBlock)(BugsnagPerformanceSpanEndCallback object, BugsnagPerformancePriority priority);
 
 @interface BugsnagPerformancePluginContext ()
+
+- (instancetype)initWithConfiguration:(BugsnagPerformanceConfiguration *)configuration
+          addSpanControlProviderBlock:(AddSpanControlProviderBlock)addSpanControlProviderBlock
+                    addSpanStartBlock:(AddStartSpanCallbackBlock)addSpanStartBlock
+                      addSpanEndBlock:(AddEndSpanCallbackBlock)addSpanEndBlock;
 
 @end

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformancePluginContext+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformancePluginContext+Private.h
@@ -1,0 +1,17 @@
+//
+//  BugsnagPerformancePluginContext+Private.h
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 03/06/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformancePluginContext.h>
+
+typedef void (^ AddStartSpanCallbackBlock)(BugsnagPerformanceSpanStartCallback object, BugsnagPerformancePriority priority);
+
+typedef void (^ AddEndSpanCallbackBlock)(BugsnagPerformanceSpanEndCallback object, BugsnagPerformancePriority priority);
+
+@interface BugsnagPerformancePluginContext ()
+
+@end

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanCondition+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanCondition+Private.h
@@ -2,7 +2,7 @@
 //  BugsnagPerformanceSpanCondition+Private.h
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 15/01/2025.
+//  Created by Robert Bartoszewski on 15/01/2025.
 //  Copyright © 2025 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanCondition.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanCondition.mm
@@ -2,7 +2,7 @@
 //  SpanCondition.m
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 15/01/2025.
+//  Created by Robert Bartoszewski on 15/01/2025.
 //  Copyright © 2025 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanControlProvider+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanControlProvider+Private.h
@@ -1,0 +1,9 @@
+//
+//  BugsnagPerformanceSpanControlProvider+Private.h
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 05/06/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+typedef void (^ AddSpanControlProviderBlock)(id<BugsnagPerformanceSpanControlProvider> object, BugsnagPerformancePriority priority);

--- a/Sources/BugsnagPerformance/Private/ConditionTimeoutExecutor.h
+++ b/Sources/BugsnagPerformance/Private/ConditionTimeoutExecutor.h
@@ -2,7 +2,7 @@
 //  ConditionTimeoutExecutor.h
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 24/01/2025.
+//  Created by Robert Bartoszewski on 24/01/2025.
 //  Copyright © 2025 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.h
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.h
@@ -2,7 +2,7 @@
 //  FrameMetricsCollector.h
 //  BugsnagPerformance
 //
-//  Created by Robert B on 23/08/2024.
+//  Created by Robert Bartoszewski on 23/08/2024.
 //  Copyright © 2024 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsCollector.mm
@@ -2,7 +2,7 @@
 //  FrameMetricsCollector.mm
 //  BugsnagPerformance
 //
-//  Created by Robert B on 23/08/2024.
+//  Created by Robert Bartoszewski on 23/08/2024.
 //  Copyright © 2024 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsSnapshot.h
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsSnapshot.h
@@ -2,7 +2,7 @@
 //  FrameMetricsSnapshot.h
 //  BugsnagPerformance
 //
-//  Created by Robert B on 23/08/2024.
+//  Created by Robert Bartoszewski on 23/08/2024.
 //  Copyright © 2024 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsSnapshot.mm
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrameMetricsSnapshot.mm
@@ -2,7 +2,7 @@
 //  FrameMetricsSnapshot.mm
 //  BugsnagPerformance
 //
-//  Created by Robert B on 23/08/2024.
+//  Created by Robert Bartoszewski on 23/08/2024.
 //  Copyright © 2024 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrozenFrameData.h
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrozenFrameData.h
@@ -2,7 +2,7 @@
 //  FrozenFrameData.h
 //  BugsnagPerformance
 //
-//  Created by Robert B on 05/09/2024.
+//  Created by Robert Bartoszewski on 05/09/2024.
 //  Copyright © 2024 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrozenFrameData.mm
+++ b/Sources/BugsnagPerformance/Private/FrameRateMetrics/FrozenFrameData.mm
@@ -2,7 +2,7 @@
 //  FrozenFrameData.mm
 //  BugsnagPerformance
 //
-//  Created by Robert B on 05/09/2024.
+//  Created by Robert Bartoszewski on 05/09/2024.
 //  Copyright © 2024 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGPerformanceSharedSessionProxy.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGPerformanceSharedSessionProxy.h
@@ -2,7 +2,7 @@
 //  BSGPerformanceSharedSessionProxy.h
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 24/10/2024.
+//  Created by Robert Bartoszewski on 24/10/2024.
 //  Copyright © 2024 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGPerformanceSharedSessionProxy.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/BSGPerformanceSharedSessionProxy.mm
@@ -2,7 +2,7 @@
 //  BSGPerformanceSharedSessionProxy.mm
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 24/10/2024.
+//  Created by Robert Bartoszewski on 24/10/2024.
 //  Copyright © 2024 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/Logging.h
+++ b/Sources/BugsnagPerformance/Private/Logging.h
@@ -1,0 +1,50 @@
+//
+//  Logging.h
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 05/06/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#define BSG_LOGLEVEL_NONE 0
+#define BSG_LOGLEVEL_ERR 10
+#define BSG_LOGLEVEL_WARN 20
+#define BSG_LOGLEVEL_INFO 30
+#define BSG_LOGLEVEL_DEBUG 40
+#define BSG_LOGLEVEL_TRACE 50
+
+#ifndef BSG_LOG_LEVEL
+#define BSG_LOG_LEVEL BSG_LOGLEVEL_INFO
+#endif
+
+#define BSG_LOG_PREFIX "[BugsnagPerformance]"
+
+#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_ERR
+#define BSGLogError(...)    NSLog(@ BSG_LOG_PREFIX " [ERROR] " __VA_ARGS__)
+#else
+#define BSGLogError(format, ...)
+#endif
+
+#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_WARN
+#define BSGLogWarning(...)  NSLog(@ BSG_LOG_PREFIX " [WARN] " __VA_ARGS__)
+#else
+#define BSGLogWarning(format, ...)
+#endif
+
+#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_INFO
+#define BSGLogInfo(...)     NSLog(@ BSG_LOG_PREFIX " [INFO] " __VA_ARGS__)
+#else
+#define BSGLogInfo(format, ...)
+#endif
+
+#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_DEBUG
+#define BSGLogDebug(...)    NSLog(@ BSG_LOG_PREFIX " [DEBUG] " __VA_ARGS__)
+#else
+#define BSGLogDebug(format, ...)
+#endif
+
+#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_TRACE
+#define BSGLogTrace(...)    NSLog(@ BSG_LOG_PREFIX " [TRACE] " __VA_ARGS__)
+#else
+#define BSGLogTrace(format, ...)
+#endif

--- a/Sources/BugsnagPerformance/Private/SpanActivityState.h
+++ b/Sources/BugsnagPerformance/Private/SpanActivityState.h
@@ -2,7 +2,7 @@
 //  SpanActivityState.h
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 24/05/2023.
+//  Created by Robert Bartoszewski on 24/05/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -2,7 +2,7 @@
 //  SpanAttributesProvider.h
 //  BugsnagPerformance
 //
-//  Created by Robert B on 21/04/2023.
+//  Created by Robert Bartoszewski on 21/04/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 #import <Foundation/Foundation.h>

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -2,7 +2,7 @@
 //  SpanAttributesProvider.mm
 //  BugsnagPerformance
 //
-//  Created by Robert B on 21/04/2023.
+//  Created by Robert Bartoszewski on 21/04/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/SpanControl/BSGCompositeSpanControlProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanControl/BSGCompositeSpanControlProvider.h
@@ -9,10 +9,9 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpanControlProvider.h>
 #import <BugsnagPerformance/BugsnagPerformancePriority.h>
 #import "../BSGPrioritizedStore.h"
+#import "../BugsnagPerformanceSpanControlProvider+Private.h"
 
-typedef void (^ BSGCompositeSpanControlProviderAddBlock)(id<BugsnagPerformanceSpanControlProvider> object,
-                                                         BugsnagPerformancePriority priority);
-typedef void (^ BSGCompositeSpanControlProviderBatchBlock)(BSGPrioritizedStoreAddBlock addBlock);
+typedef void (^ BSGCompositeSpanControlProviderBatchBlock)(AddSpanControlProviderBlock addBlock);
 
 @interface BSGCompositeSpanControlProvider : NSObject <BugsnagPerformanceSpanControlProvider>
 

--- a/Sources/BugsnagPerformance/Private/SpanStackingHandler.h
+++ b/Sources/BugsnagPerformance/Private/SpanStackingHandler.h
@@ -2,7 +2,7 @@
 //  SpanStackingHandler.h
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 24/05/2023.
+//  Created by Robert Bartoszewski on 24/05/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/SpanStackingHandler.mm
+++ b/Sources/BugsnagPerformance/Private/SpanStackingHandler.mm
@@ -2,7 +2,7 @@
 //  SpanStackingHandler.mm
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 24/05/2023.
+//  Created by Robert Bartoszewski on 24/05/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -18,6 +18,7 @@
 #import "WeakSpansList.h"
 #import "FrameRateMetrics/FrameMetricsCollector.h"
 #import "ConditionTimeoutExecutor.h"
+#import "BSGPrioritizedStore.h"
 
 #import <memory>
 
@@ -34,14 +35,14 @@ public:
            std::shared_ptr<Batch> batch,
            FrameMetricsCollector *frameMetricsCollector,
            std::shared_ptr<ConditionTimeoutExecutor> conditionTimeoutExecutor,
+           BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> *onSpanStartCallbacks,
+           BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks,
            void (^onSpanStarted)()) noexcept;
     ~Tracer() {};
 
     void earlyConfigure(BSGEarlyConfiguration *) noexcept;
     void earlySetup() noexcept {}
     void configure(BugsnagPerformanceConfiguration *config) noexcept {
-        onSpanStartCallbacks_ = config.onSpanStartCallbacks;
-        onSpanEndCallbacks_ = config.onSpanEndCallbacks;
         attributeCountLimit_ = config.attributeCountLimit;
         enabledMetrics_ = [config.enabledMetrics clone];
     };
@@ -91,8 +92,8 @@ private:
     std::mutex prewarmSpansMutex_;
     NSMutableArray<BugsnagPerformanceSpan *> *prewarmSpans_;
     NSMutableArray<BugsnagPerformanceSpan *> *blockedSpans_;
-    NSArray<BugsnagPerformanceSpanStartCallback> *onSpanStartCallbacks_;
-    NSArray<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks_;
+    BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> *onSpanStartCallbacks_;
+    BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks_;
     NSUInteger attributeCountLimit_{128};
 
     // Sloppy list of "open" spans. Some spans may have already been closed,

--- a/Sources/BugsnagPerformance/Private/Utils.h
+++ b/Sources/BugsnagPerformance/Private/Utils.h
@@ -9,49 +9,7 @@
 #pragma once
 
 #import <Foundation/Foundation.h>
-
-#define BSG_LOGLEVEL_NONE 0
-#define BSG_LOGLEVEL_ERR 10
-#define BSG_LOGLEVEL_WARN 20
-#define BSG_LOGLEVEL_INFO 30
-#define BSG_LOGLEVEL_DEBUG 40
-#define BSG_LOGLEVEL_TRACE 50
-
-#ifndef BSG_LOG_LEVEL
-#define BSG_LOG_LEVEL BSG_LOGLEVEL_INFO
-#endif
-
-#define BSG_LOG_PREFIX "[BugsnagPerformance]"
-
-#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_ERR
-#define BSGLogError(...)    NSLog(@ BSG_LOG_PREFIX " [ERROR] " __VA_ARGS__)
-#else
-#define BSGLogError(format, ...)
-#endif
-
-#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_WARN
-#define BSGLogWarning(...)  NSLog(@ BSG_LOG_PREFIX " [WARN] " __VA_ARGS__)
-#else
-#define BSGLogWarning(format, ...)
-#endif
-
-#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_INFO
-#define BSGLogInfo(...)     NSLog(@ BSG_LOG_PREFIX " [INFO] " __VA_ARGS__)
-#else
-#define BSGLogInfo(format, ...)
-#endif
-
-#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_DEBUG
-#define BSGLogDebug(...)    NSLog(@ BSG_LOG_PREFIX " [DEBUG] " __VA_ARGS__)
-#else
-#define BSGLogDebug(format, ...)
-#endif
-
-#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_TRACE
-#define BSGLogTrace(...)    NSLog(@ BSG_LOG_PREFIX " [TRACE] " __VA_ARGS__)
-#else
-#define BSGLogTrace(format, ...)
-#endif
+#import "Logging.h"
 
 namespace bugsnag {
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -276,6 +276,10 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
     [self.onSpanEndCallbacks addObject:callback];
 }
 
+- (void)addPlugin:(id<BugsnagPerformancePlugin>)plugin {
+    [self.plugins addObject:plugin];
+}
+
 @end
 
 @implementation BSGInternalConfiguration

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -72,6 +72,7 @@ using namespace bugsnag;
         _enabledMetrics = [BugsnagPerformanceEnabledMetrics new];
         _onSpanStartCallbacks = [NSMutableArray array];
         _onSpanEndCallbacks = [NSMutableArray array];
+        _plugins = [NSMutableArray array];
         _attributeArrayLengthLimit = DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT;
         _attributeStringValueLimit = DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT;
         _attributeCountLimit = DEFAULT_ATTRIBUTE_COUNT_LIMIT;

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformancePluginContext.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformancePluginContext.m
@@ -1,0 +1,76 @@
+//
+//  BugsnagPerformancePluginContext.m
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 23/05/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import "../Private/BugsnagPerformancePluginContext+Private.h"
+#import "../Private/BugsnagPerformanceSpanControlProvider+Private.h"
+
+@interface BugsnagPerformancePluginContext ()
+@property (nonatomic, strong) BugsnagPerformanceConfiguration *configuration_;
+@property (nonatomic, copy) AddSpanControlProviderBlock addSpanControlProviderBlock;
+@property (nonatomic, copy) AddStartSpanCallbackBlock addSpanStartBlock;
+@property (nonatomic, copy) AddEndSpanCallbackBlock addSpanEndBlock;
+@end
+
+@implementation BugsnagPerformancePluginContext
+
+- (instancetype)initWithConfiguration:(BugsnagPerformanceConfiguration *)configuration
+          addSpanControlProviderBlock:(AddSpanControlProviderBlock)addSpanControlProviderBlock
+                    addSpanStartBlock:(AddStartSpanCallbackBlock)addSpanStartBlock
+                      addSpanEndBlock:(AddEndSpanCallbackBlock)addSpanEndBlock
+{
+    self = [super init];
+    if (self) {
+        _configuration_ = configuration;
+        _addSpanControlProviderBlock = addSpanControlProviderBlock;
+        _addSpanStartBlock = addSpanStartBlock;
+        _addSpanEndBlock = addSpanEndBlock;
+    }
+    return self;
+}
+
+- (BugsnagPerformanceConfiguration *)configuration {
+    return self.configuration_;
+}
+
+- (void)addSpanControlProvider:(id<BugsnagPerformanceSpanControlProvider>)provider {
+    [self addSpanControlProvider:provider priority:BugsnagPerformancePriorityMedium];
+}
+
+- (void)addSpanControlProvider:(id<BugsnagPerformanceSpanControlProvider>)provider priority:(BugsnagPerformancePriority)priority {
+    @synchronized (self) {
+        if (self.addSpanControlProviderBlock) {
+            self.addSpanControlProviderBlock(provider, priority);
+        }
+    }
+}
+
+- (void)addOnSpanStartCallback:(BugsnagPerformanceSpanStartCallback)callback {
+    [self addOnSpanStartCallback:callback priority:BugsnagPerformancePriorityMedium];
+}
+
+- (void)addOnSpanStartCallback:(BugsnagPerformanceSpanStartCallback)callback priority:(BugsnagPerformancePriority)priority {
+    @synchronized (self) {
+        if (self.addSpanStartBlock) {
+            self.addSpanStartBlock(callback, priority);
+        }
+    }
+}
+
+- (void)addOnSpanEndCallback:(BugsnagPerformanceSpanEndCallback)callback {
+    [self addOnSpanEndCallback:callback priority:BugsnagPerformancePriorityMedium];
+}
+
+- (void)addOnSpanEndCallback:(BugsnagPerformanceSpanEndCallback)callback priority:(BugsnagPerformancePriority)priority {
+    @synchronized (self) {
+        if (self.addSpanEndBlock) {
+            self.addSpanEndBlock(callback, priority);
+        }
+    }
+}
+
+@end

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceRemoteSpanContext.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceRemoteSpanContext.mm
@@ -2,7 +2,7 @@
 //  BugsnagPerformanceRemoteSpanContext.mm
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 07/05/2025.
+//  Created by Robert Bartoszewski on 07/05/2025.
 //  Copyright © 2025 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -18,6 +18,8 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpanControlProvider.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanQuery.h>
 #import <BugsnagPerformance/BugsnagPerformancePriority.h>
+#import <BugsnagPerformance/BugsnagPerformancePlugin.h>
+#import <BugsnagPerformance/BugsnagPerformancePluginContext.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -15,8 +15,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef BOOL (^ BugsnagPerformanceViewControllerInstrumentationCallback)(UIViewController *viewController);
 
+/**
+ * A callback that gets called whenever a span starts.
+ */
 typedef void (^ BugsnagPerformanceSpanStartCallback)(BugsnagPerformanceSpan *span);
 
+/**
+ * A callback that gets called whenever a span ends.
+ * @return If any of the registered callbacks returns false, the span is discarded.
+ */
 typedef BOOL (^ BugsnagPerformanceSpanEndCallback)(BugsnagPerformanceSpan *span);
 
 OBJC_EXPORT

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -8,6 +8,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceErrors.h>
 #import <BugsnagPerformance/BugsnagPerformanceNetworkRequestInfo.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <BugsnagPerformance/BugsnagPerformancePlugin.h>
 
 #import <UIKit/UIKit.h>
 
@@ -61,7 +62,12 @@ OBJC_EXPORT
  * Add a callback that gets called whenever a span ends.
  * If any of the registered callbacks returns false, the span is discarded.
  */
-- (void) addOnSpanEndCallback:(BugsnagPerformanceSpanEndCallback) callback;
+- (void)addOnSpanEndCallback:(BugsnagPerformanceSpanEndCallback)callback;
+
+/**
+ * Add a plugin that gets called when the library is started.
+ */
+- (void)addPlugin:(id<BugsnagPerformancePlugin>)plugin;
 
 @property (nonatomic) NSString *apiKey;
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformancePlugin.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformancePlugin.h
@@ -1,0 +1,43 @@
+//
+//  BugsnagPerformancePlugin.h
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 23/05/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformancePluginContext.h>
+#import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A plugin interface that provides a way to extend the functionality of the performance monitoring
+ * library. Plugins are added to the library via the -[BugsnagPerformanceConfiguration addPlugin:]
+ * method, and are called when the library is started.
+ */
+@protocol BugsnagPerformancePlugin <NSObject>
+
+/**
+ * Called when the plugin is loaded. This is where you can set up any necessary resources or
+ * configurations for the plugin. This is called synchronously as part of
+ * +[BugsnagPerformance startWithConfiguration:] to configure any callbacks and hooks that the plugin needs to
+ * perform its work.
+ *
+ * @param context The context in which the plugin is being loaded. The context should not be used again after this method returns.
+ * @see +[BugsnagPerformance startWithConfiguration:]
+ */
+- (void)installWithContext:(BugsnagPerformancePluginContext *)context;
+
+/**
+ * Start the plugin. This is called after all plugins have been installed and is where you can
+ * start any background tasks or other operations that the plugin needs to perform. This is
+ * called asynchronously after [BugsnagPerformance.start] to allow the plugin to perform
+ * any necessary work without blocking the main thread.
+ */
+- (void)start;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformancePlugin.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformancePlugin.h
@@ -7,8 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <BugsnagPerformance/BugsnagPerformancePluginContext.h>
-#import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
+
+@class BugsnagPerformancePluginContext;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformancePluginContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformancePluginContext.h
@@ -14,6 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+OBJC_EXPORT
 @interface BugsnagPerformancePluginContext : NSObject
 
 /**

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformancePluginContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformancePluginContext.h
@@ -51,7 +51,7 @@ OBJC_EXPORT
  * started. This is a convenience method that is the same as calling
  * -[BugsnagPerformancePluginContext addOnSpanStartCallback:priority:] with the default priority of [BugsnagPerformancePriorityMedium].
  *
- * @param onSpanEndCallback Callback to be called on span start. Adding the same callback multiple times will not take effect
+ * @param callback Callback to be called on span start. Adding the same callback multiple times will not take effect
  * @see -[BugsnagPerformancePluginContext addOnSpanStartCallback:priority:]
  */
 - (void)addOnSpanStartCallback:(BugsnagPerformanceSpanStartCallback)callback;
@@ -63,7 +63,7 @@ OBJC_EXPORT
  * is also the priority of the [BugsnagPerformanceSpanStartCallback] added in
  * -[BugsnagPerformanceConfiguration addOnSpanStartCallback:]).
  *
- * @param onSpanEndCallback Callback to be called on span start. Adding the same callback multiple times will not take effect
+ * @param callback Callback to be called on span start. Adding the same callback multiple times will not take effect
  * @param priority The priority of the callback determines the order in which it will be called, with higher priorities being called first.
  * @see -[BugsnagPerformanceConfiguration addOnSpanStartCallback:]
  */
@@ -74,7 +74,7 @@ OBJC_EXPORT
  * ended. This is a convenience method that is the same as calling
  * -[BugsnagPerformancePluginContext addOnSpanEndCallback:priority:] with the default priority of [BugsnagPerformancePriorityMedium].
  *
- * @param onSpanEndCallback Callback to be called on span end. Adding the same callback multiple times will not take effect
+ * @param callback Callback to be called on span end. Adding the same callback multiple times will not take effect
  * @see -[BugsnagPerformancePluginContext addOnSpanEndCallback:priority:]
  */
 - (void)addOnSpanEndCallback:(BugsnagPerformanceSpanEndCallback)callback;
@@ -86,7 +86,7 @@ OBJC_EXPORT
  * is also the priority of the [BugsnagPerformanceSpanEndCallback] added in
  * -[BugsnagPerformanceConfiguration addOnSpanEndCallback:]).
  *
- * @param onSpanEndCallback Callback to be called on span end. Adding the same callback multiple times will not take effect
+ * @param callback Callback to be called on span end. Adding the same callback multiple times will not take effect
  * @param priority The priority of the callback determines the order in which it will be called, with higher priorities being called first.
  * @see -[BugsnagPerformanceConfiguration addOnSpanEndCallback:]
  */

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformancePluginContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformancePluginContext.h
@@ -1,0 +1,96 @@
+//
+//  BugsnagPerformancePluginContext.h
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 23/05/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <BugsnagPerformance/BugsnagPerformancePriority.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanControlProvider.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagPerformancePluginContext : NSObject
+
+/**
+ * The user provided configuration for the performance monitoring library. Changes made by
+ * the plugin to this configuration may be *ignored* by the library, so plugins should not
+ * modify this configuration directly (instead making any changes via the [BugsnagPerformancePluginContext] methods).
+ */
+@property (nonatomic, readonly) BugsnagPerformanceConfiguration *cofiguration;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Add a [BugsnagPerformanceSpanControlProvider] to the list of providers that can be queried via
+ * +[BugsnagPerformance getSpanControlsWithQuery:]. This is a convenience method that is the same as calling
+ * -[BugsnagPerformancePluginContext addSpanControlProvider:priority:] with the default priority of [BugsnagPerformancePriorityMedium].
+ *
+ * @param provider Span controls provider. Adding the same provider multiple times will not take effect
+ * @see +[BugsnagPerformance getSpanControlsWithQuery:]
+ */
+- (void)addSpanControlProvider:(id<BugsnagPerformanceSpanControlProvider>)provider;
+
+/**
+ * Add a [BugsnagPerformanceSpanControlProvider] to the list of providers that can be queried via
+ * +[BugsnagPerformance getSpanControlsWithQuery:].
+ *
+ * @param provider Span controls provider. Adding the same provider multiple times will not take effect
+ * @param priority The priority of the provider determines the order in which it will be queried, with higher priorities being queried first.
+ * @see +[BugsnagPerformance getSpanControlsWithQuery:]
+ */
+- (void)addSpanControlProvider:(id<BugsnagPerformanceSpanControlProvider>)provider priority:(BugsnagPerformancePriority)priority;
+
+/**
+ * Add a [BugsnagPerformanceSpanStartCallback] to the list of callbacks that will be called when a span is
+ * started. This is a convenience method that is the same as calling
+ * -[BugsnagPerformancePluginContext addOnSpanStartCallback:priority:] with the default priority of [BugsnagPerformancePriorityMedium].
+ *
+ * @param onSpanEndCallback Callback to be called on span start. Adding the same callback multiple times will not take effect
+ * @see -[BugsnagPerformancePluginContext addOnSpanStartCallback:priority:]
+ */
+- (void)addOnSpanStartCallback:(BugsnagPerformanceSpanStartCallback)callback;
+
+/**
+ * Add a [BugsnagPerformanceSpanStartCallback] to the list of callbacks that will be called when a span is
+ * started. The priority of the callback determines the order in which it will be called,
+ * with lower numbers being called first. The default priority is [BugsnagPerformancePriorityMedium] (which
+ * is also the priority of the [BugsnagPerformanceSpanStartCallback] added in
+ * -[BugsnagPerformanceConfiguration addOnSpanStartCallback:]).
+ *
+ * @param onSpanEndCallback Callback to be called on span start. Adding the same callback multiple times will not take effect
+ * @param priority The priority of the callback determines the order in which it will be called, with higher priorities being called first.
+ * @see -[BugsnagPerformanceConfiguration addOnSpanStartCallback:]
+ */
+- (void)addOnSpanStartCallback:(BugsnagPerformanceSpanStartCallback)callback priority:(BugsnagPerformancePriority)priority;
+
+/**
+ * Add a [BugsnagPerformanceSpanEndCallback] to the list of callbacks that will be called when a span is
+ * ended. This is a convenience method that is the same as calling
+ * -[BugsnagPerformancePluginContext addOnSpanEndCallback:priority:] with the default priority of [BugsnagPerformancePriorityMedium].
+ *
+ * @param onSpanEndCallback Callback to be called on span end. Adding the same callback multiple times will not take effect
+ * @see -[BugsnagPerformancePluginContext addOnSpanEndCallback:priority:]
+ */
+- (void)addOnSpanEndCallback:(BugsnagPerformanceSpanEndCallback)callback;
+
+/**
+ * Add a [BugsnagPerformanceSpanEndCallback] to the list of callbacks that will be called when a span is
+ * ended. The priority of the callback determines the order in which it will be called,
+ * with lower numbers being called first. The default priority is [BugsnagPerformancePriorityMedium] (which
+ * is also the priority of the [BugsnagPerformanceSpanEndCallback] added in
+ * -[BugsnagPerformanceConfiguration addOnSpanEndCallback:]).
+ *
+ * @param onSpanEndCallback Callback to be called on span end. Adding the same callback multiple times will not take effect
+ * @param priority The priority of the callback determines the order in which it will be called, with higher priorities being called first.
+ * @see -[BugsnagPerformanceConfiguration addOnSpanEndCallback:]
+ */
+- (void)addOnSpanEndCallback:(BugsnagPerformanceSpanEndCallback)callback priority:(BugsnagPerformancePriority)priority;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceRemoteSpanContext.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceRemoteSpanContext.h
@@ -2,7 +2,7 @@
 //  BugsnagPerformanceRemoteSpanContext.h
 //  BugsnagPerformance
 //
-//  Created by Robert B on 07/05/2025.
+//  Created by Robert Bartoszewski on 07/05/2025.
 //  Copyright © 2025 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanCondition.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanCondition.h
@@ -10,6 +10,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpanCondition.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 
+OBJC_EXPORT
 @interface BugsnagPerformanceSpanCondition: NSObject
 
 @property (nonatomic) BOOL isActive;

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanCondition.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanCondition.h
@@ -2,7 +2,7 @@
 //  BugsnagPerformanceSpanCondition.h
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 15/01/2025.
+//  Created by Robert Bartoszewski on 15/01/2025.
 //  Copyright © 2025 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanQuery.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanQuery.h
@@ -10,6 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+OBJC_EXPORT
 @interface BugsnagPerformanceSpanQuery: NSObject
 
 @property (nonatomic, readonly, nullable) Class resultType;

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceTrackedViewContainer.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceTrackedViewContainer.h
@@ -2,7 +2,7 @@
 //  BugsnagPerformanceTrackedViewContainer.h
 //  BugsnagPerformance
 //
-//  Created by Robert B on 8/12/2023.
+//  Created by Robert Bartoszewski on 8/12/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/Sources/BugsnagPerformanceSwift/BugsnagPerformanceTrackedViewController.swift
+++ b/Sources/BugsnagPerformanceSwift/BugsnagPerformanceTrackedViewController.swift
@@ -2,7 +2,7 @@
 //  BugsnagPerformanceTrackedViewController.swift
 //  BugsnagPerformance-iOS
 //
-//  Created by Robert B on 07/12/2023.
+//  Created by Robert Bartoszewski on 07/12/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/Tests/BugsnagPerformanceTests/BSGPrioritizedStoreTests.m
+++ b/Tests/BugsnagPerformanceTests/BSGPrioritizedStoreTests.m
@@ -152,4 +152,49 @@
     XCTAssertTrue([store.objects[9] isEqualToString:@"Tenth"]);
 }
 
+- (void)testAddingDuplicateElementsShouldNotTakeEffect {
+    BSGPrioritizedStore<NSString *> *store = [BSGPrioritizedStore new];
+    
+    [store batchAddObjects:^(BSGPrioritizedStoreAddBlock addBlock) {
+        addBlock(@"Third", BugsnagPerformancePriorityMedium);
+        addBlock(@"Eighth", BugsnagPerformancePriorityLow);
+        addBlock(@"Ninth", BugsnagPerformancePriorityLow);
+        addBlock(@"Ninth", BugsnagPerformancePriorityLow);
+        addBlock(@"First", BugsnagPerformancePriorityHigh);
+        addBlock(@"Fourth", BugsnagPerformancePriorityMedium);
+        addBlock(@"Fifth", BugsnagPerformancePriorityMedium);
+        addBlock(@"Sixth", BugsnagPerformancePriorityMedium);
+        addBlock(@"Ninth", BugsnagPerformancePriorityLow);
+    }];
+    
+    XCTAssertEqual([store.objects count], 7);
+    [store addObject:@"Eighth" priority:BugsnagPerformancePriorityHigh];
+    XCTAssertEqual([store.objects count], 7);
+    [store addObject:@"Second" priority:BugsnagPerformancePriorityHigh];
+    [store addObject:@"First" priority:BugsnagPerformancePriorityHigh];
+    XCTAssertEqual([store.objects count], 8);
+    
+    [store batchAddObjects:^(BSGPrioritizedStoreAddBlock addBlock) {
+        addBlock(@"Tenth", BugsnagPerformancePriorityLow);
+        addBlock(@"Ninth", BugsnagPerformancePriorityLow);
+        addBlock(@"Sixth", BugsnagPerformancePriorityLow);
+    }];
+    
+    XCTAssertEqual([store.objects count], 9);
+    
+    [store addObject:@"Seventh" priority:BugsnagPerformancePriorityMedium];
+    
+    XCTAssertEqual([store.objects count], 10);
+    XCTAssertTrue([store.objects[0] isEqualToString:@"First"]);
+    XCTAssertTrue([store.objects[1] isEqualToString:@"Second"]);
+    XCTAssertTrue([store.objects[2] isEqualToString:@"Third"]);
+    XCTAssertTrue([store.objects[3] isEqualToString:@"Fourth"]);
+    XCTAssertTrue([store.objects[4] isEqualToString:@"Fifth"]);
+    XCTAssertTrue([store.objects[5] isEqualToString:@"Sixth"]);
+    XCTAssertTrue([store.objects[6] isEqualToString:@"Seventh"]);
+    XCTAssertTrue([store.objects[7] isEqualToString:@"Eighth"]);
+    XCTAssertTrue([store.objects[8] isEqualToString:@"Ninth"]);
+    XCTAssertTrue([store.objects[9] isEqualToString:@"Tenth"]);
+}
+
 @end

--- a/Tests/BugsnagPerformanceTests/BSGPrioritizedStoreTests.m
+++ b/Tests/BugsnagPerformanceTests/BSGPrioritizedStoreTests.m
@@ -109,4 +109,47 @@
     XCTAssertTrue([store.objects[9] isEqualToString:@"Tenth"]);
 }
 
+- (void)testUsingAddBlockAfterBatchBlockReturnsShouldNotTakeEffect {
+    BSGPrioritizedStore<NSString *> *store = [BSGPrioritizedStore new];
+    
+    __block BSGPrioritizedStoreAddBlock capturedAddBlock;
+    [store batchAddObjects:^(BSGPrioritizedStoreAddBlock addBlock) {
+        capturedAddBlock = addBlock;
+        addBlock(@"Third", BugsnagPerformancePriorityMedium);
+        addBlock(@"Eighth", BugsnagPerformancePriorityLow);
+        addBlock(@"Ninth", BugsnagPerformancePriorityLow);
+        addBlock(@"First", BugsnagPerformancePriorityHigh);
+        addBlock(@"Fourth", BugsnagPerformancePriorityMedium);
+        addBlock(@"Fifth", BugsnagPerformancePriorityMedium);
+        addBlock(@"Sixth", BugsnagPerformancePriorityMedium);
+    }];
+    
+    XCTAssertEqual([store.objects count], 7);
+    capturedAddBlock(@"ToBeIgnored", BugsnagPerformancePriorityMedium);
+    XCTAssertEqual([store.objects count], 7);
+    [store addObject:@"Second" priority:BugsnagPerformancePriorityHigh];
+    XCTAssertEqual([store.objects count], 8);
+    
+    [store batchAddObjects:^(BSGPrioritizedStoreAddBlock addBlock) {
+        addBlock(@"Tenth", BugsnagPerformancePriorityLow);
+        capturedAddBlock(@"ToBeIgnored2", BugsnagPerformancePriorityMedium);
+    }];
+    
+    XCTAssertEqual([store.objects count], 9);
+    
+    [store addObject:@"Seventh" priority:BugsnagPerformancePriorityMedium];
+    
+    XCTAssertEqual([store.objects count], 10);
+    XCTAssertTrue([store.objects[0] isEqualToString:@"First"]);
+    XCTAssertTrue([store.objects[1] isEqualToString:@"Second"]);
+    XCTAssertTrue([store.objects[2] isEqualToString:@"Third"]);
+    XCTAssertTrue([store.objects[3] isEqualToString:@"Fourth"]);
+    XCTAssertTrue([store.objects[4] isEqualToString:@"Fifth"]);
+    XCTAssertTrue([store.objects[5] isEqualToString:@"Sixth"]);
+    XCTAssertTrue([store.objects[6] isEqualToString:@"Seventh"]);
+    XCTAssertTrue([store.objects[7] isEqualToString:@"Eighth"]);
+    XCTAssertTrue([store.objects[8] isEqualToString:@"Ninth"]);
+    XCTAssertTrue([store.objects[9] isEqualToString:@"Tenth"]);
+}
+
 @end

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceRemoteSpanContextTests.m
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceRemoteSpanContextTests.m
@@ -2,7 +2,7 @@
 //  BugsnagPerformanceRemoteSpanContextTests.m
 //  BugsnagPerformance-iOSTests
 //
-//  Created by Robert B on 07/05/2025.
+//  Created by Robert Bartoszewski on 07/05/2025.
 //  Copyright © 2025 Bugsnag. All rights reserved.
 //
 

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceSpanConditionTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceSpanConditionTests.mm
@@ -2,7 +2,7 @@
 //  BugsnagPerformanceSpanConditionTests.m
 //  BugsnagPerformance-iOSTests
 //
-//  Created by Robert B on 24/01/2025.
+//  Created by Robert Bartoszewski on 24/01/2025.
 //  Copyright © 2025 Bugsnag. All rights reserved.
 //
 

--- a/Tests/BugsnagPerformanceTests/BugsnagPerformanceSpanTests.mm
+++ b/Tests/BugsnagPerformanceTests/BugsnagPerformanceSpanTests.mm
@@ -2,7 +2,7 @@
 //  BugsnagPerformanceSpanTests.m
 //  BugsnagPerformance-iOSTests
 //
-//  Created by Robert B on 08/05/2025.
+//  Created by Robert Bartoszewski on 08/05/2025.
 //  Copyright © 2025 Bugsnag. All rights reserved.
 //
 

--- a/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanStackingHandlerTests.mm
@@ -2,7 +2,7 @@
 //  SpanStackingHandlerTests.mm
 //  BugsnagPerformance-iOSTests
 //
-//  Created by Robert B on 25/05/2023.
+//  Created by Robert Bartoszewski on 25/05/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/Tests/BugsnagPerformanceTests/TracerTests.mm
+++ b/Tests/BugsnagPerformanceTests/TracerTests.mm
@@ -31,7 +31,9 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
     sampler->setProbability(1.0);
     auto batch = std::make_shared<Batch>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
+    auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -55,7 +57,9 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
+    auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -79,7 +83,9 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
+    auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -103,7 +109,9 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
+    auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -124,7 +132,9 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
+    auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
     SpanOptions spanOptions;
     auto span = tracer->startNetworkSpan(@"GET", spanOptions);
     XCTAssertEqual(span.kind, SPAN_KIND_CLIENT);
@@ -139,7 +149,9 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, ^(){});
+    auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
+    auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
     SpanOptions spanOptions;
     auto span = tracer->startSpan(@"TestSpan", spanOptions, BSGTriStateYes);
     XCTAssertEqual(span.kind, SPAN_KIND_INTERNAL);

--- a/Tests/BugsnagPerformanceTestsSwift/PerformanceMicrobenchmarkTests.swift
+++ b/Tests/BugsnagPerformanceTestsSwift/PerformanceMicrobenchmarkTests.swift
@@ -2,7 +2,7 @@
 //  PerformanceMicrobenchmarkTests.swift
 //  BugsnagPerformance-iOSTests
 //
-//  Created by Robert B on 03/04/2023.
+//  Created by Robert Bartoszewski on 03/04/2023.
 //  Copyright © 2023 Bugsnag. All rights reserved.
 //
 

--- a/features/default/plugins.feature
+++ b/features/default/plugins.feature
@@ -1,0 +1,19 @@
+Feature: Plugins
+
+  Scenario: Plugins can automatically update spans
+    Given I run "PluginScenario"
+    And I wait to receive a sampling request
+    And I wait to receive a trace
+
+    Then a span named "Span 1" contains the attributes:
+      | attribute | type        | value |
+      | spanCount | intValue    | 1     |
+
+    Then a span named "Span 2" contains the attributes:
+      | attribute | type        | value |
+      | spanCount | intValue    | 2     |
+      | queried   | boolValue   | true  |
+
+    Then a span named "Span 3" contains the attributes:
+      | attribute | type        | value |
+      | spanCount | intValue    | 3     |

--- a/features/default/plugins.feature
+++ b/features/default/plugins.feature
@@ -6,14 +6,39 @@ Feature: Plugins
     And I wait to receive a trace
 
     Then a span named "Span 1" contains the attributes:
-      | attribute | type        | value |
-      | spanCount | intValue    | 1     |
+      | attribute    | type      | value |
+      | span_count   | intValue  | 1     |
+      | plugin_start | boolValue | true  |
 
     Then a span named "Span 2" contains the attributes:
-      | attribute | type        | value |
-      | spanCount | intValue    | 2     |
-      | queried   | boolValue   | true  |
+      | attribute    | type      | value |
+      | span_count   | intValue  | 2     |
+      | queried      | boolValue | true  |
+      | plugin_start | boolValue | true  |
 
     Then a span named "Span 3" contains the attributes:
-      | attribute | type        | value |
-      | spanCount | intValue    | 3     |
+      | attribute    | type      | value |
+      | span_count   | intValue  | 3     |
+      | plugin_start | boolValue | true  |
+
+  Scenario: Error during plugin installation
+    Given I run "PluginInstallErrorScenario"
+    And I wait to receive a sampling request
+    And I wait to receive a trace
+    Then every span bool attribute "buggy_span_start" does not exist
+    And every span bool attribute "buggy_span_end" does not exist
+
+    And a span named "Span 1" contains the attributes:
+      | attribute    | type      | value |
+      | span_count   | intValue  | 1     |
+      | plugin_start | boolValue | true  |
+
+    And a span named "Span 2" contains the attributes:
+      | attribute    | type      | value |
+      | span_count   | intValue  | 2     |
+      | plugin_start | boolValue | true  |
+
+    And a span named "Span 3" contains the attributes:
+      | attribute    | type      | value |
+      | span_count   | intValue  | 3     |
+      | plugin_start | boolValue | true  |

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */; };
 		CBEC89452A4ED0590088A3CE /* MaxPayloadSizeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
+		DA58B7D62DF87EC500CB80A4 /* PluginInstallErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA58B7D52DF87EA900CB80A4 /* PluginInstallErrorScenario.swift */; };
 		DA85961E2DF718D100905922 /* PluginScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA85961D2DF718C800905922 /* PluginScenario.swift */; };
 		DADB14F92DE08A030006F44F /* OnStartCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */; };
 /* End PBXBuildFile section */
@@ -200,6 +201,7 @@
 		CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkMultiple.swift; sourceTree = "<group>"; };
 		CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxPayloadSizeScenario.swift; sourceTree = "<group>"; };
 		CBF62108291A4F47004BEE0B /* RetryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryScenario.swift; sourceTree = "<group>"; };
+		DA58B7D52DF87EA900CB80A4 /* PluginInstallErrorScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginInstallErrorScenario.swift; sourceTree = "<group>"; };
 		DA85961D2DF718C800905922 /* PluginScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginScenario.swift; sourceTree = "<group>"; };
 		DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnStartCallbackScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -279,6 +281,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				DA58B7D52DF87EA900CB80A4 /* PluginInstallErrorScenario.swift */,
 				DA85961D2DF718C800905922 /* PluginScenario.swift */,
 				DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
@@ -513,6 +516,7 @@
 				CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */,
 				966634E02C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift in Sources */,
 				CB2B8A9F2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift in Sources */,
+				DA58B7D62DF87EC500CB80A4 /* PluginInstallErrorScenario.swift in Sources */,
 				09F025152BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift in Sources */,
 				0988B5372CAD32C500D131B1 /* InfraCheckNoBugsnagScenario.swift in Sources */,
 				CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */,

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */; };
 		CBEC89452A4ED0590088A3CE /* MaxPayloadSizeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
+		DA85961E2DF718D100905922 /* PluginScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA85961D2DF718C800905922 /* PluginScenario.swift */; };
 		DADB14F92DE08A030006F44F /* OnStartCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */; };
 /* End PBXBuildFile section */
 
@@ -199,6 +200,7 @@
 		CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkMultiple.swift; sourceTree = "<group>"; };
 		CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxPayloadSizeScenario.swift; sourceTree = "<group>"; };
 		CBF62108291A4F47004BEE0B /* RetryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryScenario.swift; sourceTree = "<group>"; };
+		DA85961D2DF718C800905922 /* PluginScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginScenario.swift; sourceTree = "<group>"; };
 		DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnStartCallbackScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -277,6 +279,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				DA85961D2DF718C800905922 /* PluginScenario.swift */,
 				DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
@@ -306,7 +309,6 @@
 				CBAAE2582912601D006D4AA0 /* BatchingScenario.swift */,
 				CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */,
 				09301DC02B63A65A000A7C12 /* ComplexViewScenario.swift */,
-				098FC87B2D40EAB8001B627D /* CPUMetricsScenario.swift */,
 				09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */,
 				CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */,
 				CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */,
@@ -534,6 +536,7 @@
 				01E7918A28EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift in Sources */,
 				09DC622A2C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift in Sources */,
 				DADB14F92DE08A030006F44F /* OnStartCallbackScenario.swift in Sources */,
+				DA85961E2DF718D100905922 /* PluginScenario.swift in Sources */,
 				CBE615F729A4C1F0000E72D8 /* ParentSpanScenario.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */; };
 		CBEC89452A4ED0590088A3CE /* MaxPayloadSizeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
+		DA58B7D42DF8365E00CB80A4 /* PluginScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA58B7D32DF8365E00CB80A4 /* PluginScenario.swift */; };
 		DADB14F72DDF852B0006F44F /* OnStartCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */; };
 /* End PBXBuildFile section */
 
@@ -214,6 +215,7 @@
 		CBEC89222A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkMultiple.swift; sourceTree = "<group>"; };
 		CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxPayloadSizeScenario.swift; sourceTree = "<group>"; };
 		CBF62108291A4F47004BEE0B /* RetryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryScenario.swift; sourceTree = "<group>"; };
+		DA58B7D32DF8365E00CB80A4 /* PluginScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginScenario.swift; sourceTree = "<group>"; };
 		DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnStartCallbackScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -294,6 +296,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				DA58B7D32DF8365E00CB80A4 /* PluginScenario.swift */,
 				DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
 				01D3A7DF28F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift */,
@@ -529,6 +532,7 @@
 				CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */,
 				091B95722CA179AC007DC8A9 /* AutoInstrumentNetworkPreStartScenario.swift in Sources */,
 				098C3B522C53CECF006F9886 /* SwiftErrorGenerator.swift in Sources */,
+				DA58B7D42DF8365E00CB80A4 /* PluginScenario.swift in Sources */,
 				01FE4DC328E1AF3700D1F239 /* ManualSpanScenario.swift in Sources */,
 				01FE4DC728E1D5A400D1F239 /* Fixture.swift in Sources */,
 				094F41E62C4A84D6008162A4 /* SetAttributesScenario.swift in Sources */,

--- a/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		CBEC89452A4ED0590088A3CE /* MaxPayloadSizeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */; };
 		CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF62108291A4F47004BEE0B /* RetryScenario.swift */; };
 		DA58B7D42DF8365E00CB80A4 /* PluginScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA58B7D32DF8365E00CB80A4 /* PluginScenario.swift */; };
+		DA58B7D82DF97D7200CB80A4 /* PluginInstallErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA58B7D72DF97D7200CB80A4 /* PluginInstallErrorScenario.swift */; };
 		DADB14F72DDF852B0006F44F /* OnStartCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */; };
 /* End PBXBuildFile section */
 
@@ -216,6 +217,7 @@
 		CBEC89442A4ED0590088A3CE /* MaxPayloadSizeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxPayloadSizeScenario.swift; sourceTree = "<group>"; };
 		CBF62108291A4F47004BEE0B /* RetryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryScenario.swift; sourceTree = "<group>"; };
 		DA58B7D32DF8365E00CB80A4 /* PluginScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginScenario.swift; sourceTree = "<group>"; };
+		DA58B7D72DF97D7200CB80A4 /* PluginInstallErrorScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginInstallErrorScenario.swift; sourceTree = "<group>"; };
 		DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnStartCallbackScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -296,6 +298,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				DA58B7D72DF97D7200CB80A4 /* PluginInstallErrorScenario.swift */,
 				DA58B7D32DF8365E00CB80A4 /* PluginScenario.swift */,
 				DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
@@ -505,6 +508,7 @@
 				96E0B34B2CD0E21C008AEB9C /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift in Sources */,
 				96986DA52D506B8F00A44C34 /* SpanConditionsConditionTimedOutScenario.swift in Sources */,
 				960EECE92B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift in Sources */,
+				DA58B7D82DF97D7200CB80A4 /* PluginInstallErrorScenario.swift in Sources */,
 				0983A1792B14B20C00DDF4FF /* AutoInstrumentSwiftUIScenario.swift in Sources */,
 				CBF62109291A4F47004BEE0B /* RetryScenario.swift in Sources */,
 				CB7FD92B299BB4E300499E13 /* ManualUIViewLoadScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/PluginInstallErrorScenario.swift
+++ b/features/fixtures/ios/Scenarios/PluginInstallErrorScenario.swift
@@ -1,0 +1,35 @@
+//
+//  PluginInstallErrorScenario.swift
+//  Fixture
+//
+//  Created by Yousif Ahmed on 10/06/2025.
+//
+import BugsnagPerformance
+
+class InstallErrorPlugin: NSObject, BugsnagPerformancePlugin {
+
+    func install(with context: BugsnagPerformancePluginContext) {
+        context.add(onSpanStartCallback: { (span: BugsnagPerformanceSpan) in
+            span.setAttribute("buggy_span_start", withValue: true)
+        })
+        
+        context.add(onSpanEndCallback: { (span: BugsnagPerformanceSpan) in
+            span.setAttribute("buggy_span_end", withValue: true)
+            return true
+        })
+
+        NSException(name: NSExceptionName("InstallErrorPluginException"),
+                    reason: "This plugin is intentionally buggy",
+                    userInfo: nil).raise()
+    }
+    
+    func start() {}
+}
+
+@objcMembers
+class PluginInstallErrorScenario: PluginScenario {
+    override func setInitialBugsnagConfiguration() {
+        super.setInitialBugsnagConfiguration()
+        bugsnagPerfConfig.add(InstallErrorPlugin())
+    }
+}

--- a/features/fixtures/ios/Scenarios/PluginScenario.swift
+++ b/features/fixtures/ios/Scenarios/PluginScenario.swift
@@ -1,0 +1,68 @@
+//
+//  PluginScenario.swift
+//  Fixture
+//
+//  Created by Yousif Ahmed on 09/06/2025.
+//
+import BugsnagPerformance
+
+class TestSpanControl: NSObject, BugsnagPerformanceSpanControl {
+    
+    let span: BugsnagPerformanceSpan
+    
+    init(span: BugsnagPerformanceSpan) {
+        self.span = span
+        super.init()
+    }
+}
+
+class SpanCounterPlugin: NSObject, BugsnagPerformancePlugin, BugsnagPerformanceSpanControlProvider {
+    var spanList: [BugsnagPerformanceSpan] = []
+    var spanCount = 0
+    
+    func install(with context: BugsnagPerformancePluginContext) {
+        context.add(onSpanStartCallback: { (span: BugsnagPerformanceSpan) in
+            self.spanCount += 1
+            span.setAttribute("spanCount", withValue: self.spanCount)
+            self.spanList.append(span)
+        })
+        
+        context.add(self)
+    }
+    
+    func start() {}
+    
+    func getSpanControls(with query: BugsnagPerformanceSpanQuery) -> BugsnagPerformanceSpanControl? {
+        if (query.resultType == TestSpanControl.self && query.getAttributeWithName("index") != nil) {
+            let spanCount = query.getAttributeWithName("index") as? Int
+            if (spanCount != nil && spanCount! <= self.spanCount) {
+                return TestSpanControl(span: self.spanList[spanCount! - 1])
+            }
+        }
+        
+        return nil
+    }
+}
+
+@objcMembers
+class PluginScenario: Scenario {
+    
+    override func setInitialBugsnagConfiguration() {
+        super.setInitialBugsnagConfiguration()
+        bugsnagPerfConfig.add(SpanCounterPlugin())
+    }
+    
+    override func run() {
+        let span1 = BugsnagPerformance.startSpan(name: "Span 1")
+        let span2 = BugsnagPerformance.startSpan(name: "Span 2")
+        let span3 = BugsnagPerformance.startSpan(name: "Span 3")
+
+        let query = BugsnagPerformanceSpanQuery(resultType: TestSpanControl.self, attributes: ["index": 2])
+        let spanControl = BugsnagPerformance.getSpanControls(with: query) as? TestSpanControl
+        spanControl?.span.setAttribute("queried", withValue: true)
+        
+        span1.end()
+        span2.end()
+        span3.end()
+    }
+}


### PR DESCRIPTION
## Goal

Introduce a plugin mechanism that can be used to extend the functionality of the performance SDK.

## Changeset

- Introduced the `BugsnagPerformancePlugin` protocol and `BugsnagPerformancePluginContext` to allow plugins to register span callbacks and span control providers with the client
- Added `BSGPluginManager` to handle plugin installation and initialization
- Added `addPlugin` method to `BugsnagPerformanceConfiguration`
- Updated `BSGPrioritizedStore` to prevent duplicate entries and support transactional batched updates

## Testing

Added new E2E test scenarios