### PR TITLE
Fixed issue where reported total CPU usage values were not normalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+### Bug fixes
+
+* Fixed issue where reported total CPU usage values were not normalized.
+  [444](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/444)
+
 ### Enhancements
 
 * Set default endpoints based on API key [#441](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/441)

--- a/Sources/BugsnagPerformance/Private/BSGPSystemInfo.h
+++ b/Sources/BugsnagPerformance/Private/BSGPSystemInfo.h
@@ -187,11 +187,6 @@ public:
 
     uint64_t physicalMemoryBytesTotal() { return physicalMemoryBytesTotal_; }
 
-    double calcCPUUsagePct(CFAbsoluteTime lastSampledAtSec,
-                           uint64_t *lastTimeValueUSInOut,
-                           CFAbsoluteTime nowSampledAtSec,
-                           time_value_t nowTimeValue);
-
 private:
     void deallocAllThreads();
     void deallocCPUInfo();

--- a/Sources/BugsnagPerformance/Private/BSGPSystemInfo.mm
+++ b/Sources/BugsnagPerformance/Private/BSGPSystemInfo.mm
@@ -130,16 +130,3 @@ UIDeviceBatteryState BSGPSystemInfo::batteryState() {
 NSUInteger BSGPSystemInfo::activeProcessorCount() {
     return NSProcessInfo.processInfo.activeProcessorCount;
 }
-
-double BSGPSystemInfo::calcCPUUsagePct(CFAbsoluteTime lastSampledAtSec,
-                                       uint64_t *lastTimeValueUSInOut,
-                                       CFAbsoluteTime nowSampledAtSec,
-                                       time_value_t nowTimeValue) {
-    uint64_t lastTimeValueUS = *lastTimeValueUSInOut;
-    uint64_t nowTimeValueUS = (uint64_t)(nowTimeValue.seconds * TIME_MICROS_MAX + nowTimeValue.microseconds);
-    *lastTimeValueUSInOut = nowTimeValueUS;
-
-    double diffCPUTimeSec = (double)(nowTimeValueUS - lastTimeValueUS) / TIME_MICROS_MAX;
-    CFAbsoluteTime diffClockSec = nowSampledAtSec - lastSampledAtSec;
-    return (double)diffCPUTimeSec / diffClockSec * 100;
-}

--- a/Sources/BugsnagPerformance/Private/SystemInfoSampler.mm
+++ b/Sources/BugsnagPerformance/Private/SystemInfoSampler.mm
@@ -94,10 +94,11 @@ void SystemInfoSampler::recordSample() {
     if (shouldSampleCPU_) {
         auto taskInfo = systemInfo_.taskTimeInfo();
         if (taskInfo != nullptr) {
+            double activeProcessorCount = (double) systemInfo_.activeProcessorCount();
             sample.processCPUPct = calcCPUUsagePct(lastSampledAtTime_,
                                                    lastSampleProcessCPU_,
                                                    sample.sampledAt,
-                                                   taskInfo->user_time) / systemInfo_.activeProcessorCount();
+                                                   taskInfo->user_time) / activeProcessorCount;
             lastSampleProcessCPU_ = taskInfo->user_time;
             BSGLogTrace(@"SystemInfoSampler::recordSample: taskInfo: %d.%d = %f", taskInfo->user_time.seconds, taskInfo->user_time.microseconds, sample.processCPUPct);
         }

--- a/Sources/BugsnagPerformance/Private/SystemInfoSampler.mm
+++ b/Sources/BugsnagPerformance/Private/SystemInfoSampler.mm
@@ -81,10 +81,11 @@ static double calcCPUUsagePct(CFAbsoluteTime earlierSampledAtTime,
         return 0;
     }
     auto diffCPUTimeSec = timeValToTimeInterval(currentTimeValue) - timeValToTimeInterval(earlierTimeValue);
+    auto result = diffCPUTimeSec / diffClockSec * 100;
     BSGLogTrace(@"calcCPUUsagePct(): CPU %f - %f = %f, so returning %f / %f * 100 = %f",
                 timeValToTimeInterval(currentTimeValue), timeValToTimeInterval(earlierTimeValue), diffCPUTimeSec,
-                diffCPUTimeSec, diffClockSec, diffCPUTimeSec / diffClockSec * 100);
-    return diffCPUTimeSec / diffClockSec * 100;
+                diffCPUTimeSec, diffClockSec, result);
+    return result;
 }
 
 void SystemInfoSampler::recordSample() {
@@ -96,7 +97,7 @@ void SystemInfoSampler::recordSample() {
             sample.processCPUPct = calcCPUUsagePct(lastSampledAtTime_,
                                                    lastSampleProcessCPU_,
                                                    sample.sampledAt,
-                                                   taskInfo->user_time);
+                                                   taskInfo->user_time) / systemInfo_.activeProcessorCount();
             lastSampleProcessCPU_ = taskInfo->user_time;
             BSGLogTrace(@"SystemInfoSampler::recordSample: taskInfo: %d.%d = %f", taskInfo->user_time.seconds, taskInfo->user_time.microseconds, sample.processCPUPct);
         }

--- a/Sources/BugsnagPerformance/Private/SystemInfoSampler.mm
+++ b/Sources/BugsnagPerformance/Private/SystemInfoSampler.mm
@@ -94,7 +94,7 @@ void SystemInfoSampler::recordSample() {
     if (shouldSampleCPU_) {
         auto taskInfo = systemInfo_.taskTimeInfo();
         if (taskInfo != nullptr) {
-            double activeProcessorCount = (double) systemInfo_.activeProcessorCount();
+            double activeProcessorCount = MAX((double) systemInfo_.activeProcessorCount(), 1.0);
             sample.processCPUPct = calcCPUUsagePct(lastSampledAtTime_,
                                                    lastSampleProcessCPU_,
                                                    sample.sampledAt,

--- a/features/default/metrics.feature
+++ b/features/default/metrics.feature
@@ -383,7 +383,7 @@ Feature: Spans with collected metrics
     * a span float attribute "bugsnag.system.cpu_mean_overhead" is greater than 0.0
     * a span float attribute "bugsnag.system.cpu_mean_overhead" is less than 10.0
 
-  Scenario: Do heavy work on a bg thread while collecting CPU samples
+  Scenario: Do heavy work on a background threads while collecting CPU samples
     Given I load scenario "CPUMetricsScenario"
     And I configure bugsnag "cpuMetrics" to "true"
     And I configure scenario "run_delay" to "1.1"
@@ -410,6 +410,7 @@ Feature: Spans with collected metrics
     * every span bool attribute "bugsnag.span.first_class" is true
     * a span array attribute "bugsnag.system.cpu_measures_total" contains from 3 to 4 elements
     * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 50.0
+    * a span float attribute "bugsnag.system.cpu_mean_total" is less than 100.1
     * a span array attribute "bugsnag.system.cpu_measures_main_thread" contains from 3 to 4 elements
     * a span float attribute "bugsnag.system.cpu_mean_main_thread" is greater than 0.0
     * a span float attribute "bugsnag.system.cpu_mean_main_thread" is less than 10.0

--- a/features/fixtures/ios/Scenarios/CPUMetricsScenario.swift
+++ b/features/fixtures/ios/Scenarios/CPUMetricsScenario.swift
@@ -19,10 +19,15 @@ class CPUMetricsScenario: Scenario {
         if workDuration > 0 {
             var queue = DispatchQueue.global()
             if scenarioConfig["work_on_thread"] == "main" {
-                queue = DispatchQueue.main
-            }
-            queue.asyncAfter(deadline: .now()) {
-                self.doBusyWork(forSeconds: workDuration);
+                DispatchQueue.main.asyncAfter(deadline: .now()) {
+                    self.doBusyWork(forSeconds: workDuration);
+                }
+            } else {
+                for i in 0..<5 {
+                    Thread {
+                        self.doBusyWork(forSeconds: workDuration);
+                    }.start()
+                }
             }
         }
     }


### PR DESCRIPTION
## Goal

Total CPU usage values are expected to be in the range from 0 to 100.

## Changeset

Total CPU usage is now divided by the number of active cores

## Testing

E2E tests