### PR TITLE
Fixed issue where some Network spans were categorized as custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fixed issue where some Network spans were categorized as custom.
+  [448](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/448)
+
 ## 1.14.0 (2025-06-16)
 
 ### Bug fixes

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -51,7 +51,7 @@ BugsnagPerformanceImpl::BugsnagPerformanceImpl(std::shared_ptr<Reachability> rea
 , spanControlProvider_([BSGCompositeSpanControlProvider new])
 , spanStartCallbacks_([BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new])
 , spanEndCallbacks_([BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new])
-, tracer_(std::make_shared<Tracer>(spanStackingHandler_, sampler_, batch_, frameMetricsCollector_, conditionTimeoutExecutor_, spanStartCallbacks_, spanEndCallbacks_, ^{this->onSpanStarted();}))
+, tracer_(std::make_shared<Tracer>(spanStackingHandler_, sampler_, batch_, frameMetricsCollector_, conditionTimeoutExecutor_, spanAttributesProvider_, spanStartCallbacks_, spanEndCallbacks_, ^{this->onSpanStarted();}))
 , retryQueue_(std::make_unique<RetryQueue>([persistence_->bugsnagPerformanceDir() stringByAppendingPathComponent:@"retry-queue"]))
 , appStateTracker_(appStateTracker)
 , viewControllersToSpans_([NSMapTable mapTableWithKeyOptions:NSMapTableWeakMemory | NSMapTableObjectPointerPersonality

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation.mm
@@ -262,12 +262,10 @@ void NetworkInstrumentation::NSURLSessionTask_resume(NSURLSessionTask *task) noe
         SpanOptions options;
         options.makeCurrentContext = false;
         auto span = tracer_->startNetworkSpan(req.HTTPMethod, options);
-        [span end];
         if (errorFromGetRequest) {
-            [span forceMutate:^() {
-                [span internalSetMultipleAttributes:spanAttributesProvider_->internalErrorAttributes(errorFromGetRequest)];
-            }];
+            [span internalSetMultipleAttributes:spanAttributesProvider_->internalErrorAttributes(errorFromGetRequest)];
         }
+        [span end];
         
         return;
     }

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -15,6 +15,7 @@ public:
     SpanAttributesProvider() noexcept;
     ~SpanAttributesProvider() {};
     
+    NSMutableDictionary *initialNetworkSpanAttributes() noexcept;
     NSMutableDictionary *networkSpanUrlAttributes(NSURL *url, NSError *encounteredError) noexcept;
     NSMutableDictionary *networkSpanAttributes(NSURL *url, NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics,
                                                NSError *encounteredError) noexcept;

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -19,6 +19,9 @@ public:
     NSMutableDictionary *networkSpanUrlAttributes(NSURL *url, NSError *encounteredError) noexcept;
     NSMutableDictionary *networkSpanAttributes(NSURL *url, NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics,
                                                NSError *encounteredError) noexcept;
+    
+    NSMutableDictionary *internalErrorAttributes(NSError *encounteredError) noexcept;
+    
     NSMutableDictionary *appStartSpanAttributes(NSString *firstViewName, bool isColdLaunch) noexcept;
     NSMutableDictionary *appStartPhaseSpanAttributes(NSString *phase) noexcept;
     NSMutableDictionary *viewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -109,6 +109,14 @@ static uint64_t CFAbsoluteTimeToUTCNanos(CFAbsoluteTime time) {
 }
 
 NSMutableDictionary *
+SpanAttributesProvider::initialNetworkSpanAttributes() noexcept {
+    BSGLogTrace(@"SpanAttributesProvider::initialNetworkSpanAttributes");
+    auto attributes = [NSMutableDictionary new];
+    attributes[@"bugsnag.span.category"] = @"network";
+    return attributes;
+}
+
+NSMutableDictionary *
 SpanAttributesProvider::networkSpanAttributes(NSURL *url,
                                               NSURLSessionTask *task,
                                               NSURLSessionTaskMetrics *metrics,

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -113,6 +113,7 @@ SpanAttributesProvider::initialNetworkSpanAttributes() noexcept {
     BSGLogTrace(@"SpanAttributesProvider::initialNetworkSpanAttributes");
     auto attributes = [NSMutableDictionary new];
     attributes[@"bugsnag.span.category"] = @"network";
+    attributes[@"http.url"] = @"unknown";
     return attributes;
 }
 

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -130,7 +130,7 @@ SpanAttributesProvider::networkSpanAttributes(NSURL *url,
     }
     if (encounteredError != nil) {
         BSGLogTrace(@"SpanAttributesProvider::networkSpanAttributes: Caller encountered error \"%@\". Adding instrumentation_message attribute", encounteredError.description);
-        attributes[@"bugsnag.instrumentation_message"] = encounteredError.description;
+        [attributes addEntriesFromDictionary:internalErrorAttributes(encounteredError)];
     }
     attributes[@"http.flavor"] = getHTTPFlavour(metrics);
     attributes[@"http.method"] = getTaskRequest(task, nil).HTTPMethod;
@@ -152,6 +152,16 @@ SpanAttributesProvider::networkSpanUrlAttributes(NSURL *url, NSError *encountere
     }
     if (encounteredError != nil) {
         BSGLogTrace(@"SpanAttributesProvider::networkSpanUrlAttributes: Caller encountered error \"%@\". Adding instrumentation_message attribute", encounteredError.description);
+        [attributes addEntriesFromDictionary:internalErrorAttributes(encounteredError)];
+    }
+    return attributes;
+}
+
+NSMutableDictionary *
+SpanAttributesProvider::internalErrorAttributes(NSError *encounteredError) noexcept {
+    BSGLogTrace(@"SpanAttributesProvider::errorAttributes");
+    auto attributes = [NSMutableDictionary new];
+    if (encounteredError != nil) {
         attributes[@"bugsnag.instrumentation_message"] = encounteredError.description;
     }
     return attributes;

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -35,6 +35,7 @@ public:
            std::shared_ptr<Batch> batch,
            FrameMetricsCollector *frameMetricsCollector,
            std::shared_ptr<ConditionTimeoutExecutor> conditionTimeoutExecutor,
+           std::shared_ptr<SpanAttributesProvider> spanAttributesProvider,
            BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> *onSpanStartCallbacks,
            BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks,
            void (^onSpanStarted)()) noexcept;
@@ -86,6 +87,7 @@ private:
     std::shared_ptr<SpanStackingHandler> spanStackingHandler_;
     FrameMetricsCollector *frameMetricsCollector_;
     std::shared_ptr<ConditionTimeoutExecutor> conditionTimeoutExecutor_;
+    std::shared_ptr<SpanAttributesProvider> spanAttributesProvider_;
 
     std::atomic<bool> willDiscardPrewarmSpans_{false};
     BugsnagPerformanceEnabledMetrics *enabledMetrics_{[BugsnagPerformanceEnabledMetrics withAllEnabled]};

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -345,7 +345,7 @@ Tracer::startViewLoadSpan(BugsnagPerformanceViewType viewType,
 
 BugsnagPerformanceSpan *
 Tracer::startNetworkSpan(NSString *httpMethod, SpanOptions options) noexcept {
-    auto name = [NSString stringWithFormat:@"[HTTP/%@]", httpMethod];
+    auto name = [NSString stringWithFormat:@"[HTTP/%@]", httpMethod ?: @"unknown"];
     auto span = startSpan(name, options, BSGTriStateUnset);
     span.kind = SPAN_KIND_CLIENT;
     [span internalSetMultipleAttributes:spanAttributesProvider_->initialNetworkSpanAttributes()];

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -23,6 +23,7 @@ Tracer::Tracer(std::shared_ptr<SpanStackingHandler> spanStackingHandler,
                std::shared_ptr<Batch> batch,
                FrameMetricsCollector *frameMetricsCollector,
                std::shared_ptr<ConditionTimeoutExecutor> conditionTimeoutExecutor,
+               std::shared_ptr<SpanAttributesProvider> spanAttributesProvider,
                BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> *onSpanStartCallbacks,
                BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks,
                void (^onSpanStarted)()) noexcept
@@ -34,6 +35,7 @@ Tracer::Tracer(std::shared_ptr<SpanStackingHandler> spanStackingHandler,
 , batch_(batch)
 , frameMetricsCollector_(frameMetricsCollector)
 , conditionTimeoutExecutor_(conditionTimeoutExecutor)
+, spanAttributesProvider_(spanAttributesProvider)
 , onSpanStartCallbacks_(onSpanStartCallbacks)
 , onSpanEndCallbacks_(onSpanEndCallbacks)
 , onSpanStarted_(onSpanStarted)
@@ -346,6 +348,7 @@ Tracer::startNetworkSpan(NSString *httpMethod, SpanOptions options) noexcept {
     auto name = [NSString stringWithFormat:@"[HTTP/%@]", httpMethod];
     auto span = startSpan(name, options, BSGTriStateUnset);
     span.kind = SPAN_KIND_CLIENT;
+    [span internalSetMultipleAttributes:spanAttributesProvider_->initialNetworkSpanAttributes()];
     return span;
 }
 

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -20,8 +20,9 @@ using namespace bugsnag;
 - (void)testInitialNetworkSpanAttributes {
     SpanAttributesProvider provider;
     auto attributes = provider.initialNetworkSpanAttributes();
-    XCTAssertEqual(1U, attributes.count);
+    XCTAssertEqual(2U, attributes.count);
     XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"network");
+    XCTAssertEqualObjects(attributes[@"http.url"], @"unknown");
 }
 
 - (void)testNetworkSpanUrlAttributes {

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -17,6 +17,13 @@ using namespace bugsnag;
 
 @implementation SpanAttributesTests
 
+- (void)testInitialNetworkSpanAttributes {
+    SpanAttributesProvider provider;
+    auto attributes = provider.initialNetworkSpanAttributes();
+    XCTAssertEqual(1U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"network");
+}
+
 - (void)testNetworkSpanUrlAttributes {
     SpanAttributesProvider provider;
     NSURL *url = [NSURL URLWithString:@"https://bugsnag.com"];

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -48,6 +48,14 @@ using namespace bugsnag;
     XCTAssertEqual(0U, attributes.count);
 }
 
+- (void)testInternalErrorAttributes {
+    SpanAttributesProvider provider;
+    NSError *error = [NSError errorWithDomain:@"test" code:1 userInfo:nil];
+    auto attributes = provider.internalErrorAttributes(error);
+    XCTAssertEqual(1U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.instrumentation_message"], @"Error Domain=test Code=1 \"(null)\"");
+}
+
 - (void)testAppStartPhaseSpanAttributes {
     SpanAttributesProvider provider;
 

--- a/Tests/BugsnagPerformanceTests/TracerTests.mm
+++ b/Tests/BugsnagPerformanceTests/TracerTests.mm
@@ -29,11 +29,12 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto sampler = std::make_shared<Sampler>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
+    auto spanAttributesProvider = std::make_shared<SpanAttributesProvider>();
     sampler->setProbability(1.0);
     auto batch = std::make_shared<Batch>();
     auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
     auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanAttributesProvider, spanStartCallbacks, spanEndCallbacks, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -57,9 +58,10 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
+    auto spanAttributesProvider = std::make_shared<SpanAttributesProvider>();
     auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
     auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanAttributesProvider, spanStartCallbacks, spanEndCallbacks, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -83,9 +85,10 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
+    auto spanAttributesProvider = std::make_shared<SpanAttributesProvider>();
     auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
     auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanAttributesProvider, spanStartCallbacks, spanEndCallbacks, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -109,9 +112,10 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
+    auto spanAttributesProvider = std::make_shared<SpanAttributesProvider>();
     auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
     auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanAttributesProvider, spanStartCallbacks, spanEndCallbacks, ^(){});
     tracer->earlyConfigure(earlyConfig);
     tracer->earlySetup();
     tracer->configure(config);
@@ -132,12 +136,14 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
+    auto spanAttributesProvider = std::make_shared<SpanAttributesProvider>();
     auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
     auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanAttributesProvider, spanStartCallbacks, spanEndCallbacks, ^(){});
     SpanOptions spanOptions;
     auto span = tracer->startNetworkSpan(@"GET", spanOptions);
     XCTAssertEqual(span.kind, SPAN_KIND_CLIENT);
+    XCTAssertTrue([[span getAttribute:@"bugsnag.span.category"] isEqualToString: @"network"]);
     XCTAssertEqualObjects(span.name, @"[HTTP/GET]");
 }
 
@@ -149,9 +155,10 @@ static BugsnagPerformanceConfiguration *newConfig() {
     auto batch = std::make_shared<Batch>();
     auto frameMetricsCollector = [FrameMetricsCollector new];
     auto conditionTimeoutExecutor = std::make_shared<ConditionTimeoutExecutor>();
+    auto spanAttributesProvider = std::make_shared<SpanAttributesProvider>();
     auto spanStartCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new];
     auto spanEndCallbacks = [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new];
-    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanStartCallbacks, spanEndCallbacks, ^(){});
+    auto tracer = std::make_shared<Tracer>(stackingHandler, sampler, batch, frameMetricsCollector, conditionTimeoutExecutor, spanAttributesProvider, spanStartCallbacks, spanEndCallbacks, ^(){});
     SpanOptions spanOptions;
     auto span = tracer->startSpan(@"TestSpan", spanOptions, BSGTriStateYes);
     XCTAssertEqual(span.kind, SPAN_KIND_INTERNAL);

--- a/Tests/BugsnagPerformanceTests/TracerTests.mm
+++ b/Tests/BugsnagPerformanceTests/TracerTests.mm
@@ -143,7 +143,7 @@ static BugsnagPerformanceConfiguration *newConfig() {
     SpanOptions spanOptions;
     auto span = tracer->startNetworkSpan(@"GET", spanOptions);
     XCTAssertEqual(span.kind, SPAN_KIND_CLIENT);
-    XCTAssertTrue([[span getAttribute:@"bugsnag.span.category"] isEqualToString: @"network"]);
+    XCTAssertEqualObjects([span getAttribute:@"bugsnag.span.category"], @"network");
     XCTAssertEqualObjects(span.name, @"[HTTP/GET]");
 }
 
@@ -161,7 +161,7 @@ static BugsnagPerformanceConfiguration *newConfig() {
     SpanOptions spanOptions;
     auto span = tracer->startNetworkSpan(nil, spanOptions);
     XCTAssertEqual(span.kind, SPAN_KIND_CLIENT);
-    XCTAssertTrue([[span getAttribute:@"bugsnag.span.category"] isEqualToString: @"network"]);
+    XCTAssertEqualObjects([span getAttribute:@"bugsnag.span.category"], @"network");
     XCTAssertEqualObjects(span.name, @"[HTTP/unknown]");
 }
 

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -626,9 +626,12 @@ Feature: Automatic instrumentation spans
     * a span field "kind" equals 3
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "bugsnag.instrumentation_message" exists
     * a span string attribute "bugsnag.instrumentation_message" matches the regex "Error.*"
     * a span bool attribute "bugsnag.span.first_class" is true
     * a span bool attribute "bugsnag.span.first_class" does not exist
+    * a span string attribute "bugsnag.span.category" equals "network"
+    * a span string attribute "http.url" equals "unknown"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"


### PR DESCRIPTION
## Goal

Network spans for tasks that throw an exception on attempt to read current/original request were categorized as custom and the error message was not added to them.
Additionally, network spans wouldn't land under Network tab by default.

## Changeset

- Added the necessary attributes to all network spans
- Added error message to spans created for tasks with non-obtainable request

## Testing

Unit tests and E2E tests