### PR TITLE
Allow e2e test requests to be forwarded to InsightHub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ x-common-environment: &common-environment
   MAZE_BUGSNAG_API_KEY:
   MAZE_APPIUM_BUGSNAG_API_KEY:
   MAZE_REPEATER_API_KEY:
+  MAZE_HUB_REPEATER_API_KEY:
   MAZE_NO_FAIL_FAST:
 
 services:


### PR DESCRIPTION
## Goal

Allow e2e test requests to be forwarded to Bugsnag and InsightHub.

## Design

With these in place we can set API keys in our secrets bucket and have e2e test requests forwarded to InsightHub for testing purposes.

## Testing

Covered by CI.