### PR TITLE
Don't send CPU data if cpu_mean_total is not available

### DIFF
--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -268,7 +268,7 @@ SpanAttributesProvider::cpuSampleAttributes(const std::vector<SystemInfoSampleDa
 
     NSMutableDictionary *result = [NSMutableDictionary new];
 
-    if (timestamps.count < 2) {
+    if (timestamps.count < 2 || processSampleCount == 0) {
         return result;
     }
 

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -174,6 +174,26 @@ using namespace bugsnag;
     XCTAssertEqual(0U, attributes.count);
 }
 
+- (void)testCPUAttributesNilIfInvalidCPUMeanTotal {
+    SpanAttributesProvider provider;
+    std::vector<SystemInfoSampleData> samples = {
+        SystemInfoSampleData(1),
+        SystemInfoSampleData(2),
+        SystemInfoSampleData(3),
+    };
+
+    auto attributes = provider.cpuSampleAttributes(samples);
+    XCTAssertEqual(0U, attributes.count);
+
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_measures_timestamps"]);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_measures_total"]);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_mean_total"]);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_measures_main_thread"]);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_mean_main_thread"]);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_measures_overhead"]);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_mean_overhead"]);
+}
+
 - (void)testCPUSampleAttributes {
     SpanAttributesProvider provider;
     std::vector<SystemInfoSampleData> samples = {
@@ -252,19 +272,12 @@ using namespace bugsnag;
     samples[0].mainThreadCPUPct = 20;
     samples[1].mainThreadCPUPct = 50;
 
+    // CPU_MEAN_TOTAL not available, not sending other CPU data
     auto attributes = provider.cpuSampleAttributes(samples);
-    XCTAssertEqual(3U, attributes.count);
-    NSArray *expectedTimestamps = @[
-        @978307201000000000,
-        @978307202000000000,
-    ];
-    NSArray *expectedMainThread = @[
-        @20.0,
-        @50.0,
-    ];
-    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_timestamps"], expectedTimestamps);
-    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_main_thread"], expectedMainThread);
-    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_main_thread"], @35.0);
+    XCTAssertEqual(0U, attributes.count);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_measures_timestamps"]);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_measures_main_thread"]);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_mean_main_thread"]);
 }
 
 - (void)testCPUSampleAttributesOverheadOnly {
@@ -277,19 +290,12 @@ using namespace bugsnag;
     samples[0].monitorThreadCPUPct = 30;
     samples[1].monitorThreadCPUPct = 60;
 
+    // CPU_MEAN_TOTAL not available, not sending other CPU data
     auto attributes = provider.cpuSampleAttributes(samples);
-    XCTAssertEqual(3U, attributes.count);
-    NSArray *expectedTimestamps = @[
-        @978307201000000000,
-        @978307202000000000,
-    ];
-    NSArray *expectedMonitorThread = @[
-        @30.0,
-        @60.0,
-    ];
-    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_timestamps"], expectedTimestamps);
-    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_overhead"], expectedMonitorThread);
-    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_overhead"], @45.0);
+    XCTAssertEqual(0U, attributes.count);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_measures_timestamps"]);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_measures_overhead"]);
+    XCTAssertNil(attributes[@"bugsnag.system.cpu_mean_overhead"]);
 }
 
 - (void)testCPUSampleAttributesComplex {


### PR DESCRIPTION
## Goal
We shouldn’t send CPU metrics if there is no cpu_mean_total due to it being unavailable on the device.

## Changeset
If `processSampleCount` is zero that means that `cpu_mean_total` cannot be calculated.
So we check for it early and don't calculate any other cpu related attribute.

## Testing
Added new unit tests with `cpu_mean_total` being unavailable.
Adjusted existing tests that checked main thread only and overhead only.