### PR TITLE
Split Preload and Presentation phases of pre-loaded ViewLoads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## TBD
 
+### Enhancements
+
+* Split Preload and Presentation phases of pre-loaded ViewLoads. [455](https://github.com/bugsnag/bugsnag-cocoa-performance/pull/455)
+
 ### Bug fixes
 
 * Fixed issue where some Network spans were categorized as custom.

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -25,7 +25,8 @@ public:
     NSMutableDictionary *appStartSpanAttributes(NSString *firstViewName, bool isColdLaunch) noexcept;
     NSMutableDictionary *appStartPhaseSpanAttributes(NSString *phase) noexcept;
     NSMutableDictionary *viewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
-    NSMutableDictionary *preloadedViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
+    NSMutableDictionary *preloadViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
+    NSMutableDictionary *presentingViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
     NSMutableDictionary *viewLoadPhaseSpanAttributes(NSString *className, NSString *phase) noexcept;
     NSMutableDictionary *customSpanAttributes() noexcept;
 

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -199,10 +199,19 @@ SpanAttributesProvider::viewLoadSpanAttributes(NSString *className, BugsnagPerfo
 }
 
 NSMutableDictionary *
-SpanAttributesProvider::preloadedViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept {
+SpanAttributesProvider::preloadViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept {
     return @{
         @"bugsnag.span.category": @"view_load",
-        @"bugsnag.view.name": [NSString stringWithFormat:@"%@ (pre-loaded)", className],
+        @"bugsnag.view.name": [NSString stringWithFormat:@"%@ (preload)", className],
+        @"bugsnag.view.type": getBugsnagPerformanceViewTypeName(viewType)
+    }.mutableCopy;
+}
+
+NSMutableDictionary *
+SpanAttributesProvider::presentingViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept {
+    return @{
+        @"bugsnag.span.category": @"view_load",
+        @"bugsnag.view.name": [NSString stringWithFormat:@"%@ (presentation)", className],
         @"bugsnag.view.type": getBugsnagPerformanceViewTypeName(viewType)
     }.mutableCopy;
 }

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -110,25 +110,47 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"?");
 }
 
-- (void)testPreloadedViewLoadSpanAttributes {
+- (void)testPreloadViewLoadSpanAttributes {
     SpanAttributesProvider provider;
 
-    auto attributes = provider.preloadedViewLoadSpanAttributes(@"myView", BugsnagPerformanceViewTypeUIKit);
+    auto attributes = provider.preloadViewLoadSpanAttributes(@"myView", BugsnagPerformanceViewTypeUIKit);
     XCTAssertEqual(3U, attributes.count);
     XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
-    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (pre-loaded)");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (preload)");
     XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"UIKit");
 
-    attributes = provider.preloadedViewLoadSpanAttributes(@"myView", BugsnagPerformanceViewTypeSwiftUI);
+    attributes = provider.preloadViewLoadSpanAttributes(@"myView", BugsnagPerformanceViewTypeSwiftUI);
     XCTAssertEqual(3U, attributes.count);
     XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
-    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (pre-loaded)");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (preload)");
     XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"SwiftUI");
 
-    attributes = provider.preloadedViewLoadSpanAttributes(@"myView", (BugsnagPerformanceViewType)100);
+    attributes = provider.preloadViewLoadSpanAttributes(@"myView", (BugsnagPerformanceViewType)100);
     XCTAssertEqual(3U, attributes.count);
     XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
-    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (pre-loaded)");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (preload)");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"?");
+}
+
+- (void)testPresentingViewLoadSpanAttributes {
+    SpanAttributesProvider provider;
+
+    auto attributes = provider.presentingViewLoadSpanAttributes(@"myView", BugsnagPerformanceViewTypeUIKit);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (presentation)");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"UIKit");
+
+    attributes = provider.presentingViewLoadSpanAttributes(@"myView", BugsnagPerformanceViewTypeSwiftUI);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (presentation)");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"SwiftUI");
+
+    attributes = provider.presentingViewLoadSpanAttributes(@"myView", (BugsnagPerformanceViewType)100);
+    XCTAssertEqual(3U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"view_load");
+    XCTAssertEqualObjects(attributes[@"bugsnag.view.name"], @"myView (presentation)");
     XCTAssertEqualObjects(attributes[@"bugsnag.view.type"], @"?");
 }
 

--- a/features/default/automatic_spans.feature
+++ b/features/default/automatic_spans.feature
@@ -298,7 +298,7 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentPreLoadedViewLoadScenario
     Given I run "AutoInstrumentPreLoadedViewLoadScenario"
-    And I wait for 18 spans
+    And I wait for 19 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoad/UIKit]/Fixture.ViewController"
@@ -310,7 +310,8 @@ Feature: Automatic instrumentation spans
     * a span field "name" equals "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.ViewController"
     * a span field "name" equals "[ViewLoadPhase/Subview layout]/Fixture.ViewController"
     * a span field "name" equals "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.ViewController"
-    * a span field "name" equals "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (pre-loaded)"
+    * a span field "name" equals "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (pre-load)"
+    * a span field "name" equals "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (presenting)"
     * a span field "name" equals "[ViewLoadPhase/loadView]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
     * a span field "name" equals "[ViewLoadPhase/viewDidLoad]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
     * a span field "name" equals "[ViewLoadPhase/viewWillAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
@@ -319,6 +320,17 @@ Feature: Automatic instrumentation spans
     * a span field "name" equals "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
     * a span field "name" equals "[ViewLoadPhase/Subview layout]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
     * a span field "name" equals "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (pre-load)" ended at the same time as a span named "[ViewLoadPhase/viewDidLoad]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (presenting)" ended after a span named "[ViewLoadPhase/viewDidAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController"
+    * a span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (pre-load)" ended before a span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (presenting)" started
+    * a span named "[ViewLoadPhase/loadView]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" is a child of span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (pre-load)"
+    * a span named "[ViewLoadPhase/viewDidLoad]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" is a child of span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (pre-load)"
+    * a span named "[ViewLoadPhase/viewWillAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" is a child of span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (presenting)"
+    * a span named "[ViewLoadPhase/View appearing]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" is a child of span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (presenting)"
+    * a span named "[ViewLoadPhase/viewDidAppear]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" is a child of span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (presenting)"
+    * a span named "[ViewLoadPhase/viewWillLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" is a child of span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (presenting)"
+    * a span named "[ViewLoadPhase/Subview layout]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" is a child of span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (presenting)"
+    * a span named "[ViewLoadPhase/viewDidLayoutSubviews]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController" is a child of span named "[ViewLoad/UIKit]/Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (presenting)"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "kind" equals 1
@@ -326,7 +338,8 @@ Feature: Automatic instrumentation spans
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * a span string attribute "bugsnag.span.category" equals "view_load"
     * a span string attribute "bugsnag.view.name" equals "Fixture.ViewController"
-    * a span string attribute "bugsnag.view.name" equals "Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (pre-loaded)"
+    * a span string attribute "bugsnag.view.name" equals "Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (preload)"
+    * a span string attribute "bugsnag.view.name" equals "Fixture.AutoInstrumentPreLoadedViewLoadScenario_ViewController (presentation)"
     * a span bool attribute "bugsnag.span.first_class" is true
     * a span string attribute "bugsnag.view.type" equals "UIKit"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"


### PR DESCRIPTION
## Goal

iOS pre-loads applications that it predicts will probably be used in near future. At that time the app is not visible on the screen. From phone users perspective it makes it feel like the application is starting up faster. The time elapsed from the pre-load to the time the app is open can be substantial.
Initially we decided to implement a heuristic to detect a pre-load (a long delay between the view controller being loaded and it started being presented), once we detect it then we add “(pre-loaded)” to the name of the Span and adjust its start time.
Now we are changing the approach and splitting those ViewLoads into two spans.

## Design

As the information on time elapsed between the end of viewLoad phase and the beginning of viewWillAppear phase isn’t relevant to application performance, we split the ViewLoad span into two:  (preload) and (presenting).

## Testing

E2E tests