### PR TITLE
Fix zero padding of span and trace IDs in Crosstalk API

### DIFF
--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceCrossTalkAPI.mm
@@ -69,8 +69,8 @@ typedef void (^ViewLoadCallback)(BugsnagPerformanceSpan *, UIViewController *);
         return nil;
     }
     return @[
-        [NSString stringWithFormat:@"%llx%llx", span.traceIdHi, span.traceIdLo],
-        [NSString stringWithFormat:@"%llx", span.spanId]
+        [NSString stringWithFormat:@"%016llx%016llx", span.traceIdHi, span.traceIdLo],
+        [NSString stringWithFormat:@"%016llx", span.spanId]
     ];
 }
 


### PR DESCRIPTION
## Goal

Ensure span and trace IDs returned from `getCurrentTraceAndSpanIdV1` are correctly padded when encoding to prevent invalid IDs from being transmitted

## Changeset

Updated the string format to match that used when JSON encoding

