### PR TITLE
Setting parent context to nil in the span options should prevent the span from becoming a child

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		09F23A8F2CE3521D00F0D769 /* BugsnagSwiftToolsImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F23A8E2CE3521D00F0D769 /* BugsnagSwiftToolsImpl.swift */; };
 		09FFD4402BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 09FFD43E2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.h */; };
 		09FFD4412BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm in Sources */ = {isa = PBXBuildFile; fileRef = 09FFD43F2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm */; };
+		1C7852A22E5F5B3000BB8E2D /* SpanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C7852A12E5F5B2E00BB8E2D /* SpanContext.h */; };
+		1C7852A42E5F698300BB8E2D /* SpanContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C7852A32E5F697D00BB8E2D /* SpanContext.mm */; };
 		8A80DA8B2966CE940035BDA9 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		8A80DA912966CEB30035BDA9 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A80DA80296588840035BDA9 /* ConfigurationTests.swift */; };
 		960EECF12B23DF9B009FAA11 /* BugsnagPerformanceTrackedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960EECED2B237561009FAA11 /* BugsnagPerformanceTrackedViewController.swift */; };
@@ -409,6 +411,8 @@
 		09F23A8E2CE3521D00F0D769 /* BugsnagSwiftToolsImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugsnagSwiftToolsImpl.swift; sourceTree = "<group>"; };
 		09FFD43E2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceCrossTalkAPI.h; sourceTree = "<group>"; };
 		09FFD43F2BEE3DE2009B0E04 /* BugsnagPerformanceCrossTalkAPI.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceCrossTalkAPI.mm; sourceTree = "<group>"; };
+		1C7852A12E5F5B2E00BB8E2D /* SpanContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpanContext.h; sourceTree = "<group>"; };
+		1C7852A32E5F697D00BB8E2D /* SpanContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SpanContext.mm; sourceTree = "<group>"; };
 		72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformance.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A80DA80296588840035BDA9 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		8A80DA872966CE940035BDA9 /* BugsnagPerformance-iOSTestsSwift.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagPerformance-iOSTestsSwift.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -709,6 +713,8 @@
 		0122C21F29019770002D243C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				1C7852A32E5F697D00BB8E2D /* SpanContext.mm */,
+				1C7852A12E5F5B2E00BB8E2D /* SpanContext.h */,
 				CB572EA829BB783200FD7A2A /* AppStateTracker.h */,
 				CB572EA929BB783200FD7A2A /* AppStateTracker.m */,
 				CBE8EA1C294B5E1500702950 /* Batch.h */,
@@ -1133,6 +1139,7 @@
 				963726CA2DEAB24900C739E6 /* BugsnagPerformancePriority+Private.h in Headers */,
 				964B785F2D504FD800FF077D /* BugsnagPerformanceSpanCondition+Private.h in Headers */,
 				963726C62DEAB14D00C739E6 /* BSGCompositeSpanControlProvider.h in Headers */,
+				1C7852A22E5F5B3000BB8E2D /* SpanContext.h in Headers */,
 				0122C24A29019770002D243C /* AppStartupInstrumentation.h in Headers */,
 				CB04969B2915194E0097E526 /* OtlpUploader.h in Headers */,
 				966634D12C8909BB004A934D /* FrameMetricsCollector.h in Headers */,
@@ -1630,6 +1637,7 @@
 				0122C24829019770002D243C /* NetworkInstrumentation.mm in Sources */,
 				0122C24D29019770002D243C /* ViewLoadInstrumentation.mm in Sources */,
 				015836C229125E7A002F54C8 /* ResourceAttributes.mm in Sources */,
+				1C7852A42E5F698300BB8E2D /* SpanContext.mm in Sources */,
 				01A414D22913C238003152A4 /* Reachability.mm in Sources */,
 				96D55C802A1EA5C6006D1F29 /* SpanStackingHandler.mm in Sources */,
 				CB34771F29068C350033759C /* BSGURLSessionPerformanceProxy.mm in Sources */,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanContext+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpanContext+Private.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)encodedAsTraceParentWithSampled:(BOOL)sampled;
 
++ (BugsnagPerformanceSpanContext*)defaultContext;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/SpanContext.h
+++ b/Sources/BugsnagPerformance/Private/SpanContext.h
@@ -1,0 +1,20 @@
+//
+//  SpanContext.h
+//  BugsnagPerformance
+//
+//  Created by Daria Bialobrzeska on 27/08/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+#ifndef BUGSNAGPERFORMANCE_SPANCONTEXT_H
+#define BUGSNAGPERFORMANCE_SPANCONTEXT_H
+
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+
+namespace bugsnag {
+
+static BugsnagPerformanceSpanContext *defaultContext = nil;
+
+BugsnagPerformanceSpanContext *getDefaultSpanContext();
+}
+
+#endif // BUGSNAGPERFORMANCE_SPANCONTEXT_H

--- a/Sources/BugsnagPerformance/Private/SpanContext.mm
+++ b/Sources/BugsnagPerformance/Private/SpanContext.mm
@@ -1,0 +1,19 @@
+//
+//  SpanContext.m
+//  BugsnagPerformance
+//
+//  Created by Daria Bialobrzeska on 27/08/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+#import "SpanContext.h"
+
+namespace bugsnag {
+
+    BugsnagPerformanceSpanContext *getDefaultSpanContext() {
+        if (defaultContext == nil) {
+            defaultContext = [[BugsnagPerformanceSpanContext alloc] initWithTraceId:{.hi = 0, .lo = 0 } spanId:0];
+        }
+
+        return defaultContext;
+    }
+}

--- a/Sources/BugsnagPerformance/Private/SpanOptions.h
+++ b/Sources/BugsnagPerformance/Private/SpanOptions.h
@@ -10,6 +10,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
 #import "Utils.h"
 #import "Metrics.h"
+#import "SpanContext.h"
 
 namespace bugsnag {
 
@@ -37,7 +38,7 @@ public:
     
     SpanOptions()
     // These defaults must match the defaults in BugsnagPerformanceSpanOptions.m
-    : SpanOptions(nil,
+    : SpanOptions(getDefaultSpanContext(),
                   CFABSOLUTETIME_INVALID,
                   true,
                   BSGTriStateUnset,

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -14,6 +14,7 @@
 #import "Instrumentation/ViewLoadInstrumentation.h"
 #import "BugsnagPerformanceLibrary.h"
 #import "FrameRateMetrics/FrameMetricsCollector.h"
+#import "BugsnagPerformanceSpanContext+Private.h"
 #import <algorithm>
 
 using namespace bugsnag;
@@ -103,6 +104,8 @@ Tracer::startSpan(NSString *name, SpanOptions options, BSGTriState defaultFirstC
     __block auto blockThis = this;
     auto parentSpan = options.parentContext;
     if (parentSpan == nil) {
+        BSGLogTrace(@"Tracer::startSpan: Parent is intentionally set to nil");
+    } else if (parentSpan == [BugsnagPerformanceSpanContext defaultContext]) {
         BSGLogTrace(@"Tracer::startSpan: No parent specified; using current span");
         parentSpan = spanStackingHandler_->currentSpan();
     }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanContext.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanContext.mm
@@ -7,8 +7,14 @@
 //
 
 #import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+#import "../Private/BugsnagPerformanceSpanContext+Private.h"
+#import "../Private/SpanContext.h"
 
 @implementation BugsnagPerformanceSpanContext
+
++ (BugsnagPerformanceSpanContext*)defaultContext {
+    return bugsnag::getDefaultSpanContext();
+}
 
 - (instancetype) initWithTraceId:(TraceId) traceId spanId:(SpanId) spanId {
     if ((self = [super init])) {

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanOptions.h>
+#import "../Private/BugsnagPerformanceSpanContext+Private.h"
 
 @implementation BugsnagPerformanceSpanMetricsOptions
 
@@ -52,7 +53,7 @@
 - (instancetype)init {
     // These defaults must match the defaults in SpanOptions.h
     return [self initWithStartTime:nil
-                     parentContext:nil
+                     parentContext:[BugsnagPerformanceSpanContext defaultContext]
                 makeCurrentContext:true
                         firstClass:BSGTriStateUnset
                     metricsOptions:[BugsnagPerformanceSpanMetricsOptions new]];

--- a/features/default/manual_spans.feature
+++ b/features/default/manual_spans.feature
@@ -519,3 +519,19 @@ Feature: Manual creation of spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "custom"
+
+  Scenario: Manually start and end a span with nil parent context
+    Given I run "ManualSpanWithContextParentNilScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "ManualSpanWithContextParentNilScenario"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "parentSpanId" does not exist
+    * every span field "kind" equals 1
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span string attribute "bugsnag.span.category" equals "custom"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		09F23AC12CF0CBB500F0D769 /* AutoInstrumentGenericViewLoadScenario2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F23AC02CF0CBB500F0D769 /* AutoInstrumentGenericViewLoadScenario2.swift */; };
 		09F3F5282D6C728300BAA0A3 /* MemoryMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F3F5272D6C728300BAA0A3 /* MemoryMetricsScenario.swift */; };
 		09F3F5302D6F17B300BAA0A3 /* RenderingMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F3F52F2D6F17B300BAA0A3 /* RenderingMetricsScenario.swift */; };
+		1C7852A62E5FA7DF00BB8E2D /* ManualSpanWithContextParentNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7852A52E5FA7C700BB8E2D /* ManualSpanWithContextParentNilScenario.swift */; };
 		960EECE92B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960EECE82B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift */; };
 		96284DCE2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96284DCD2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift */; };
 		964735CB2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964735CA2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */; };
@@ -161,6 +162,7 @@
 		09F23AC02CF0CBB500F0D769 /* AutoInstrumentGenericViewLoadScenario2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentGenericViewLoadScenario2.swift; sourceTree = "<group>"; };
 		09F3F5272D6C728300BAA0A3 /* MemoryMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryMetricsScenario.swift; sourceTree = "<group>"; };
 		09F3F52F2D6F17B300BAA0A3 /* RenderingMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderingMetricsScenario.swift; sourceTree = "<group>"; };
+		1C7852A52E5FA7C700BB8E2D /* ManualSpanWithContextParentNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanWithContextParentNilScenario.swift; sourceTree = "<group>"; };
 		960EECE82B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentGenericViewLoadScenario.swift; sourceTree = "<group>"; };
 		96284DCD2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentPreLoadedViewLoadScenario.swift; sourceTree = "<group>"; };
 		964735CA2CCF137A00759ED9 /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkSharedSessionInvalidateScenario.swift; sourceTree = "<group>"; };
@@ -338,6 +340,7 @@
 				01E7918928EC7B5E00855993 /* ManualSpanBeforeStartScenario.swift */,
 				01FE4DC228E1AF3700D1F239 /* ManualSpanScenario.swift */,
 				96F129342DCE0CFE00A6FB2B /* ManualSpanWithRemoteContextParentScenario.swift */,
+				1C7852A52E5FA7C700BB8E2D /* ManualSpanWithContextParentNilScenario.swift */,
 				CB7FD92A299BB4E300499E13 /* ManualUIViewLoadScenario.swift */,
 				098808DF2B10A6E400DC1677 /* ManualViewLoadPhaseScenario.swift */,
 				01E3F99028F46B6700003F44 /* ManualViewLoadScenario.swift */,
@@ -485,6 +488,7 @@
 				96284DCE2B626B6F00025070 /* AutoInstrumentPreLoadedViewLoadScenario.swift in Sources */,
 				09637A3C2B0607F300F4F776 /* Logging.swift in Sources */,
 				9657A89B2A3D06EB001CEF5D /* AutoInstrumentNavigationViewLoadScenario.swift in Sources */,
+				1C7852A62E5FA7DF00BB8E2D /* ManualSpanWithContextParentNilScenario.swift in Sources */,
 				96986DA02D50654500A44C34 /* SpanConditionsMultipleConditionsScenario.swift in Sources */,
 				01D3A7E028F0290D0063D79E /* AutoInstrumentAppStartsScenario.swift in Sources */,
 				96986D9E2D5060E600A44C34 /* SpanConditionsSimpleConditionScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/ManualSpanWithContextParentNilScenario.swift
+++ b/features/fixtures/ios/Scenarios/ManualSpanWithContextParentNilScenario.swift
@@ -1,0 +1,23 @@
+//
+//  ManualSpanWithContextParentNilScenario.swift
+//  Fixture
+//
+//  Created by Daria Bialobrzeska on 27/08/2025.
+//
+
+import Bugsnag
+import BugsnagPerformance
+
+@objcMembers
+class ManualSpanWithContextParentNilScenario: Scenario {
+
+    override func run() {
+        let opts = BugsnagPerformanceSpanOptions()
+        opts.setParentContext(nil)
+        let span = BugsnagPerformance.startSpan(
+            name: "ManualSpanWithContextParentNilScenario",
+            options: opts
+        )
+        span.end()
+    }
+}


### PR DESCRIPTION
## Goal
According to the documentation, explicitly setting span's parent context to nil should prevent it from becoming a child span.

## Changeset
To differentiate explicit nil parent context and unset one the defaultContext was introduced.
Exposed via C and Obj-C style functions.

## Testing
MazeRunner test added to check if parent context stays nil.