### PR TITLE
BugsnagPerformanceNamedSpans optimization

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -126,6 +126,9 @@
 		967F6F1829C3783B0054EED8 /* BugsnagPerformanceConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */; };
 		968AA5FB2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 968AA5FA2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h */; };
 		968AA5FD2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm in Sources */ = {isa = PBXBuildFile; fileRef = 968AA5FC2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm */; };
+		96A143C22E80D3CB009138C3 /* NamedSpansStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 96A143C12E80D3BA009138C3 /* NamedSpansStore.h */; };
+		96A143C42E80D3DD009138C3 /* NamedSpansStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96A143C32E80D3D8009138C3 /* NamedSpansStore.mm */; };
+		96A143C62E80DDEB009138C3 /* NamedSpanState.h in Headers */ = {isa = PBXBuildFile; fileRef = 96A143C52E80DDE6009138C3 /* NamedSpanState.h */; };
 		96D415F329E6ADC500AEE435 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D415F229E6ADC500AEE435 /* AppDelegate.swift */; };
 		96D415F729E6ADC500AEE435 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D415F629E6ADC500AEE435 /* ViewController.swift */; };
 		96D415FA29E6ADC500AEE435 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 96D415F829E6ADC500AEE435 /* Main.storyboard */; };
@@ -458,6 +461,9 @@
 		967F6F1729C3782D0054EED8 /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
 		968AA5FA2CCA5A9200BA69CF /* BSGPerformanceSharedSessionProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGPerformanceSharedSessionProxy.h; sourceTree = "<group>"; };
 		968AA5FC2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGPerformanceSharedSessionProxy.mm; sourceTree = "<group>"; };
+		96A143C12E80D3BA009138C3 /* NamedSpansStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NamedSpansStore.h; sourceTree = "<group>"; };
+		96A143C32E80D3D8009138C3 /* NamedSpansStore.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NamedSpansStore.mm; sourceTree = "<group>"; };
+		96A143C52E80DDE6009138C3 /* NamedSpanState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NamedSpanState.h; sourceTree = "<group>"; };
 		96D415F029E6ADC500AEE435 /* BugsnagPerformanceTestsApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BugsnagPerformanceTestsApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		96D415F229E6ADC500AEE435 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		96D415F629E6ADC500AEE435 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -1044,8 +1050,8 @@
 		DA8E5ECF2E2FC36B0049F7AB /* Public */ = {
 			isa = PBXGroup;
 			children = (
-				DA87DAEE2E2FDFE60040F086 /* BugsnagPerformanceNamedSpansPlugin.mm */,
 				DA87DAFA2E3792B10040F086 /* BugsnagPerformanceNamedSpanQuery.m */,
+				DA87DAEE2E2FDFE60040F086 /* BugsnagPerformanceNamedSpansPlugin.mm */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -1053,9 +1059,9 @@
 		DA8E5EF92E2FC9AD0049F7AB /* BugsnagPerformanceNamedSpans */ = {
 			isa = PBXGroup;
 			children = (
+				DA87DAF72E3791CE0040F086 /* BugsnagPerformanceNamedSpanQuery.h */,
 				963828C52E3CFE1800404F3A /* BugsnagPerformanceNamedSpans.h */,
 				DA8E5EFD2E2FCA020049F7AB /* BugsnagPerformanceNamedSpansPlugin.h */,
-				DA87DAF72E3791CE0040F086 /* BugsnagPerformanceNamedSpanQuery.h */,
 			);
 			path = BugsnagPerformanceNamedSpans;
 			sourceTree = "<group>";
@@ -1072,6 +1078,9 @@
 			isa = PBXGroup;
 			children = (
 				DA9BB1CA2E40CC19009A7D25 /* BugsnagPerformanceNamedSpansPlugin+Private.h */,
+				96A143C12E80D3BA009138C3 /* NamedSpansStore.h */,
+				96A143C32E80D3D8009138C3 /* NamedSpansStore.mm */,
+				96A143C52E80DDE6009138C3 /* NamedSpanState.h */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -1187,6 +1196,8 @@
 				96F417152E3B8E7000EABD8E /* BugsnagPerformanceNamedSpans.h in Headers */,
 				DA9BB1CB2E40CC19009A7D25 /* BugsnagPerformanceNamedSpansPlugin+Private.h in Headers */,
 				DA87DAF92E3791CE0040F086 /* BugsnagPerformanceNamedSpanQuery.h in Headers */,
+				96A143C62E80DDEB009138C3 /* NamedSpanState.h in Headers */,
+				96A143C22E80D3CB009138C3 /* NamedSpansStore.h in Headers */,
 				DA8E5EFF2E2FCA020049F7AB /* BugsnagPerformanceNamedSpansPlugin.h in Headers */,
 				963828C62E3CFE2400404F3A /* BugsnagPerformanceNamedSpans.h in Headers */,
 			);
@@ -1680,6 +1691,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96A143C42E80D3DD009138C3 /* NamedSpansStore.mm in Sources */,
 				96F417162E3B8E7000EABD8E /* BugsnagPerformanceNamedSpans.docc in Sources */,
 				DA87DAF02E2FDFE60040F086 /* BugsnagPerformanceNamedSpansPlugin.mm in Sources */,
 				DA87DAFB2E3792B10040F086 /* BugsnagPerformanceNamedSpanQuery.m in Sources */,

--- a/Sources/BugsnagPerformanceNamedSpans/Private/BugsnagPerformanceNamedSpansPlugin+Private.h
+++ b/Sources/BugsnagPerformanceNamedSpans/Private/BugsnagPerformanceNamedSpansPlugin+Private.h
@@ -15,11 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Creates a new plugin instance with a custom timeout interval (for testing purposes).
  */
-- (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval NS_DESIGNATED_INITIALIZER;
-
-@property (nonatomic, assign, readonly) NSTimeInterval timeoutInterval;
-
-@property (nonatomic, assign, readonly) std::shared_ptr<std::unordered_map<void *, dispatch_source_t>> spanTimeoutTimers;
+- (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
+                          sweepInterval:(NSTimeInterval)sweepInterval NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Sources/BugsnagPerformanceNamedSpans/Private/NamedSpanState.h
+++ b/Sources/BugsnagPerformanceNamedSpans/Private/NamedSpanState.h
@@ -1,0 +1,23 @@
+//
+//  NamedSpanState.h
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 22/09/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+
+namespace bugsnag {
+class NamedSpanState {
+public:
+    NamedSpanState(BugsnagPerformanceSpan *span,
+                   CFAbsoluteTime expireTime) noexcept
+    : span(span)
+    , expireTime(expireTime) {};
+    ~NamedSpanState() {};
+    
+    BugsnagPerformanceSpan *span;
+    CFAbsoluteTime expireTime;
+};
+}

--- a/Sources/BugsnagPerformanceNamedSpans/Private/NamedSpansStore.h
+++ b/Sources/BugsnagPerformanceNamedSpans/Private/NamedSpansStore.h
@@ -1,0 +1,44 @@
+//
+//  NamedSpansStore.h
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 22/09/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import <BugsnagPerformance/BugsnagPerformanceSpan.h>
+#import "NamedSpanState.h"
+#import <map>
+#import <list>
+#import <mutex>
+
+namespace bugsnag {
+class NamedSpansStore {
+public:
+    NamedSpansStore(NSTimeInterval timeout,
+                       NSTimeInterval sweepInterval) noexcept
+    : timeout_(timeout)
+    , sweepInterval_(sweepInterval) {}
+    
+    ~NamedSpansStore() noexcept {
+        if (timer_ != nullptr) {
+            dispatch_cancel(timer_);
+        }
+    };
+    
+    void start() noexcept;
+    void add(BugsnagPerformanceSpan *span) noexcept;
+    void remove(BugsnagPerformanceSpan *span) noexcept;
+    BugsnagPerformanceSpan *getSpan(NSString *name) noexcept;
+private:
+    std::map<NSString *, std::list<std::shared_ptr<NamedSpanState>>::iterator> nameToSpan_{};
+    std::list<std::shared_ptr<NamedSpanState>> spanStates_{};
+    std::mutex mutex_;
+    dispatch_source_t timer_;
+    NSTimeInterval timeout_;
+    NSTimeInterval sweepInterval_;
+    
+    std::list<std::shared_ptr<NamedSpanState>>::iterator stateForName(NSString *name) noexcept;
+    void sweepExpiredSpans() noexcept;
+};
+}

--- a/Sources/BugsnagPerformanceNamedSpans/Private/NamedSpansStore.mm
+++ b/Sources/BugsnagPerformanceNamedSpans/Private/NamedSpansStore.mm
@@ -1,0 +1,93 @@
+//
+//  NamedSpansStore.mm
+//  BugsnagPerformance
+//
+//  Created by Robert Bartoszewski on 22/09/2025.
+//  Copyright © 2025 Bugsnag. All rights reserved.
+//
+
+#import "NamedSpansStore.h"
+
+using namespace bugsnag;
+
+void
+NamedSpansStore::start() noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    
+    __block auto blockThis = this;
+    dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0,
+                                                     dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0));
+    
+    dispatch_source_set_timer(timer,
+                              dispatch_time(DISPATCH_TIME_NOW,
+                                            (int64_t)(sweepInterval_ * NSEC_PER_SEC)),
+                              (uint64_t)(sweepInterval_ * NSEC_PER_SEC),
+                             0);
+    
+    dispatch_source_set_event_handler(timer, ^{
+        blockThis->sweepExpiredSpans();
+    });
+    
+    dispatch_resume(timer);
+    timer_ = timer;
+}
+
+void
+NamedSpansStore::add(BugsnagPerformanceSpan *span) noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto existingState = stateForName(span.name);
+    if (existingState != spanStates_.end()) {
+        spanStates_.erase(existingState);
+    }
+    auto spanState = std::make_shared<NamedSpanState>(span, CFAbsoluteTimeGetCurrent() + timeout_);
+    spanStates_.push_back(spanState);
+    nameToSpan_[span.name] = std::prev(spanStates_.end());
+}
+
+void
+NamedSpansStore::remove(BugsnagPerformanceSpan *span) noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto state = stateForName(span.name);
+    if (state != spanStates_.end() && (*state)->span == span) {
+        spanStates_.erase(state);
+        nameToSpan_.erase(span.name);
+    }
+}
+
+BugsnagPerformanceSpan *
+NamedSpansStore::getSpan(NSString *name) noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto state = stateForName(name);
+    if (state == spanStates_.end()) {
+        return nullptr;
+    }
+    return (*state)->span;
+}
+
+#pragma mark Private
+
+void
+NamedSpansStore::sweepExpiredSpans() noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
+    
+    auto state = spanStates_.begin();
+    while (state != spanStates_.end()) {
+        if (now > (*state)->expireTime) {
+            auto name = (*state)->span.name;
+            nameToSpan_.erase(name);
+            state = spanStates_.erase(state);
+        } else {
+            return;
+        }
+    }
+}
+
+std::list<std::shared_ptr<NamedSpanState>>::iterator
+NamedSpansStore::stateForName(NSString *name) noexcept {
+    auto result = nameToSpan_.find(name);
+    if (result == nameToSpan_.end()) {
+        return spanStates_.end();
+    }
+    return (*result).second;
+}

--- a/Tests/BugsnagPerformanceNamedSpansTests/BugsnagPerformanceNamedSpansTests.mm
+++ b/Tests/BugsnagPerformanceNamedSpansTests/BugsnagPerformanceNamedSpansTests.mm
@@ -75,7 +75,7 @@ static BugsnagPerformanceSpan *createSpan(NSString *name) {
 
 - (void)setUp {
     [super setUp];
-    self.plugin = [[BugsnagPerformanceNamedSpansPlugin alloc] initWithTimeoutInterval:0.2]; // Use a short timeout for testing
+    self.plugin = [[BugsnagPerformanceNamedSpansPlugin alloc] initWithTimeoutInterval:0.2 sweepInterval:0.01]; // Use a short timeout for testing
     self.mockContext = (BugsnagPerformancePluginContext *)[[FakePluginContext alloc] init];
 }
 
@@ -100,16 +100,6 @@ static BugsnagPerformanceSpan *createSpan(NSString *name) {
 - (void)testStartMethod {
     // start method should not throw
     XCTAssertNoThrow([self.plugin start]);
-}
-
-- (void)testInitWithCustomTimeoutInterval {
-    BugsnagPerformanceNamedSpansPlugin *customPlugin = [[BugsnagPerformanceNamedSpansPlugin alloc] initWithTimeoutInterval:30.0];
-    XCTAssertEqual(customPlugin.timeoutInterval, 30.0);
-}
-
-- (void)testDefaultInitUsesDefaultTimeout {
-    BugsnagPerformanceNamedSpansPlugin *defaultPlugin = [[BugsnagPerformanceNamedSpansPlugin alloc] init];
-    XCTAssertEqual(defaultPlugin.timeoutInterval, 600.0); // 10 minutes
 }
 
 #pragma mark - Span Caching Tests
@@ -261,7 +251,6 @@ static BugsnagPerformanceSpan *createSpan(NSString *name) {
     BugsnagPerformanceNamedSpanQuery *query = [BugsnagPerformanceNamedSpanQuery queryWithName:@"timeout-span"];
     id<BugsnagPerformanceSpanControl> cachedSpan = [self.plugin getSpanControlsWithQuery:query];
     XCTAssertIdentical(cachedSpan, span);
-    XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 1UL);
 
     // Wait for timeout to trigger
     XCTestExpectation *timeoutExpectation = [self expectationWithDescription:@"Span timeout should remove span from cache"];
@@ -270,39 +259,14 @@ static BugsnagPerformanceSpan *createSpan(NSString *name) {
         // Check span is removed from cache after timeout interval
         id<BugsnagPerformanceSpanControl> stillCachedSpan = [self.plugin getSpanControlsWithQuery:query];
         XCTAssertNil(stillCachedSpan);
-        XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 0UL);
         [timeoutExpectation fulfill];
     });
     
     [self waitForExpectations:@[timeoutExpectation] timeout:0.5];
 }
 
-- (void)testTimeoutTimerCancelledWhenSpanEnds {
-    [self.plugin installWithContext:self.mockContext];
-    
-    BugsnagPerformanceSpan *span = createSpan(@"timer-span");
-    FakePluginContext *fakeContext = (FakePluginContext *)self.mockContext;
-    
-    // Start span (creates timeout timer)
-    fakeContext.spanStartCallback(span);
-    
-    // Verify span is cached
-    BugsnagPerformanceNamedSpanQuery *query = [BugsnagPerformanceNamedSpanQuery queryWithName:@"timer-span"];
-    id<BugsnagPerformanceSpanControl> cachedSpan = [self.plugin getSpanControlsWithQuery:query];
-    XCTAssertIdentical(cachedSpan, span);
-    XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 1UL);
 
-    // End span (should cancel timeout timer and remove from cache)
-    BOOL result = fakeContext.spanEndCallback(span);
-    XCTAssertTrue(result);
-    
-    // Verify span is removed from cache
-    id<BugsnagPerformanceSpanControl> removedSpan = [self.plugin getSpanControlsWithQuery:query];
-    XCTAssertNil(removedSpan);
-    XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 0UL);
-}
-
-- (void)testTimeoutTimerCancelledWhenNewSpanWithSameNameStarted {
+- (void)testTimeoutIsRenewedWhenNewSpanWithSameNameStarted {
     [self.plugin installWithContext:self.mockContext];
     
     BugsnagPerformanceSpan *span1 = createSpan(@"test-span");
@@ -316,15 +280,11 @@ static BugsnagPerformanceSpan *createSpan(NSString *name) {
     BugsnagPerformanceNamedSpanQuery *query = [BugsnagPerformanceNamedSpanQuery queryWithName:@"test-span"];
     id<BugsnagPerformanceSpanControl> cachedSpan = [self.plugin getSpanControlsWithQuery:query];
     XCTAssertIdentical(cachedSpan, span1);
-    
-    XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 1UL);
 
     // Wait for first span's timeout to almost elapse (0.15 seconds of 0.2 second timeout)
     XCTestExpectation *stagingExpectation = [self expectationWithDescription:@"Second span with same name should replace first span"];
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        // Verify first span's timer is still active
-        XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 1UL);
 
         // Start second span with same name (should cancel first timer and create a new one)
         fakeContext.spanStartCallback(span2);
@@ -332,7 +292,6 @@ static BugsnagPerformanceSpan *createSpan(NSString *name) {
         // Verify second span replaced first span
         id<BugsnagPerformanceSpanControl> newCachedSpan = [self.plugin getSpanControlsWithQuery:query];
         XCTAssertIdentical(newCachedSpan, span2);
-        XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 1UL);
 
         [stagingExpectation fulfill];
     });
@@ -346,14 +305,13 @@ static BugsnagPerformanceSpan *createSpan(NSString *name) {
         // Verify second span is still cached
         id<BugsnagPerformanceSpanControl> stillCachedSpan = [self.plugin getSpanControlsWithQuery:query];
         XCTAssertIdentical(stillCachedSpan, span2);
-        XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 1UL);
         [timeoutExpectation fulfill];
     });
     
     [self waitForExpectations:@[timeoutExpectation] timeout:0.3];
 }
 
-- (void)testMultipleSpansWithDifferentNamesHaveSeparateTimeoutTimers {
+- (void)testMultipleSpansWithDifferentNamesAreRemovedFromCacheOnTheirTimeout {
     [self.plugin installWithContext:self.mockContext];
     
     BugsnagPerformanceSpan *span1 = createSpan(@"span-one");
@@ -363,15 +321,12 @@ static BugsnagPerformanceSpan *createSpan(NSString *name) {
     
     // Start first span
     fakeContext.spanStartCallback(span1);
-    XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 1UL);
 
     // Start second span with different name
     fakeContext.spanStartCallback(span2);
-    XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 2UL);
 
     // Start third span with different name
     fakeContext.spanStartCallback(span3);
-    XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 3UL);
 
     // Verify all spans are cached
     BugsnagPerformanceNamedSpanQuery *query1 = [BugsnagPerformanceNamedSpanQuery queryWithName:@"span-one"];
@@ -385,7 +340,6 @@ static BugsnagPerformanceSpan *createSpan(NSString *name) {
     // End middle span - should only remove its timer
     BOOL result = fakeContext.spanEndCallback(span2);
     XCTAssertTrue(result);
-    XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 2UL);
 
     // Verify span2 is removed but span1 and span3 remain
     XCTAssertIdentical([self.plugin getSpanControlsWithQuery:query1], span1);
@@ -399,7 +353,6 @@ static BugsnagPerformanceSpan *createSpan(NSString *name) {
         // Both remaining spans should be removed by timeout
         XCTAssertNil([self.plugin getSpanControlsWithQuery:query1]);
         XCTAssertNil([self.plugin getSpanControlsWithQuery:query3]);
-        XCTAssertEqual(self.plugin.spanTimeoutTimers->size(), 0UL);
         [timeoutExpectation fulfill];
     });
     


### PR DESCRIPTION
## Goal

Reduce BugsnagPerformanceNamedSpans overhead.

## Changeset
- Rewrote NamedSpan store using C++ data structures
- Replaced creating timers for each span with a single periodic sweeper timer

## Testing

Existing E2E, unit and benchmarking tests