### PR TITLE
plat-16014 resource usages aggreation changes

### DIFF
--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 		DA8E5EF42E2FC45B0049F7AB /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		DA8E5EFF2E2FCA020049F7AB /* BugsnagPerformanceNamedSpansPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8E5EFD2E2FCA020049F7AB /* BugsnagPerformanceNamedSpansPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA9BB1CB2E40CC19009A7D25 /* BugsnagPerformanceNamedSpansPlugin+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9BB1CA2E40CC19009A7D25 /* BugsnagPerformanceNamedSpansPlugin+Private.h */; };
+		E15559F82FD2750D00D51E68 /* SessionMetricsAccumulator.h in Headers */ = {isa = PBXBuildFile; fileRef = E15559F72FD2750500D51E68 /* SessionMetricsAccumulator.h */; };
 		E1AE2B5C2F76F9FA00019D5A /* EarlyConfigurationInfoPlistTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E1AE2B5B2F76F9FA00019D5A /* EarlyConfigurationInfoPlistTests.mm */; };
 /* End PBXBuildFile section */
 
@@ -738,6 +739,8 @@
 		DA8E5EFD2E2FCA020049F7AB /* BugsnagPerformanceNamedSpansPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceNamedSpansPlugin.h; sourceTree = "<group>"; };
 		DA8E5F0F2E2FCDED0049F7AB /* BugsnagPerformanceNamedSpansTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceNamedSpansTests.mm; sourceTree = "<group>"; };
 		DA9BB1CA2E40CC19009A7D25 /* BugsnagPerformanceNamedSpansPlugin+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagPerformanceNamedSpansPlugin+Private.h"; sourceTree = "<group>"; };
+		E15559F42FD2716700D51E68 /* SessionMetricsAccumulatorTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SessionMetricsAccumulatorTests.mm; sourceTree = "<group>"; };
+		E15559F72FD2750500D51E68 /* SessionMetricsAccumulator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SessionMetricsAccumulator.h; sourceTree = "<group>"; };
 		E1AE2B5B2F76F9FA00019D5A /* EarlyConfigurationInfoPlistTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EarlyConfigurationInfoPlistTests.mm; sourceTree = "<group>"; };
 		EDE8339F2AF550E20042A78F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sources/BugsnagPerformance/resources/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -976,6 +979,7 @@
 				CBEC51DA2976F1F9009C0CE3 /* RetryQueue.h */,
 				CBEC51DB2976F1F9009C0CE3 /* RetryQueue.mm */,
 				01A58C0C29092D25006E4DF7 /* Sampler.h */,
+				E15559F72FD2750500D51E68 /* SessionMetricsAccumulator.h */,
 				96D55C822A1EBA35006D1F29 /* SpanActivityState.h */,
 				01A414CB2913C0F0003152A4 /* SpanAttributes.h */,
 				01A414CC2913C0F0003152A4 /* SpanAttributes.mm */,
@@ -1067,6 +1071,7 @@
 				01A414C42912B93F003152A4 /* ResourceAttributesTests.mm */,
 				CBEC51E029793B1E009C0CE3 /* RetryQueueTests.mm */,
 				01A58C10290931A5006E4DF7 /* SamplerTests.mm */,
+				E15559F42FD2716700D51E68 /* SessionMetricsAccumulatorTests.mm */,
 				098FC8782D3FADFE001B627D /* SpanAttributesTests.mm */,
 				CB747D1E299E4984003CA1B4 /* SpanOptionsTests.mm */,
 				96D55C872A1EE26A006D1F29 /* SpanStackingHandlerTests.mm */,
@@ -1606,6 +1611,7 @@
 				967949BF2E993749005FD87F /* SpanStoreImpl.h in Headers */,
 				09F23A8C2CE351ED00F0D769 /* BugsnagSwiftTools.h in Headers */,
 				0921F02B2A67CBD600C764EB /* BugsnagPerformanceNetworkRequestInfo.h in Headers */,
+				E15559F82FD2750D00D51E68 /* SessionMetricsAccumulator.h in Headers */,
 				962CE7D52E60967A00380522 /* BugsnagPerformanceLoadingIndicatorView+Private.h in Headers */,
 				963726CA2DEAB24900C739E6 /* BugsnagPerformancePriority+Private.h in Headers */,
 				962CE7DF2E60988100380522 /* ViewLoadEarlyPhaseHandlerImpl.h in Headers */,

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -37,8 +37,10 @@
 #import "SpanFactory/Network/NetworkSpanFactoryImpl.h"
 #import "SpanLifecycle/SpanLifecycleHandlerImpl.h"
 #import "SpanStore/SpanStoreImpl.h"
+#import "SessionMetricsAccumulator.h"
 
 #import <mutex>
+#import <map>
 
 namespace bugsnag {
 
@@ -59,6 +61,8 @@ public:
     BugsnagPerformanceSpan *startCustomSpan(NSString *name) noexcept;
 
     BugsnagPerformanceSpan *startCustomSpan(NSString *name, BugsnagPerformanceSpanOptions *options) noexcept;
+
+    BugsnagPerformanceSpan *startAppSessionSpan(NSString *sessionType) noexcept;
 
     BugsnagPerformanceSpan *startViewLoadSpan(NSString *name, BugsnagPerformanceViewType viewType) noexcept;
 
@@ -138,6 +142,19 @@ private:
     bool hasCheckedAppStartDuration_{false};
     bool isDevelopment_{false};
 
+    struct SessionAccumulatorState {
+        SessionMetricsAccumulator accumulator;
+        //bool pauseOnBackground{true};
+    };
+
+    // Active session accumulators — sampler feeds these every second while span is open.
+    std::map<void *, SessionAccumulatorState> sessionAccumulators_;
+    // Finished session accumulators — snapshot moved here when span ends so the sampler
+    // stops feeding it; the batch-send worker reads from here at upload time.
+    std::map<void *, SessionAccumulatorState> finishedSessionAccumulators_;
+    std::mutex sessionAccumulatorsMutex_;
+    std::atomic<bool> isAppInBackground_{false};
+
     // Tasks
     NSArray<Task> *buildInitialTasks() noexcept;
     NSArray<Task> *buildRecurringTasks() noexcept;
@@ -166,6 +183,9 @@ private:
       sendableSpans(NSMutableArray<BugsnagPerformanceSpan *> *spans) noexcept;
     bool shouldSampleCPU(BugsnagPerformanceSpan *span) noexcept;
     bool shouldSampleMemory(BugsnagPerformanceSpan *span) noexcept;
+    void applySampleAttributesFromHistory(BugsnagPerformanceSpan *span, bool isSessionSpan) noexcept;
+    void applySessionSpanSampleAttributes(BugsnagPerformanceSpan *span) noexcept;
+    void applyNonSessionSpanSampleAttributes(BugsnagPerformanceSpan *span) noexcept;
 
 public: // For testing
     void testing_setProbability(double probability) { onProbabilityChanged(probability); };

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -8,6 +8,7 @@
 
 #import "BugsnagPerformanceImpl.h"
 #import "BugsnagPerformanceConfiguration+Private.h"
+#import "BugsnagPerformancePriority+Private.h"
 
 #import "OtlpTraceEncoding.h"
 #import "Utils.h"
@@ -26,6 +27,25 @@ using namespace bugsnag;
 static constexpr double SAMPLER_INTERVAL_SECONDS = 1.0;
 static constexpr double SAMPLER_HISTORY_SECONDS = 10 * 60;
 static constexpr NSTimeInterval WORK_INTERVAL_DEBUG_MODE_SECONDS = 5;
+
+// Category value written onto every app-session span so other code can identify them.
+static NSString * const BSGSpanCategoryAppSession = @"app_session";
+
+// Normalise a caller-supplied session-type string into a safe CamelCase identifier.
+static NSString *sanitizeSessionTypeIdentifier(NSString *sessionType) {
+    NSCharacterSet *separators = [[NSCharacterSet alphanumericCharacterSet] invertedSet];
+    if ([sessionType rangeOfCharacterFromSet:separators].location == NSNotFound && sessionType.length > 0) {
+        return sessionType;
+    }
+    NSMutableString *out = [NSMutableString string];
+    for (NSString *part in [sessionType componentsSeparatedByCharactersInSet:separators]) {
+        if (part.length == 0) { continue; }
+        NSString *low = part.lowercaseString;
+        [out appendString:[low stringByReplacingCharactersInRange:NSMakeRange(0,1)
+                                                       withString:[[low substringToIndex:1] uppercaseString]]];
+    }
+    return out.length > 0 ? out : @"Session";
+}
 
 static NSString *getPersistenceDir() {
     // Persistent data in bugsnag-performance can handle files disappearing, so put it in the caches dir.
@@ -245,6 +265,51 @@ void BugsnagPerformanceImpl::start() noexcept {
 
     systemInfoSampler_.start();
 
+    // Every 1 second the sampler fires its callback.  Feed the sample only into
+    // ACTIVE session accumulators (sessionAccumulators_).  Once a session span ends
+    // its accumulator is moved to finishedSessionAccumulators_ (see span-end callback
+    // registered below) so the sampler cannot add post-end samples.
+    systemInfoSampler_.setOnSampleRecorded([this](const SystemInfoSampleData &sample) {
+        std::lock_guard<std::mutex> guard(this->sessionAccumulatorsMutex_);
+        for (auto &kv : this->sessionAccumulators_) {
+            SessionAccumulatorState &state = kv.second;
+
+            BSGLogDebug(@"[BugsnagSession] sampler: feeding sample to accumulator (validCPU=%d, validMem=%d, currentCount=%llu)",
+                  (int)sample.hasValidCPUData(), (int)sample.hasValidMemoryData(),
+                  state.accumulator.processCPU.count + 1);
+            state.accumulator.addSample(sample);
+        }
+    });
+
+    // Register a span-end callback so that when any session span ends we
+    // immediately move its accumulator from the active map to the finished map.
+    // This stops the sampler from adding post-end samples and gives the
+    // batch-send worker a stable, immutable snapshot to read at upload time.
+    //
+    // Priority MAX = runs first, before any user-registered callbacks, so the
+    // snapshot is captured at the exact moment the span ended.
+    // No changes to SpanLifecycleHandlerImpl are required.
+    BugsnagPerformanceSpanEndCallback sessionSnapshotCallback = ^BOOL(BugsnagPerformanceSpan *span) {
+        if ([span hasAttribute:@"bugsnag.span.category" withValue:BSGSpanCategoryAppSession]) {
+            std::lock_guard<std::mutex> guard(this->sessionAccumulatorsMutex_);
+            auto it = this->sessionAccumulators_.find((__bridge void *)span);
+            if (it != this->sessionAccumulators_.end()) {
+                // Move snapshot: active → finished so the sampler thread stops feeding it.
+                BSGLogDebug(@"[BugsnagSession] span-end callback: moving accumulator to finished map for span=%@ ptr=%p cpu.count=%llu mem.count=%llu",
+                      span.name, (__bridge void *)span,
+                      it->second.accumulator.processCPU.count,
+                      it->second.accumulator.memory.count);
+                this->finishedSessionAccumulators_[(__bridge void *)span] = it->second;
+                this->sessionAccumulators_.erase(it);
+            } else {
+                BSGLogDebug(@"[BugsnagSession] span-end callback: span=%@ is app_session but NOT found in sessionAccumulators_ (ptr=%p, map size=%zu)",
+                      span.name, (__bridge void *)span, this->sessionAccumulators_.size());
+            }
+        }
+        return YES; // Our internal callback never discards a span.
+    };
+    [spanEndCallbacks_ addObject:sessionSnapshotCallback priority:BugsnagPerformancePriorityMax];
+
     [worker_ start];
     [frameMetricsCollector_ start];
 
@@ -319,6 +384,14 @@ BugsnagPerformanceImpl::sendableSpans(NSMutableArray<BugsnagPerformanceSpan *> *
     for (BugsnagPerformanceSpan *span in spans) {
         if (span.state != SpanStateAborted && sampler_->sampled(span)) {
             [sendableSpans addObject:span];
+        } else {
+            // Span dropped (aborted or unsampled) — clean up its accumulator from
+            // both maps so memory does not grow unboundedly.
+            if ([span hasAttribute:@"bugsnag.span.category" withValue:BSGSpanCategoryAppSession]) {
+                std::lock_guard<std::mutex> guard(sessionAccumulatorsMutex_);
+                sessionAccumulators_.erase((__bridge void *)span);
+                finishedSessionAccumulators_.erase((__bridge void *)span);
+            }
         }
     }
     return sendableSpans;
@@ -337,6 +410,117 @@ bool BugsnagPerformanceImpl::shouldSampleMemory(BugsnagPerformanceSpan *span) no
     }
     return span.metricsOptions.memory == BSGTriStateYes;
 }
+
+// ---------------------------------------------------------------------------
+// Sample-attribute helpers — keep session and non-session paths clearly separated
+// ---------------------------------------------------------------------------
+
+// Existing sampler-history path — unchanged behavior for all non-session spans.
+void BugsnagPerformanceImpl::applySampleAttributesFromHistory(BugsnagPerformanceSpan *span,
+                                                              bool isSessionSpan __unused) noexcept {
+    auto samples = systemInfoSampler_.samplesAroundTimePeriod(span.actuallyStartedAt, span.actuallyEndedAt);
+    BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): System info sample size = %zu", samples.size());
+    if (samples.size() >= 2) {
+        if (shouldSampleCPU(span)) {
+            BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): Getting CPU sample attributes for span %@", span.name);
+            [span forceMutate:^() {
+                [span internalSetMultipleAttributes:spanAttributesProvider_->cpuSampleAttributes(samples)];
+            }];
+        }
+        if (shouldSampleMemory(span)) {
+            BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): Getting memory sample attributes for span %@", span.name);
+            [span forceMutate:^() {
+                [span internalSetMultipleAttributes:spanAttributesProvider_->memorySampleAttributes(samples)];
+            }];
+        }
+    }
+}
+
+// Session-span path — reads from finishedSessionAccumulators_, which contains the
+// stable snapshot taken exactly when the span ended (sampler cannot add to it after that).
+// If the accumulator has data, use it for exact long-session stats.
+// If the accumulator is empty or missing, fall back to the session-specific samples-based
+// overloads so that the same attribute keys (min/max/mean/timestamps) are always present —
+// matching the behavior that existed before this feature was added.
+void BugsnagPerformanceImpl::applySessionSpanSampleAttributes(BugsnagPerformanceSpan *span) noexcept {
+    SessionMetricsAccumulator acc;
+    bool hasAcc = false;
+    {
+        std::lock_guard<std::mutex> guard(sessionAccumulatorsMutex_);
+        auto it = finishedSessionAccumulators_.find((__bridge void *)span);
+        if (it != finishedSessionAccumulators_.end()) {
+            acc = it->second.accumulator;
+            finishedSessionAccumulators_.erase(it);
+            hasAcc = true;
+        }
+    }
+
+    BSGLogDebug(@"[BugsnagSession] applySessionSpanSampleAttributes: span=%@, hasAcc=%d, hasCPU=%d, hasMem=%d, shouldCPU=%d, shouldMem=%d",
+          span.name, hasAcc,
+          hasAcc ? (int)acc.hasCPUData() : -1,
+          hasAcc ? (int)acc.hasMemoryData() : -1,
+          (int)shouldSampleCPU(span),
+          (int)shouldSampleMemory(span));
+
+    // Only use the accumulator path when it actually collected samples.
+    // If hasAcc is true but both hasCPUData and hasMemoryData are false (e.g. simulator
+    // with no valid CPU readings), fall through to the samples-based fallback below so the
+    // span still receives attributes from the sampler history ring-buffer.
+    if (hasAcc && (acc.hasCPUData() || acc.hasMemoryData())) {
+        if (shouldSampleCPU(span) && acc.hasCPUData()) {
+            BSGLogDebug(@"[BugsnagSession] Using accumulator CPU: processCPU.count=%llu", acc.processCPU.count);
+            [span forceMutate:^() {
+                NSDictionary *attributes = spanAttributesProvider_->sessionCPUSampleAttributes(acc, span.endAbsTime);
+                BSGLogDebug(@"[BugsnagSession] CPU accumulator attributes count=%lu keys=%@", (unsigned long)attributes.count, attributes.allKeys);
+                [span internalSetMultipleAttributes:attributes];
+            }];
+        }
+        if (shouldSampleMemory(span) && acc.hasMemoryData()) {
+            BSGLogDebug(@"[BugsnagSession] Using accumulator Memory: memory.count=%llu", acc.memory.count);
+            [span forceMutate:^() {
+                NSDictionary *attributes = spanAttributesProvider_->sessionMemorySampleAttributes(acc, span.endAbsTime);
+                BSGLogDebug(@"[BugsnagSession] Memory accumulator attributes count=%lu keys=%@", (unsigned long)attributes.count, attributes.allKeys);
+                [span internalSetMultipleAttributes:attributes];
+            }];
+        }
+        return;
+    }
+
+    // Fallback: accumulator not found, or has no data.
+    // Use the session-specific samples-based overloads — these produce the same rich
+    // attribute set (min/max/mean/timestamps) as the accumulator path, sourced from
+    // the sampler history window. This exactly matches the attribute payload that was
+    // produced before the accumulator feature was introduced, so no attributes are lost.
+    auto samples = systemInfoSampler_.samplesAroundTimePeriod(span.actuallyStartedAt, span.actuallyEndedAt);
+    BSGLogDebug(@"[BugsnagSession] Fallback to history: sampleCount=%zu, startedAt=%f, endedAt=%f",
+          samples.size(), (double)span.actuallyStartedAt, (double)span.actuallyEndedAt);
+    if (samples.empty()) {
+        BSGLogDebug(@"[BugsnagSession] WARNING: No samples found in history — no metrics will be attached to session span");
+        return;
+    }
+    if (shouldSampleCPU(span)) {
+        [span forceMutate:^() {
+            NSDictionary *attributes = spanAttributesProvider_->sessionCPUSampleAttributes(samples, span.endAbsTime);
+            BSGLogDebug(@"[BugsnagSession] CPU history attributes count=%lu keys=%@", (unsigned long)attributes.count, attributes.allKeys);
+            [span internalSetMultipleAttributes:attributes];
+        }];
+    }
+    if (shouldSampleMemory(span)) {
+        [span forceMutate:^() {
+            NSDictionary *attributes = spanAttributesProvider_->sessionMemorySampleAttributes(samples, span.endAbsTime);
+            BSGLogDebug(@"[BugsnagSession] Memory history attributes count=%lu keys=%@", (unsigned long)attributes.count, attributes.allKeys);
+            [span internalSetMultipleAttributes:attributes];
+        }];
+    }
+    BSGLogDebug(@"[BugsnagSession] Final span attributes after applying session metrics: %@", span.attributes);
+}
+
+// Non-session spans — delegates to the unchanged history path.
+void BugsnagPerformanceImpl::applyNonSessionSpanSampleAttributes(BugsnagPerformanceSpan *span) noexcept {
+    applySampleAttributesFromHistory(span, false);
+}
+
+// ---------------------------------------------------------------------------
 
 bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
     BSGLogDebug(@"BugsnagPerformanceImpl::sendCurrentBatchTask()");
@@ -359,22 +543,13 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((SAMPLER_INTERVAL_SECONDS + 0.5) * NSEC_PER_SEC)),
                    dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0), ^{
         BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): Delayed %f seconds, now getting system info", SAMPLER_INTERVAL_SECONDS + 0.5);
-        for(BugsnagPerformanceSpan *span: spans) {
-            auto samples = systemInfoSampler_.samplesAroundTimePeriod(span.actuallyStartedAt, span.actuallyEndedAt);
-            BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): System info sample size = %zu", samples.size());
-            if (samples.size() >= 2) {
-                if (shouldSampleCPU(span)) {
-                    BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): Getting CPU sample attributes for span %@", span.name);
-                    [span forceMutate:^() {
-                        [span internalSetMultipleAttributes:spanAttributesProvider_->cpuSampleAttributes(samples)];
-                    }];
-                }
-                if (shouldSampleMemory(span)) {
-                    BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): Getting memory sample attributes for span %@", span.name);
-                    [span forceMutate:^() {
-                        [span internalSetMultipleAttributes:spanAttributesProvider_->memorySampleAttributes(samples)];
-                    }];
-                }
+        for (BugsnagPerformanceSpan *span: spans) {
+            // Session spans get their metrics from the running accumulator (exact, no ring-buffer limit).
+            // All other span types keep the original sampler-history-based behavior unchanged.
+            if ([span hasAttribute:@"bugsnag.span.category" withValue:BSGSpanCategoryAppSession]) {
+                applySessionSpanSampleAttributes(span);
+            } else {
+                applyNonSessionSpanSampleAttributes(span);
             }
         }
 
@@ -564,6 +739,29 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startCustomSpan(NSString *name, 
     auto options = SpanOptions(optionsIn);
     auto span = tracer_->startCustomSpan(name, options);
     [span internalSetMultipleAttributes:spanAttributesProvider_->customSpanAttributes()];
+    return span;
+}
+
+BugsnagPerformanceSpan *BugsnagPerformanceImpl::startAppSessionSpan(NSString *sessionType) noexcept {
+    NSString *safeType = sessionType ?: @"";
+    NSString *name = [NSString stringWithFormat:@"[AppSession/%@]", sanitizeSessionTypeIdentifier(safeType)];
+
+    BugsnagPerformanceSpanOptions *optionsIn = [BugsnagPerformanceSpanOptions new];
+    [[optionsIn setMakeCurrentContext:NO] setFirstClass:BSGTriStateYes];
+    [optionsIn setParentContext:nil];
+
+    auto span = tracer_->startCustomSpan(name, SpanOptions(optionsIn));
+    [span internalSetMultipleAttributes:spanAttributesProvider_->sessionSpanAttributes(safeType)];
+
+    // Create one running accumulator that will collect every per-second sample
+    // for the entire session lifetime — fully isolated inside BugsnagPerformanceImpl,
+    // no changes required in the span lifecycle layer.
+    {
+        std::lock_guard<std::mutex> guard(sessionAccumulatorsMutex_);
+        SessionAccumulatorState state;
+        state.accumulator = SessionMetricsAccumulator(span.actuallyStartedAt);
+        sessionAccumulators_[(__bridge void *)span] = state;
+    }
     return span;
 }
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceSpan+Private.h
@@ -108,6 +108,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)forceMutate:(void (^)())block;
 
+- (instancetype)clone;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/BugsnagPerformance/Private/SessionMetricsAccumulator.h
+++ b/Sources/BugsnagPerformance/Private/SessionMetricsAccumulator.h
@@ -1,0 +1,139 @@
+//
+//  SessionMetricsAccumulator.h
+//  BugsnagPerformance
+//
+//  Created by Meiyalagan Ramadurai on 05/06/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+//
+//  Created to fix data loss for long sessions (> ring buffer history).
+//  Instead of relying on the ring buffer which only retains ~20 minutes of raw samples,
+//  this accumulator maintains running min/max/sum/count in O(1) memory.
+//  Every new sample from SystemInfoSampler is streamed here immediately.
+//
+//  For a 30-minute or 3-hour session the result is EXACT — no data loss, no chunking needed.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <stdint.h>
+#import <algorithm>
+#import "SystemInfoSampler.h"
+
+namespace bugsnag {
+
+// ---------------------------------------------------------------------------
+// Running stats for a single double metric (CPU percentages)
+// ---------------------------------------------------------------------------
+struct RunningDoubleStats {
+    uint64_t count{0};
+    double   sum{0.0};
+    double   min{0.0};
+    double   max{0.0};
+
+    void addSample(double value) noexcept {
+        if (count == 0) {
+            min = value;
+            max = value;
+        } else {
+            if (value < min) min = value;
+            if (value > max) max = value;
+        }
+        sum += value;
+        count++;
+    }
+
+    double mean() const noexcept {
+        return count > 0 ? sum / (double)count : 0.0;
+    }
+
+    bool hasData() const noexcept { return count > 0; }
+};
+
+// ---------------------------------------------------------------------------
+// Running stats for a single uint64_t metric (memory bytes)
+// ---------------------------------------------------------------------------
+struct RunningUInt64Stats {
+    uint64_t count{0};
+    uint64_t sum{0};
+    uint64_t min{0};
+    uint64_t max{0};
+    uint64_t lastTotalSize{0}; // device total physical memory (for reporting)
+
+    void addSample(uint64_t inUse, uint64_t totalSize) noexcept {
+        if (count == 0) {
+            min = inUse;
+            max = inUse;
+        } else {
+            if (inUse < min) min = inUse;
+            if (inUse > max) max = inUse;
+        }
+        sum += inUse;
+        count++;
+        lastTotalSize = totalSize;
+    }
+
+    uint64_t mean() const noexcept {
+        return count > 0 ? sum / count : 0ULL;
+    }
+
+    bool hasData() const noexcept { return count > 0; }
+};
+
+// ---------------------------------------------------------------------------
+// Accumulates CPU + memory running stats for one session span lifetime.
+// Call addSample() for every new SystemInfoSampleData from the sampler.
+// Call reset() when the session span ends and you've consumed the stats.
+// ---------------------------------------------------------------------------
+class SessionMetricsAccumulator {
+public:
+    // CPU stats
+    RunningDoubleStats processCPU;
+    RunningDoubleStats mainThreadCPU;
+    RunningDoubleStats monitorThreadCPU;
+
+    // Memory stats
+    RunningUInt64Stats memory;
+
+    // Session span start timestamp — only samples at or after this time are accepted.
+    CFAbsoluteTime sessionStartTime{0};
+
+    explicit SessionMetricsAccumulator(CFAbsoluteTime startTime = 0) noexcept
+        : sessionStartTime(startTime)
+    {}
+
+    /// Feed one raw sample into the running stats.
+    /// Samples before sessionStartTime are ignored.
+    void addSample(const SystemInfoSampleData &sample) noexcept {
+        if (!sample.isSampledAtValid()) { return; }
+        if (sample.sampledAt < sessionStartTime)  { return; }
+
+        if (sample.isProcessCPUPctValid()) {
+            processCPU.addSample(sample.processCPUPct);
+        }
+        if (sample.isMainThreadCPUPctValid()) {
+            mainThreadCPU.addSample(sample.mainThreadCPUPct);
+        }
+        if (sample.isMonitorThreadCPUPctValid()) {
+            monitorThreadCPU.addSample(sample.monitorThreadCPUPct);
+        }
+        if (sample.isPhysicalMemoryInUseValid()) {
+            memory.addSample(sample.physicalMemoryBytesInUse, sample.physicalMemoryBytesTotal);
+        }
+    }
+
+    bool hasCPUData()    const noexcept { return processCPU.hasData() || mainThreadCPU.hasData() || monitorThreadCPU.hasData(); }
+    bool hasMemoryData() const noexcept { return memory.hasData(); }
+
+    void reset() noexcept {
+        processCPU      = {};
+        mainThreadCPU   = {};
+        monitorThreadCPU = {};
+        memory          = {};
+    }
+};
+
+} // namespace bugsnag
+

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 #import "BugsnagPerformanceViewType+Private.h"
 #import "SystemInfoSampler.h"
+#import "SessionMetricsAccumulator.h"
 
 namespace bugsnag {
 class SpanAttributesProvider {
@@ -30,8 +31,19 @@ public:
     NSMutableDictionary *presentingViewLoadSpanAttributes(NSString *className, BugsnagPerformanceViewType viewType) noexcept;
     NSMutableDictionary *viewLoadPhaseSpanAttributes(NSString *className, NSString *phase) noexcept;
     NSMutableDictionary *customSpanAttributes() noexcept;
+    NSMutableDictionary *sessionSpanAttributes(NSString *sessionType) noexcept;
 
     NSMutableDictionary *cpuSampleAttributes(const std::vector<SystemInfoSampleData> &samples) noexcept;
     NSMutableDictionary *memorySampleAttributes(const std::vector<SystemInfoSampleData> &samples) noexcept;
+    NSMutableDictionary *sessionCPUSampleAttributes(const std::vector<SystemInfoSampleData> &samples,
+                                                    CFAbsoluteTime endTime) noexcept;
+    NSMutableDictionary *sessionMemorySampleAttributes(const std::vector<SystemInfoSampleData> &samples,
+                                                       CFAbsoluteTime endTime) noexcept;
+
+    /// Accumulator-based overloads — use these for long sessions (no ring-buffer data loss).
+    NSMutableDictionary *sessionCPUSampleAttributes(const SessionMetricsAccumulator &acc,
+                                                    CFAbsoluteTime endTime) noexcept;
+    NSMutableDictionary *sessionMemorySampleAttributes(const SessionMetricsAccumulator &acc,
+                                                       CFAbsoluteTime endTime) noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -9,6 +9,7 @@
 #import "SpanAttributesProvider.h"
 #import <Foundation/Foundation.h>
 #import "Utils.h"
+#import <algorithm>
 #if TARGET_OS_IOS
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
@@ -20,6 +21,29 @@ static NSDictionary *accessTechnologyMappingDictionary();
 // https://stackoverflow.com/questions/58426438/what-is-key-in-cttelephonynetworkinfo-servicesubscribercellularproviders-and-c
 static NSString * const networkSubtypeKey = @"0000000100000001";
 static NSString * const connectionTypeCell = @"cell";
+static NSString * const BSGSpanCategoryAppSession = @"app_session";
+
+static NSString *sanitizeSessionTypeIdentifier(NSString *sessionType) {
+    NSCharacterSet *separatorCharacterSet = [[NSCharacterSet alphanumericCharacterSet] invertedSet];
+    NSRange sepRange = [sessionType rangeOfCharacterFromSet:separatorCharacterSet];
+    if (sepRange.location == NSNotFound && sessionType.length > 0) {
+        return sessionType;
+    }
+
+    NSMutableString *sanitized = [NSMutableString string];
+    for (NSString *component in [sessionType componentsSeparatedByCharactersInSet:separatorCharacterSet]) {
+        if (component.length == 0) {
+            continue;
+        }
+
+        NSString *lowercasedComponent = component.lowercaseString;
+        NSString *capitalizedComponent = [lowercasedComponent stringByReplacingCharactersInRange:NSMakeRange(0, 1)
+                                                                                       withString:[[lowercasedComponent substringToIndex:1] uppercaseString]];
+        [sanitized appendString:capitalizedComponent];
+    }
+
+    return sanitized.length > 0 ? sanitized : @"Session";
+}
 
 SpanAttributesProvider::SpanAttributesProvider() noexcept {};
 
@@ -238,6 +262,14 @@ SpanAttributesProvider::customSpanAttributes() noexcept {
 }
 
 NSMutableDictionary *
+SpanAttributesProvider::sessionSpanAttributes(NSString *sessionType) noexcept {
+    return @{
+        @"bugsnag.span.category": BSGSpanCategoryAppSession,
+        @"bugsnag.app_session.name": sanitizeSessionTypeIdentifier(sessionType ?: @""),
+    }.mutableCopy;
+}
+
+NSMutableDictionary *
 SpanAttributesProvider::cpuSampleAttributes(const std::vector<SystemInfoSampleData> &samples) noexcept {
     auto process = [[NSMutableArray alloc] initWithCapacity:samples.size()];
     auto mainThread = [[NSMutableArray alloc] initWithCapacity:samples.size()];
@@ -307,6 +339,96 @@ SpanAttributesProvider::cpuSampleAttributes(const std::vector<SystemInfoSampleDa
 }
 
 NSMutableDictionary *
+SpanAttributesProvider::sessionCPUSampleAttributes(const std::vector<SystemInfoSampleData> &samples,
+                                                   CFAbsoluteTime endTime) noexcept {
+    uint64_t processSampleCount = 0;
+    double processTotal = 0;
+    double processMin = 0;
+    double processMax = 0;
+    uint64_t mainThreadSampleCount = 0;
+    double mainThreadTotal = 0;
+    double mainThreadMin = 0;
+    double mainThreadMax = 0;
+    uint64_t monitorThreadSampleCount = 0;
+    double monitorThreadTotal = 0;
+    double monitorThreadMin = 0;
+    double monitorThreadMax = 0;
+
+    for (const auto &sample: samples) {
+        if (!sample.isSampledAtValid()) {
+            continue;
+        }
+
+        if (sample.isProcessCPUPctValid()) {
+            if (processSampleCount == 0) {
+                processMin = sample.processCPUPct;
+                processMax = sample.processCPUPct;
+            } else {
+                processMin = std::min(processMin, sample.processCPUPct);
+                processMax = std::max(processMax, sample.processCPUPct);
+            }
+            processSampleCount++;
+            processTotal += sample.processCPUPct;
+        }
+
+        if (sample.isMainThreadCPUPctValid()) {
+            if (mainThreadSampleCount == 0) {
+                mainThreadMin = sample.mainThreadCPUPct;
+                mainThreadMax = sample.mainThreadCPUPct;
+            } else {
+                mainThreadMin = std::min(mainThreadMin, sample.mainThreadCPUPct);
+                mainThreadMax = std::max(mainThreadMax, sample.mainThreadCPUPct);
+            }
+            mainThreadSampleCount++;
+            mainThreadTotal += sample.mainThreadCPUPct;
+        }
+
+        if (sample.isMonitorThreadCPUPctValid()) {
+            if (monitorThreadSampleCount == 0) {
+                monitorThreadMin = sample.monitorThreadCPUPct;
+                monitorThreadMax = sample.monitorThreadCPUPct;
+            } else {
+                monitorThreadMin = std::min(monitorThreadMin, sample.monitorThreadCPUPct);
+                monitorThreadMax = std::max(monitorThreadMax, sample.monitorThreadCPUPct);
+            }
+            monitorThreadSampleCount++;
+            monitorThreadTotal += sample.monitorThreadCPUPct;
+        }
+    }
+
+    NSMutableDictionary *result = [NSMutableDictionary new];
+    if (processSampleCount == 0) {
+        return result;
+    }
+
+    NSNumber *endTimestamp = @(CFAbsoluteTimeToUTCNanos(endTime));
+    double processMean = processTotal / (double)processSampleCount;
+    result[@"bugsnag.system.cpu_measures_timestamps"] = @[endTimestamp];
+    result[@"bugsnag.system.cpu_measures_total"] = @[@(processMean)];
+    result[@"bugsnag.system.cpu_mean_total"] = @(processMean);
+    result[@"bugsnag.system.cpu_min_total"] = @(processMin);
+    result[@"bugsnag.system.cpu_max_total"] = @(processMax);
+
+    if (mainThreadSampleCount > 0) {
+        double mainThreadMean = mainThreadTotal / (double)mainThreadSampleCount;
+        result[@"bugsnag.system.cpu_measures_main_thread"] = @[@(mainThreadMean)];
+        result[@"bugsnag.system.cpu_mean_main_thread"] = @(mainThreadMean);
+        result[@"bugsnag.system.cpu_min_main_thread"] = @(mainThreadMin);
+        result[@"bugsnag.system.cpu_max_main_thread"] = @(mainThreadMax);
+    }
+
+    if (monitorThreadSampleCount > 0) {
+        double monitorThreadMean = monitorThreadTotal / (double)monitorThreadSampleCount;
+        result[@"bugsnag.system.cpu_measures_overhead"] = @[@(monitorThreadMean)];
+        result[@"bugsnag.system.cpu_mean_overhead"] = @(monitorThreadMean);
+        result[@"bugsnag.system.cpu_min_overhead"] = @(monitorThreadMin);
+        result[@"bugsnag.system.cpu_max_overhead"] = @(monitorThreadMax);
+    }
+
+    return result;
+}
+
+NSMutableDictionary *
 SpanAttributesProvider::memorySampleAttributes(const std::vector<SystemInfoSampleData> &samples) noexcept {
     auto memory = [[NSMutableArray alloc] initWithCapacity:samples.size()];
     auto timestamps = [[NSMutableArray alloc] initWithCapacity:samples.size()];
@@ -341,5 +463,107 @@ SpanAttributesProvider::memorySampleAttributes(const std::vector<SystemInfoSampl
         @"bugsnag.system.memory.spaces.device.size": @(memorySize),
         @"bugsnag.system.memory.spaces.device.used": memory,
         @"bugsnag.system.memory.spaces.device.mean": @(memoryUseTotal / memorySampleCount),
+    }.mutableCopy;
+}
+
+// ---------------------------------------------------------------------------
+// Accumulator-based overloads (no ring-buffer data loss for long sessions)
+// ---------------------------------------------------------------------------
+
+NSMutableDictionary *
+SpanAttributesProvider::sessionCPUSampleAttributes(const SessionMetricsAccumulator &acc,
+                                                   CFAbsoluteTime endTime) noexcept {
+    NSMutableDictionary *result = [NSMutableDictionary new];
+    if (!acc.processCPU.hasData()) {
+        return result;
+    }
+
+    NSNumber *endTimestamp = @(CFAbsoluteTimeToUTCNanos(endTime));
+    const double processMean      = acc.processCPU.mean();
+    result[@"bugsnag.system.cpu_measures_timestamps"] = @[endTimestamp];
+    result[@"bugsnag.system.cpu_measures_total"]      = @[@(processMean)];
+    result[@"bugsnag.system.cpu_mean_total"]          = @(processMean);
+    result[@"bugsnag.system.cpu_min_total"]           = @(acc.processCPU.min);
+    result[@"bugsnag.system.cpu_max_total"]           = @(acc.processCPU.max);
+
+    if (acc.mainThreadCPU.hasData()) {
+        const double mainMean = acc.mainThreadCPU.mean();
+        result[@"bugsnag.system.cpu_measures_main_thread"] = @[@(mainMean)];
+        result[@"bugsnag.system.cpu_mean_main_thread"]     = @(mainMean);
+        result[@"bugsnag.system.cpu_min_main_thread"]      = @(acc.mainThreadCPU.min);
+        result[@"bugsnag.system.cpu_max_main_thread"]      = @(acc.mainThreadCPU.max);
+    }
+
+    if (acc.monitorThreadCPU.hasData()) {
+        const double monitorMean = acc.monitorThreadCPU.mean();
+        result[@"bugsnag.system.cpu_measures_overhead"] = @[@(monitorMean)];
+        result[@"bugsnag.system.cpu_mean_overhead"]     = @(monitorMean);
+        result[@"bugsnag.system.cpu_min_overhead"]      = @(acc.monitorThreadCPU.min);
+        result[@"bugsnag.system.cpu_max_overhead"]      = @(acc.monitorThreadCPU.max);
+    }
+
+    return result;
+}
+
+NSMutableDictionary *
+SpanAttributesProvider::sessionMemorySampleAttributes(const SessionMetricsAccumulator &acc,
+                                                      CFAbsoluteTime endTime) noexcept {
+    if (!acc.memory.hasData()) {
+        return [NSMutableDictionary new];
+    }
+
+    NSNumber *endTimestamp = @(CFAbsoluteTimeToUTCNanos(endTime));
+    return @{
+        @"bugsnag.system.memory.timestamps":              @[endTimestamp],
+        @"bugsnag.system.memory.spaces.device.size":      @(acc.memory.lastTotalSize),
+        @"bugsnag.system.memory.spaces.device.used":      @[@(acc.memory.mean())],
+        @"bugsnag.system.memory.spaces.device.mean":      @(acc.memory.mean()),
+        @"bugsnag.system.memory.spaces.device.min":       @(acc.memory.min),
+        @"bugsnag.system.memory.spaces.device.max":       @(acc.memory.max),
+    }.mutableCopy;
+}
+
+// ---------------------------------------------------------------------------
+
+NSMutableDictionary *
+SpanAttributesProvider::sessionMemorySampleAttributes(const std::vector<SystemInfoSampleData> &samples,
+                                                      CFAbsoluteTime endTime) noexcept {
+    uint64_t memorySampleCount = 0;
+    uint64_t memoryUseTotal = 0;
+    uint64_t memorySize = 0;
+    uint64_t memoryMin = 0;
+    uint64_t memoryMax = 0;
+
+    for (const auto &sample: samples) {
+        if (!sample.isSampledAtValid() || !sample.isPhysicalMemoryInUseValid()) {
+            continue;
+        }
+
+        memorySize = sample.physicalMemoryBytesTotal;
+        if (memorySampleCount == 0) {
+            memoryMin = sample.physicalMemoryBytesInUse;
+            memoryMax = sample.physicalMemoryBytesInUse;
+        } else {
+            memoryMin = std::min(memoryMin, sample.physicalMemoryBytesInUse);
+            memoryMax = std::max(memoryMax, sample.physicalMemoryBytesInUse);
+        }
+
+        memorySampleCount++;
+        memoryUseTotal += sample.physicalMemoryBytesInUse;
+    }
+
+    if (memorySampleCount == 0) {
+        return [NSMutableDictionary new];
+    }
+
+    uint64_t memoryMean = memoryUseTotal / memorySampleCount;
+    NSNumber *endTimestamp = @(CFAbsoluteTimeToUTCNanos(endTime));
+    return @{
+        @"bugsnag.system.memory.timestamps": @[endTimestamp],
+        @"bugsnag.system.memory.spaces.device.size": @(memorySize),
+        @"bugsnag.system.memory.spaces.device.used": @[@(memoryMean)],
+        @"bugsnag.system.memory.spaces.device.mean": @(memoryMean),
+        @"bugsnag.system.memory.spaces.device.min": @(memoryMin),
+        @"bugsnag.system.memory.spaces.device.max": @(memoryMax),
     }.mutableCopy;
 }

--- a/Sources/BugsnagPerformance/Private/SystemInfoSampler.h
+++ b/Sources/BugsnagPerformance/Private/SystemInfoSampler.h
@@ -12,6 +12,7 @@
 #import <CoreFoundation/CoreFoundation.h>
 #import <vector>
 #import <mutex>
+#import <functional>
 #import "BSGPSystemInfo.h"
 #import "FixedLengthDequeue.h"
 #import "PhasedStartup.h"
@@ -86,6 +87,14 @@ public:
      */
     std::vector<SystemInfoSampleData> samplesAroundTimePeriod(CFAbsoluteTime startTime, CFAbsoluteTime endTime);
 
+    void setOnSampleRecorded(std::function<void(const SystemInfoSampleData &)> callback) noexcept {
+        // recordMutex_ is held by the sampler thread whenever recordSample() runs,
+        // so protecting onSampleRecorded_ with the same lock prevents a data race
+        // between this setter (main thread) and the sampler read (sampler thread).
+        std::lock_guard<std::mutex> guard(recordMutex_);
+        onSampleRecorded_ = std::move(callback);
+    }
+
 private:
     CFAbsoluteTime calculateAppStartTime();
     void recordSample();
@@ -113,6 +122,9 @@ private:
     time_value_t lastSampleProcessCPU_{0};
     time_value_t lastSampleMainThreadCPU_{0};
     time_value_t lastSampleMonitorThreadCPU_{0};
+    // Optional callback — invoked (outside samplesMutex_) after each valid sample is stored.
+    // Must be set before the sampler thread fires (or protected by recordMutex_ — see setOnSampleRecorded).
+    std::function<void(const SystemInfoSampleData &)> onSampleRecorded_;
 };
 
 }

--- a/Sources/BugsnagPerformance/Private/SystemInfoSampler.mm
+++ b/Sources/BugsnagPerformance/Private/SystemInfoSampler.mm
@@ -139,8 +139,13 @@ void SystemInfoSampler::recordSample() {
     lastSampledAtTime_ = sample.sampledAt;
 
     if (sample.hasValidData()) {
-        std::lock_guard<std::mutex> guard(samplesMutex_);
-        samples_.push_back(sample);
+        {
+            std::lock_guard<std::mutex> guard(samplesMutex_);
+            samples_.push_back(sample);
+        }
+        if (onSampleRecorded_) {
+            onSampleRecorded_(sample);
+        }
     }
 }
 

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformance.mm
@@ -34,6 +34,13 @@ using namespace bugsnag;
     return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startCustomSpan(name, options);
 }
 
+// startAppSessionSpan: is intentionally not declared in the public header.
+// It remains here for future re-exposure: to make it public again, simply add the
+// declaration back to BugsnagPerformance.h.
++ (BugsnagPerformanceSpan *)startAppSessionSpan:(NSString *)sessionType {
+    return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startAppSessionSpan(sessionType);
+}
+
 + (BugsnagPerformanceSpan *)startViewLoadSpanWithName:(NSString *)name viewType:(BugsnagPerformanceViewType)viewType {
     return BugsnagPerformanceLibrary::getBugsnagPerformanceImpl()->startViewLoadSpan(name, viewType);
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpan.mm
@@ -46,6 +46,8 @@ static CFAbsoluteTime currentTimeIfUnset(CFAbsoluteTime time) {
     if ((self = [super initWithTraceId:traceId spanId:spanId])) {
         _actuallyStartedAt = CFAbsoluteTimeGetCurrent();
         _actuallyEndedAt = CFABSOLUTETIME_INVALID;
+        // Ensure endAbsTime is marked invalid until an end time is set.
+        _endAbsTime = CFABSOLUTETIME_INVALID;
         _startClock = currentMonotonicClockNsecIfUnset(startAbsTime);
         _name = name;
         _parentId = parentId;

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -45,7 +45,6 @@ OBJC_EXPORT
  * Starts a manual app session span with an explicit background sampling policy.
  *
  * @param sessionType A user-defined session label.
- * @param startBackground If YES, sampling continues while app is backgrounded for this session.
  */
 + (BugsnagPerformanceSpan *)startAppSessionSpan:(NSString *)sessionType
   NS_SWIFT_NAME(startAppSessionSpan(_:));

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformance.h
@@ -41,6 +41,15 @@ OBJC_EXPORT
 
 + (BugsnagPerformanceSpan *)startSpanWithName:(NSString *)name options:(BugsnagPerformanceSpanOptions *)options NS_SWIFT_NAME(startSpan(name:options:));
 
+/**
+ * Starts a manual app session span with an explicit background sampling policy.
+ *
+ * @param sessionType A user-defined session label.
+ * @param startBackground If YES, sampling continues while app is backgrounded for this session.
+ */
++ (BugsnagPerformanceSpan *)startAppSessionSpan:(NSString *)sessionType
+  NS_SWIFT_NAME(startAppSessionSpan(_:));
+
 + (BugsnagPerformanceSpanContext *)currentContext;
 
 @end

--- a/Tests/BugsnagPerformanceTests/SessionMetricsAccumulatorTests.mm
+++ b/Tests/BugsnagPerformanceTests/SessionMetricsAccumulatorTests.mm
@@ -6,7 +6,7 @@
  //  - SessionMetricsAccumulator (running min/max/sum/count for CPU and memory)
  //  - SpanAttributesProvider accumulator-based overloads
 //
-
+#import <XCTest/XCTest.h>
 #import "TestHelpers.h"
 #import "../../Sources/BugsnagPerformance/Private/AppStateTracker.h"
 #import "../../Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h"
@@ -341,8 +341,8 @@ static SystemInfoSampleData makeSample(CFAbsoluteTime t,
      auto impl = std::make_unique<bugsnag::BugsnagPerformanceImpl>(
          std::make_shared<bugsnag::Reachability>(), [AppStateTracker new]);
  
-     BugsnagPerformanceSpan *s1 = impl->startAppSessionSpan(@"Session1", true);
-     BugsnagPerformanceSpan *s2 = impl->startAppSessionSpan(@"Session2", true);
+     BugsnagPerformanceSpan *s1 = impl->startAppSessionSpan(@"Session1");
+     BugsnagPerformanceSpan *s2 = impl->startAppSessionSpan(@"Session2");
  
      [s1 end];
      [s2 end];

--- a/Tests/BugsnagPerformanceTests/SessionMetricsAccumulatorTests.mm
+++ b/Tests/BugsnagPerformanceTests/SessionMetricsAccumulatorTests.mm
@@ -1,0 +1,403 @@
+//
+//  SessionMetricsAccumulatorTests.mm
+//  BugsnagPerformance-iOSTests
+//
+ //  Tests for:
+ //  - SessionMetricsAccumulator (running min/max/sum/count for CPU and memory)
+ //  - SpanAttributesProvider accumulator-based overloads
+//
+
+#import "TestHelpers.h"
+#import "../../Sources/BugsnagPerformance/Private/AppStateTracker.h"
+#import "../../Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h"
+#import "../../Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h"
+#import "../../Sources/BugsnagPerformance/Private/Reachability.h"
+#import "../../Sources/BugsnagPerformance/Private/SessionMetricsAccumulator.h"
+#import "../../Sources/BugsnagPerformance/Private/SpanAttributesProvider.h"
+#import "../../Sources/BugsnagPerformance/Private/SystemInfoSampler.h"
+
+using namespace bugsnag;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static SystemInfoSampleData makeSample(CFAbsoluteTime t,
+                                       double processCPU,
+                                       double mainThread,
+                                       double monitorThread,
+                                       uint64_t memInUse,
+                                       uint64_t memTotal) {
+    SystemInfoSampleData s(t);
+    s.processCPUPct        = processCPU;
+    s.mainThreadCPUPct     = mainThread;
+    s.monitorThreadCPUPct  = monitorThread;
+    s.physicalMemoryBytesInUse  = memInUse;
+    s.physicalMemoryBytesTotal  = memTotal;
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+@interface SessionMetricsAccumulatorTests : XCTestCase
+@end
+
+@implementation SessionMetricsAccumulatorTests
+
+// ============================================================
+// MARK: — RunningDoubleStats
+// ============================================================
+
+- (void)testRunningDoubleStats_empty {
+    RunningDoubleStats stats;
+    XCTAssertFalse(stats.hasData());
+    XCTAssertEqual(stats.count, 0ULL);
+    XCTAssertEqual(stats.mean(), 0.0);
+}
+
+- (void)testRunningDoubleStats_singleSample {
+    RunningDoubleStats stats;
+    stats.addSample(42.0);
+    XCTAssertTrue(stats.hasData());
+    XCTAssertEqual(stats.count, 1ULL);
+    XCTAssertEqual(stats.sum,   42.0);
+    XCTAssertEqual(stats.min,   42.0);
+    XCTAssertEqual(stats.max,   42.0);
+    XCTAssertEqual(stats.mean(), 42.0);
+}
+
+- (void)testRunningDoubleStats_multipleSamples_minMaxMean {
+    RunningDoubleStats stats;
+    stats.addSample(10.0);
+    stats.addSample(30.0);
+    stats.addSample(20.0);
+    XCTAssertEqual(stats.count, 3ULL);
+    XCTAssertEqual(stats.min,   10.0);
+    XCTAssertEqual(stats.max,   30.0);
+    XCTAssertEqualWithAccuracy(stats.mean(), 20.0, 0.001);
+}
+
+// ============================================================
+// MARK: — RunningUInt64Stats
+// ============================================================
+
+- (void)testRunningUInt64Stats_empty {
+    RunningUInt64Stats stats;
+    XCTAssertFalse(stats.hasData());
+    XCTAssertEqual(stats.mean(), 0ULL);
+}
+
+- (void)testRunningUInt64Stats_singleSample {
+    RunningUInt64Stats stats;
+    stats.addSample(512, 1024);
+    XCTAssertTrue(stats.hasData());
+    XCTAssertEqual(stats.count,        1ULL);
+    XCTAssertEqual(stats.min,          512ULL);
+    XCTAssertEqual(stats.max,          512ULL);
+    XCTAssertEqual(stats.mean(),       512ULL);
+    XCTAssertEqual(stats.lastTotalSize, 1024ULL);
+}
+
+- (void)testRunningUInt64Stats_minMaxMean {
+    RunningUInt64Stats stats;
+    stats.addSample(100, 1024);
+    stats.addSample(200, 1024);
+    stats.addSample(300, 2048); // total size updated
+    XCTAssertEqual(stats.min,          100ULL);
+    XCTAssertEqual(stats.max,          300ULL);
+    XCTAssertEqual(stats.mean(),       200ULL);  // (100+200+300)/3 = 200
+    XCTAssertEqual(stats.lastTotalSize, 2048ULL);
+}
+
+// ============================================================
+// MARK: — SessionMetricsAccumulator — basic
+// ============================================================
+
+- (void)testAccumulator_freshIsEmpty {
+    SessionMetricsAccumulator acc;
+    XCTAssertFalse(acc.hasCPUData());
+    XCTAssertFalse(acc.hasMemoryData());
+}
+
+- (void)testAccumulator_addValidSample {
+    SessionMetricsAccumulator acc(0);
+    auto s = makeSample(1.0, 20.0, 10.0, 5.0, 500, 1024);
+    acc.addSample(s);
+
+    XCTAssertTrue(acc.hasCPUData());
+    XCTAssertTrue(acc.hasMemoryData());
+    XCTAssertEqual(acc.processCPU.count,    1ULL);
+    XCTAssertEqual(acc.mainThreadCPU.count, 1ULL);
+    XCTAssertEqual(acc.memory.count,        1ULL);
+}
+
+- (void)testAccumulator_minMaxMeanOverMultipleSamples {
+    SessionMetricsAccumulator acc(0);
+    // CPU: 10, 50, 30  → mean=30, min=10, max=50
+    acc.addSample(makeSample(1.0, 10.0, 5.0, 1.0, 100, 1000));
+    acc.addSample(makeSample(2.0, 50.0, 25.0, 2.0, 200, 1000));
+    acc.addSample(makeSample(3.0, 30.0, 15.0, 3.0, 300, 1000));
+
+    XCTAssertEqualWithAccuracy(acc.processCPU.mean(), 30.0, 0.001);
+    XCTAssertEqual(acc.processCPU.min, 10.0);
+    XCTAssertEqual(acc.processCPU.max, 50.0);
+
+    XCTAssertEqualWithAccuracy(acc.mainThreadCPU.mean(), 15.0, 0.001);
+    XCTAssertEqual(acc.mainThreadCPU.min, 5.0);
+    XCTAssertEqual(acc.mainThreadCPU.max, 25.0);
+
+    XCTAssertEqual(acc.memory.mean(), 200ULL);
+    XCTAssertEqual(acc.memory.min, 100ULL);
+    XCTAssertEqual(acc.memory.max, 300ULL);
+}
+
+// ============================================================
+// MARK: — SessionMetricsAccumulator — filtering
+// ============================================================
+
+- (void)testAccumulator_ignoresSamplesBeforeSessionStart {
+    // session started at t=10; samples at t=5 must be rejected
+    SessionMetricsAccumulator acc(10.0);
+
+    auto earlyS = makeSample(5.0, 99.0, 99.0, 99.0, 9999, 9999);
+    acc.addSample(earlyS);
+    XCTAssertFalse(acc.hasCPUData(),    @"Sample before session start must not be counted");
+    XCTAssertFalse(acc.hasMemoryData(), @"Sample before session start must not be counted");
+
+    auto validS = makeSample(10.0, 20.0, 10.0, 5.0, 500, 1024);
+    acc.addSample(validS);
+    XCTAssertTrue(acc.hasCPUData());
+    XCTAssertTrue(acc.hasMemoryData());
+    XCTAssertEqual(acc.processCPU.count, 1ULL);
+}
+
+- (void)testAccumulator_ignoresInvalidSampledAt {
+    SessionMetricsAccumulator acc(0);
+    SystemInfoSampleData invalidSample; // sampledAt == -1 by default
+    acc.addSample(invalidSample);
+    XCTAssertFalse(acc.hasCPUData());
+    XCTAssertFalse(acc.hasMemoryData());
+}
+
+- (void)testAccumulator_partialData_onlyCPUNoMemory {
+    SessionMetricsAccumulator acc(0);
+    SystemInfoSampleData s(1.0);
+    s.processCPUPct = 25.0;
+    // memory fields left at 0 / invalid
+    acc.addSample(s);
+
+    XCTAssertTrue(acc.hasCPUData());
+    XCTAssertFalse(acc.hasMemoryData(), @"Memory inUse==0 is considered invalid");
+}
+
+// ============================================================
+// MARK: — SessionMetricsAccumulator — reset
+// ============================================================
+
+- (void)testAccumulator_resetClearsAllData {
+    SessionMetricsAccumulator acc(0);
+    acc.addSample(makeSample(1.0, 30.0, 15.0, 5.0, 400, 1024));
+    XCTAssertTrue(acc.hasCPUData());
+
+    acc.reset();
+    XCTAssertFalse(acc.hasCPUData());
+    XCTAssertFalse(acc.hasMemoryData());
+    XCTAssertEqual(acc.processCPU.count, 0ULL);
+    XCTAssertEqual(acc.memory.count,     0ULL);
+}
+
+// ============================================================
+// MARK: — SpanAttributesProvider — accumulator overloads
+// ============================================================
+
+- (void)testSessionCPUFromAccumulator_emptyReturnsEmptyDict {
+    SpanAttributesProvider provider;
+    SessionMetricsAccumulator acc;
+    auto attrs = provider.sessionCPUSampleAttributes(acc, 10.0);
+    XCTAssertEqual(attrs.count, 0U);
+}
+
+- (void)testSessionCPUFromAccumulator_singleSample {
+    SpanAttributesProvider provider;
+    SessionMetricsAccumulator acc(0);
+    acc.addSample(makeSample(1.0, 20.0, 10.0, 5.0, 0, 0));
+
+    auto attrs = provider.sessionCPUSampleAttributes(acc, 2.0);
+    XCTAssertNotNil(attrs[@"bugsnag.system.cpu_measures_timestamps"]);
+    XCTAssertEqualObjects(attrs[@"bugsnag.system.cpu_mean_total"], @20.0);
+    XCTAssertEqualObjects(attrs[@"bugsnag.system.cpu_min_total"],  @20.0);
+    XCTAssertEqualObjects(attrs[@"bugsnag.system.cpu_max_total"],  @20.0);
+    // mean == min == max for single sample
+}
+
+- (void)testSessionCPUFromAccumulator_multiSample_matchesVectorOverload {
+    // Build identical data into both vector and accumulator paths and compare output.
+    SpanAttributesProvider provider;
+
+    std::vector<SystemInfoSampleData> samples;
+    SessionMetricsAccumulator acc(0);
+    for (int i = 1; i <= 4; i++) {
+        auto s = makeSample((CFAbsoluteTime)i, 10.0 * i, 5.0 * i, 2.0 * i, (uint64_t)(100 * i), 1000);
+        samples.push_back(s);
+        acc.addSample(s);
+    }
+    // samples: CPU 10,20,30,40  → mean=25, min=10, max=40
+
+    auto vecAttrs = provider.sessionCPUSampleAttributes(samples, 5.0);
+    auto accAttrs = provider.sessionCPUSampleAttributes(acc,     5.0);
+
+    XCTAssertEqualObjects(vecAttrs[@"bugsnag.system.cpu_mean_total"], accAttrs[@"bugsnag.system.cpu_mean_total"]);
+    XCTAssertEqualObjects(vecAttrs[@"bugsnag.system.cpu_min_total"],  accAttrs[@"bugsnag.system.cpu_min_total"]);
+    XCTAssertEqualObjects(vecAttrs[@"bugsnag.system.cpu_max_total"],  accAttrs[@"bugsnag.system.cpu_max_total"]);
+
+    XCTAssertEqualObjects(vecAttrs[@"bugsnag.system.cpu_mean_main_thread"], accAttrs[@"bugsnag.system.cpu_mean_main_thread"]);
+    XCTAssertEqualObjects(vecAttrs[@"bugsnag.system.cpu_min_main_thread"],  accAttrs[@"bugsnag.system.cpu_min_main_thread"]);
+    XCTAssertEqualObjects(vecAttrs[@"bugsnag.system.cpu_max_main_thread"],  accAttrs[@"bugsnag.system.cpu_max_main_thread"]);
+}
+
+- (void)testSessionMemoryFromAccumulator_emptyReturnsEmptyDict {
+    SpanAttributesProvider provider;
+    SessionMetricsAccumulator acc;
+    auto attrs = provider.sessionMemorySampleAttributes(acc, 10.0);
+    XCTAssertEqual(attrs.count, 0U);
+}
+
+- (void)testSessionMemoryFromAccumulator_singleSample {
+    SpanAttributesProvider provider;
+    SessionMetricsAccumulator acc(0);
+    acc.addSample(makeSample(1.0, 0, 0, 0, 500, 1024));
+
+    auto attrs = provider.sessionMemorySampleAttributes(acc, 2.0);
+    XCTAssertEqual(attrs.count, 6U);
+    XCTAssertEqualObjects(attrs[@"bugsnag.system.memory.spaces.device.size"], @1024ULL);
+    XCTAssertEqualObjects(attrs[@"bugsnag.system.memory.spaces.device.mean"], @500ULL);
+    XCTAssertEqualObjects(attrs[@"bugsnag.system.memory.spaces.device.min"],  @500ULL);
+    XCTAssertEqualObjects(attrs[@"bugsnag.system.memory.spaces.device.max"],  @500ULL);
+}
+
+- (void)testSessionMemoryFromAccumulator_multiSample_matchesVectorOverload {
+    SpanAttributesProvider provider;
+
+    std::vector<SystemInfoSampleData> samples;
+    SessionMetricsAccumulator acc(0);
+    for (int i = 1; i <= 4; i++) {
+        auto s = makeSample((CFAbsoluteTime)i, 0, 0, 0, (uint64_t)(100 * i), 1000);
+        samples.push_back(s);
+        acc.addSample(s);
+    }
+    // memory: 100,200,300,400  → mean=250, min=100, max=400
+
+    auto vecAttrs = provider.sessionMemorySampleAttributes(samples, 5.0);
+    auto accAttrs = provider.sessionMemorySampleAttributes(acc,     5.0);
+
+    XCTAssertEqualObjects(vecAttrs[@"bugsnag.system.memory.spaces.device.mean"], accAttrs[@"bugsnag.system.memory.spaces.device.mean"]);
+    XCTAssertEqualObjects(vecAttrs[@"bugsnag.system.memory.spaces.device.min"],  accAttrs[@"bugsnag.system.memory.spaces.device.min"]);
+    XCTAssertEqualObjects(vecAttrs[@"bugsnag.system.memory.spaces.device.max"],  accAttrs[@"bugsnag.system.memory.spaces.device.max"]);
+}
+
+- (void)testSessionMemoryFromAccumulator_hasAllExpectedKeys {
+    SpanAttributesProvider provider;
+    SessionMetricsAccumulator acc(0);
+    acc.addSample(makeSample(1.0, 0, 0, 0, 400, 1000));
+    acc.addSample(makeSample(2.0, 0, 0, 0, 600, 1000));
+
+    auto attrs = provider.sessionMemorySampleAttributes(acc, 3.0);
+    XCTAssertNotNil(attrs[@"bugsnag.system.memory.timestamps"]);
+    XCTAssertNotNil(attrs[@"bugsnag.system.memory.spaces.device.size"]);
+    XCTAssertNotNil(attrs[@"bugsnag.system.memory.spaces.device.used"]);
+    XCTAssertNotNil(attrs[@"bugsnag.system.memory.spaces.device.mean"]);
+    XCTAssertNotNil(attrs[@"bugsnag.system.memory.spaces.device.min"]);
+    XCTAssertNotNil(attrs[@"bugsnag.system.memory.spaces.device.max"]);
+    XCTAssertEqualObjects(attrs[@"bugsnag.system.memory.spaces.device.min"],  @400ULL);
+     XCTAssertEqualObjects(attrs[@"bugsnag.system.memory.spaces.device.max"],  @600ULL);
+     XCTAssertEqualObjects(attrs[@"bugsnag.system.memory.spaces.device.mean"], @500ULL);
+ }
+ 
+ // ============================================================
+ // MARK: — Session span — accumulator created on start
+ // ============================================================
+ 
+ - (void)testSessionSpanStart_createsAccumulator {
+     // Verify startAppSessionSpan creates a span correctly and does not crash
+     // (the accumulator is internal; we verify indirectly by checking span state)
+     auto impl = std::make_unique<bugsnag::BugsnagPerformanceImpl>(
+         std::make_shared<bugsnag::Reachability>(), [AppStateTracker new]);
+
+     BugsnagPerformanceSpan *sessionSpan = impl->startAppSessionSpan(@"TestSession");
+
+    XCTAssertNotNil(sessionSpan);
+    XCTAssertTrue([sessionSpan.name hasPrefix:@"[AppSession/TestSession]"]);
+    XCTAssertEqualObjects(sessionSpan.attributes[@"bugsnag.span.category"], @"app_session");
+    XCTAssertEqual(sessionSpan.state, SpanStateOpen);
+
+    [sessionSpan end];
+    XCTAssertEqual(sessionSpan.state, SpanStateEnded);
+}
+
+ - (void)testSessionSpanEnd_doesNotCrash {
+     // Verify ending a session span (which triggers accumulator move) does not crash
+     auto impl = std::make_unique<bugsnag::BugsnagPerformanceImpl>(
+         std::make_shared<bugsnag::Reachability>(), [AppStateTracker new]);
+ 
+     BugsnagPerformanceSpan *s1 = impl->startAppSessionSpan(@"Session1", true);
+     BugsnagPerformanceSpan *s2 = impl->startAppSessionSpan(@"Session2", true);
+ 
+     [s1 end];
+     [s2 end];
+ 
+     XCTAssertEqual(s1.state, SpanStateEnded);
+     XCTAssertEqual(s2.state, SpanStateEnded);
+ }
+
+ - (void)testSessionSpanEnd_abortedSpanHandledGracefully {
+     // Verify that aborting a session span (sampling could drop it)
+     // does not crash and does not leave orphaned accumulator entries
+     auto impl = std::make_unique<bugsnag::BugsnagPerformanceImpl>(
+         std::make_shared<bugsnag::Reachability>(), [AppStateTracker new]);
+
+     BugsnagPerformanceSpan *span = impl->startAppSessionSpan(@"AbortedSession");
+     [span abortIfOpen];
+     XCTAssertEqual(span.state, SpanStateAborted);
+     // If this reaches here without crash/leak, the cleanup path is safe
+ }
+
+- (void)testSessionSpanStart_withStartBackgroundParameter {
+    auto impl = std::make_unique<bugsnag::BugsnagPerformanceImpl>(
+        std::make_shared<bugsnag::Reachability>(), [AppStateTracker new]);
+
+    BugsnagPerformanceSpan *sessionSpan = impl->startAppSessionSpan(@"BackgroundMusic");
+
+    XCTAssertNotNil(sessionSpan);
+    XCTAssertTrue([sessionSpan.name hasPrefix:@"[AppSession/BackgroundMusic]"]);
+    XCTAssertEqualObjects(sessionSpan.attributes[@"bugsnag.span.category"], @"app_session");
+
+    [sessionSpan end];
+}
+
+// ============================================================
+// MARK: — Long session accuracy: same result as iterating vector
+// ============================================================
+
+- (void)testAccumulator_1000Samples_matchesBruteForce {
+    const int N = 1000;
+    SessionMetricsAccumulator acc(0);
+    double bruteSum = 0, bruteMin = DBL_MAX, bruteMax = -DBL_MAX;
+
+    for (int i = 0; i < N; i++) {
+        double v = (double)(i % 100 + 1); // cycles 1..100
+        acc.addSample(makeSample((CFAbsoluteTime)(i + 1), v, 0, 0, 0, 0));
+        bruteSum += v;
+        bruteMin = MIN(bruteMin, v);
+        bruteMax = MAX(bruteMax, v);
+    }
+
+    XCTAssertEqual(acc.processCPU.count, (uint64_t)N);
+    XCTAssertEqualWithAccuracy(acc.processCPU.sum,  bruteSum, 0.001);
+    XCTAssertEqualWithAccuracy(acc.processCPU.min,  bruteMin, 0.001);
+    XCTAssertEqualWithAccuracy(acc.processCPU.max,  bruteMax, 0.001);
+    XCTAssertEqualWithAccuracy(acc.processCPU.mean(), bruteSum / N, 0.001);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -7,6 +7,9 @@
 //
 
 #import "TestHelpers.h"
+#import "../../Sources/BugsnagPerformance/Private/AppStateTracker.h"
+#import "../../Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h"
+#import "../../Sources/BugsnagPerformance/Private/Reachability.h"
 #import "../../Sources/BugsnagPerformance/Private/SpanAttributesProvider.h"
 
 using namespace bugsnag;
@@ -172,6 +175,29 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"custom");
 }
 
+- (void)testSessionSpanAttributes {
+    SpanAttributesProvider provider;
+
+    auto attributes = provider.sessionSpanAttributes(@"Playback");
+    XCTAssertEqual(2U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"app_session");
+    XCTAssertEqualObjects(attributes[@"bugsnag.app_session.name"], @"Playback");
+}
+
+- (void)testSessionSpanAttributesAreSanitized {
+    SpanAttributesProvider provider;
+
+    auto attributes = provider.sessionSpanAttributes(@"Active Usage");
+    XCTAssertEqualObjects(attributes[@"bugsnag.app_session.name"], @"ActiveUsage");
+}
+
+- (void)testSessionSpanAttributesFallbackForEmptyInput {
+    SpanAttributesProvider provider;
+
+    auto attributes = provider.sessionSpanAttributes(@"");
+    XCTAssertEqualObjects(attributes[@"bugsnag.app_session.name"], @"Session");
+}
+
 - (void)testCPUSampleAttributesInsufficient {
     SpanAttributesProvider provider;
 
@@ -282,6 +308,56 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_timestamps"], expectedTimestamps);
     XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_total"], expectedProcess);
     XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_total"], @25.0);
+}
+
+- (void)testSessionCPUSampleAttributes {
+    SpanAttributesProvider provider;
+    std::vector<SystemInfoSampleData> samples = {
+        SystemInfoSampleData(1),
+        SystemInfoSampleData(2),
+    };
+
+    samples[0].processCPUPct = 10;
+    samples[0].mainThreadCPUPct = 20;
+    samples[0].monitorThreadCPUPct = 30;
+
+    samples[1].processCPUPct = 40;
+    samples[1].mainThreadCPUPct = 50;
+    samples[1].monitorThreadCPUPct = 60;
+
+    auto attributes = provider.sessionCPUSampleAttributes(samples, 12);
+    XCTAssertEqual(13U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_timestamps"], (@[@978307212000000000]));
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_total"], (@[@25.0]));
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_total"], @25.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_min_total"], @10.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_max_total"], @40.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_main_thread"], (@[@35.0]));
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_main_thread"], @35.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_min_main_thread"], @20.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_max_main_thread"], @50.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_overhead"], (@[@45.0]));
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_overhead"], @45.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_min_overhead"], @30.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_max_overhead"], @60.0);
+}
+
+- (void)testSessionCPUSampleAttributesWithSingleSample {
+    SpanAttributesProvider provider;
+    std::vector<SystemInfoSampleData> samples = {
+        SystemInfoSampleData(1),
+    };
+
+    samples[0].processCPUPct = 10;
+    samples[0].mainThreadCPUPct = 20;
+    samples[0].monitorThreadCPUPct = 30;
+
+    auto attributes = provider.sessionCPUSampleAttributes(samples, 11);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_timestamps"], (@[@978307211000000000]));
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_measures_total"], (@[@10.0]));
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_mean_total"], @10.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_min_total"], @10.0);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.cpu_max_total"], @10.0);
 }
 
 - (void)testCPUSampleAttributesMainThreadOnly {
@@ -437,6 +513,48 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"bugsnag.system.memory.spaces.device.size"], @100);
     XCTAssertEqualObjects(attributes[@"bugsnag.system.memory.spaces.device.used"], expectedMemory);
     XCTAssertEqualObjects(attributes[@"bugsnag.system.memory.spaces.device.mean"], @65.0);
+}
+
+- (void)testSessionMemorySampleAttributes {
+    SpanAttributesProvider provider;
+    std::vector<SystemInfoSampleData> samples = {
+        SystemInfoSampleData(11),
+        SystemInfoSampleData(12),
+    };
+
+    samples[0].physicalMemoryBytesTotal = 100;
+    samples[0].physicalMemoryBytesInUse = 80;
+    samples[1].physicalMemoryBytesTotal = 100;
+    samples[1].physicalMemoryBytesInUse = 50;
+
+    auto attributes = provider.sessionMemorySampleAttributes(samples, 13);
+    XCTAssertEqual(6U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.memory.timestamps"], (@[@978307213000000000]));
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.memory.spaces.device.size"], @100);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.memory.spaces.device.used"], (@[@65]));
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.memory.spaces.device.mean"], @65);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.memory.spaces.device.min"], @50);
+    XCTAssertEqualObjects(attributes[@"bugsnag.system.memory.spaces.device.max"], @80);
+}
+
+- (void)testStartSessionSpanDoesNotBecomeCurrentContext {
+    auto impl = std::make_unique<bugsnag::BugsnagPerformanceImpl>(std::make_shared<bugsnag::Reachability>(), [AppStateTracker new]);
+
+    BugsnagPerformanceSpan *sessionSpan = impl->startAppSessionSpan(@"Active Usage");
+    XCTAssertEqualObjects(sessionSpan.name, @"[AppSession/ActiveUsage]");
+    XCTAssertEqualObjects(sessionSpan.attributes[@"bugsnag.span.category"], @"app_session");
+    XCTAssertEqualObjects(sessionSpan.attributes[@"bugsnag.app_session.name"], @"ActiveUsage");
+    XCTAssertEqual(sessionSpan.firstClass, BSGTriStateYes);
+    XCTAssertEqual(sessionSpan.parentId, (SpanId)0);
+    XCTAssertNil(impl->currentContext());
+
+    BugsnagPerformanceSpan *customSpan = impl->startCustomSpan(@"child");
+    XCTAssertEqual(customSpan.parentId, (SpanId)0);
+    XCTAssertEqual(customSpan.spanId, impl->currentContext().spanId);
+
+    [customSpan end];
+    XCTAssertNil(impl->currentContext());
+    [sessionSpan end];
 }
 
 

--- a/features/default/resource-usage-aggregation.feature
+++ b/features/default/resource-usage-aggregation.feature
@@ -1,0 +1,114 @@
+Feature: Foreground App Session Span - Happy Path
+
+Scenario: App session span sends app-session attributes
+    Given I load scenario "AppSessionResourceUsageScenario"
+    And I configure bugsnag "memoryMetrics" to "true"
+    And I configure bugsnag "cpuMetrics" to "false"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "TestManualSpan"
+
+Scenario: App session span contains memory aggregate attributes
+    Given I load scenario "AppSessionResourceUsageScenario"
+    And I configure bugsnag "memoryMetrics" to "true"
+    And I configure scenario "session_type" to "memory session"
+    And I configure scenario "span_duration" to "2.5"
+    And I configure scenario "variant_name" to "Memory"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[AppSession/MemorySession]"
+    * a span string attribute "bugsnag.span.category" equals "app_session"
+    * a span integer attribute "bugsnag.system.memory.spaces.device.size" is greater than 0
+    * a span integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
+    * a span integer attribute "bugsnag.system.memory.spaces.device.min" is greater than 0
+    * a span integer attribute "bugsnag.system.memory.spaces.device.max" is greater than 0
+
+Scenario: App session span contains CPU aggregate attributes
+    Given I load scenario "AppSessionResourceUsageScenario"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure scenario "session_type" to "cpu session"
+    And I configure scenario "span_duration" to "2.5"
+    And I configure scenario "work_duration" to "2.0"
+    And I configure scenario "work_on_thread" to "main"
+    And I configure scenario "variant_name" to "CPU"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[AppSession/CPUSession]"
+    * a span string attribute "bugsnag.span.category" equals "app_session"
+    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
+    * a span float attribute "bugsnag.system.cpu_min_total" is greater than 0.0
+    * a span float attribute "bugsnag.system.cpu_max_total" is greater than 0.0
+
+Scenario: App session type is sanitized
+    Given I load scenario "AppSessionResourceUsageScenario"
+    And I configure bugsnag "memoryMetrics" to "true"
+    And I configure scenario "session_type" to "user checkout-flow"
+    And I configure scenario "span_duration" to "2.0"
+    And I configure scenario "variant_name" to "Sanitized"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[AppSession/UserCheckoutFlow]"
+    * a span string attribute "bugsnag.span.category" equals "app_session"
+    * a span string attribute "bugsnag.app_session.name" equals "UserCheckoutFlow"
+
+Scenario: App session span does not contain resource usage when metrics are disabled
+    Given I load scenario "AppSessionResourceUsageScenario"
+    And I configure bugsnag "memoryMetrics" to "false"
+    And I configure bugsnag "cpuMetrics" to "false"
+    And I configure scenario "session_type" to "disabled metrics"
+    And I configure scenario "span_duration" to "2.0"
+    And I configure scenario "variant_name" to "MetricsDisabled"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[AppSession/DisabledMetrics]"
+    * a span string attribute "bugsnag.span.category" equals "app_session"
+    * every span attribute "bugsnag.system.memory.spaces.device.mean" does not exist
+    * every span attribute "bugsnag.system.memory.spaces.device.min" does not exist
+    * every span attribute "bugsnag.system.memory.spaces.device.max" does not exist
+    * every span attribute "bugsnag.system.cpu_mean_total" does not exist
+    * every span attribute "bugsnag.system.cpu_min_total" does not exist
+    * every span attribute "bugsnag.system.cpu_max_total" does not exist
+
+Scenario: Normal custom span is not treated as app session span
+    Given I load scenario "MemoryMetricsScenario"
+    And I configure bugsnag "memoryMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "1.5"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "CustomRegression"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "MemoryMetricsScenarioCustomRegression"
+    * every span string attribute "bugsnag.span.category" equals "custom"
+    * every span attribute "bugsnag.app_session.name" does not exist
+    * a span integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
+
+Scenario: Aborted app session span is not sent
+    Given I load scenario "AppSessionResourceUsageScenario"
+    And I configure bugsnag "memoryMetrics" to "true"
+    And I configure scenario "session_type" to "aborted session"
+    And I configure scenario "span_duration" to "1.0"
+    And I configure scenario "abort_span" to "true"
+    And I configure scenario "variant_name" to "Aborted"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 5 seconds
+    
+Scenario: Force-terminated app session span is not sent
+    Given I load scenario "AppSessionResourceUsageScenario"
+    And I configure bugsnag "memoryMetrics" to "true"
+    And I configure scenario "session_type" to "force killed session"
+    And I configure scenario "span_duration" to "30.0"
+    And I configure scenario "variant_name" to "ForceKilled"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 3 seconds
+    And I close the app
+    And I wait for 5 seconds
+    Then I should receive no spans

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		DA95ABF32E3A7E52001E6B0E /* NamedSpansPluginScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA95ABF22E3A7E52001E6B0E /* NamedSpansPluginScenario.swift */; };
 		DAC7DD672E3CBED10091961A /* BugsnagPerformanceNamedSpans in Frameworks */ = {isa = PBXBuildFile; productRef = DAC7DD662E3CBED10091961A /* BugsnagPerformanceNamedSpans */; };
 		DADB14F92DE08A030006F44F /* OnStartCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */; };
+		E1A5A6432FE05B9F00A663EA /* AppSessionResourceUsageScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5A6422FE05B9F00A663EA /* AppSessionResourceUsageScenario.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -260,6 +261,7 @@
 		DA85961D2DF718C800905922 /* PluginScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginScenario.swift; sourceTree = "<group>"; };
 		DA95ABF22E3A7E52001E6B0E /* NamedSpansPluginScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedSpansPluginScenario.swift; sourceTree = "<group>"; };
 		DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnStartCallbackScenario.swift; sourceTree = "<group>"; };
+		E1A5A6422FE05B9F00A663EA /* AppSessionResourceUsageScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionResourceUsageScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -341,6 +343,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				E1A5A6422FE05B9F00A663EA /* AppSessionResourceUsageScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
 				96D090D42EEB3DA700BAA6D4 /* AppStartInterruptedScenario.swift */,
 				96D090DC2EEB89F400BAA6D4 /* AppStartLegacyDelayedStartScenario.swift */,
@@ -618,6 +621,7 @@
 				96F901092EE7B7FF0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift in Sources */,
 				CB572EAD29BB829800FD7A2A /* BackgroundForegroundScenario.swift in Sources */,
 				96EB8B502EB26B4400DDBF86 /* StartupEnabledMetrics.swift in Sources */,
+				E1A5A6432FE05B9F00A663EA /* AppSessionResourceUsageScenario.swift in Sources */,
 				96D090DD2EEB89F500BAA6D4 /* AppStartLegacyDelayedStartScenario.swift in Sources */,
 				966634E02C9DE384004A934D /* FrameMetricsSlowFramesScenario.swift in Sources */,
 				CB2B8A9F2A0E80B80054FBBE /* AutoInstrumentNetworkBadAddressScenario.swift in Sources */,

--- a/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		DAC7DD6C2E3CDA990091961A /* BugsnagPerformanceNamedSpans.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAC7DD6A2E3CDA590091961A /* BugsnagPerformanceNamedSpans.xcframework */; };
 		DAC7DD6D2E3CDA990091961A /* BugsnagPerformanceNamedSpans.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DAC7DD6A2E3CDA590091961A /* BugsnagPerformanceNamedSpans.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DADB14F72DDF852B0006F44F /* OnStartCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */; };
+		E1A5A6412FE052BB00A663EA /* AppSessionResourceUsageScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5A6402FE052BB00A663EA /* AppSessionResourceUsageScenario.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -280,6 +281,7 @@
 		DA95ABF42E3A7FBA001E6B0E /* NamedSpansPluginScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedSpansPluginScenario.swift; sourceTree = "<group>"; };
 		DAC7DD6A2E3CDA590091961A /* BugsnagPerformanceNamedSpans.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BugsnagPerformanceNamedSpans.xcframework; path = ../../../BugsnagPerformanceNamedSpans.xcframework; sourceTree = "<group>"; };
 		DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnStartCallbackScenario.swift; sourceTree = "<group>"; };
+		E1A5A6402FE052BB00A663EA /* AppSessionResourceUsageScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionResourceUsageScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -364,6 +366,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				E1A5A6402FE052BB00A663EA /* AppSessionResourceUsageScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
 				96D090D62EEB3E1D00BAA6D4 /* AppStartInterruptedScenario.swift */,
 				966CF1BD2EEBA46700774E2B /* AppStartLegacyDelayedStartScenario.swift */,
@@ -645,6 +648,7 @@
 				966CF1C12EEBA46700774E2B /* AppStartLegacyDelayedStartScenario.swift in Sources */,
 				966CF1C22EEBA46700774E2B /* AppStartLegacyScenario.swift in Sources */,
 				966CF1C32EEBA46700774E2B /* AppStartLegacyStartAfterAppStartScenario.swift in Sources */,
+				E1A5A6412FE052BB00A663EA /* AppSessionResourceUsageScenario.swift in Sources */,
 				966CF1C42EEBA46700774E2B /* AppStartLegacyInterruptedScenario.swift in Sources */,
 				CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */,
 				091B95722CA179AC007DC8A9 /* AutoInstrumentNetworkPreStartScenario.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/AppSessionResourceUsageScenario.swift
+++ b/features/fixtures/ios/Scenarios/AppSessionResourceUsageScenario.swift
@@ -1,0 +1,95 @@
+//
+//  AppSessionResourceUsageScenario.swift
+//  BugsnagPerformance
+//
+//  Created by Meiyalagan Ramadurai on 15/06/26.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class AppSessionResourceUsageScenario: Scenario {
+    var sessionSpan: BugsnagPerformanceSpan?
+    override func run() {
+        // Read config from scenarioConfig dictionary (NOT instance properties)
+        let sessionType = scenarioConfig["session_type"] ?? "manual session"
+        let duration = toDouble(string: scenarioConfig["span_duration"]) > 0
+            ? toDouble(string: scenarioConfig["span_duration"])
+            : 5.0
+        let shouldAbort = toBool(string: scenarioConfig["abort_span"])
+        let workDur = toDouble(string: scenarioConfig["work_duration"])
+        let workThread = scenarioConfig["work_on_thread"] ?? "main"
+        NSLog("App session_type=\(sessionType), duration=\(duration), abort=\(shouldAbort)")
+        if sessionType == "manual session" {
+            // Scenario 1: simple manual span
+            let opts = BugsnagPerformanceSpanOptions()
+            _ = opts.setFirstClass(.yes)
+            self.sessionSpan = BugsnagPerformance.startSpan(
+                name: "TestManualSpan",
+                options: opts
+            )
+            Thread.sleep(forTimeInterval: 2.0)
+            sessionSpan?.end()
+            waitForBrowserstack()
+        } else {
+            // Scenarios 2-5, 7: app session spans
+            let sessionTypeId = toPascalCase(sessionType)
+            let appSessionSpanName = "[AppSession/\(sessionTypeId)]"
+            NSLog("App Starting session span: \(appSessionSpanName)")
+            let opts = BugsnagPerformanceSpanOptions()
+            _ = opts.setFirstClass(.yes)
+            _ = opts.setMakeCurrentContext(false)
+            self.sessionSpan = BugsnagPerformance.startSpan(
+                name: appSessionSpanName,
+                options: opts
+            )
+            sessionSpan?.setAttribute("bugsnag.span.category", withValue: "app_session")
+            sessionSpan?.setAttribute("bugsnag.app_session.name", withValue: sessionTypeId)
+            // CPU work if configured
+            if workDur > 0 {
+                NSLog("App Doing CPU work for \(workDur)s on \(workThread)")
+                if workThread == "main" {
+                    doBusyWork(forDuration: workDur)
+                } else {
+                    DispatchQueue.global().async {
+                        self.doBusyWork(forDuration: workDur)
+                    }
+                    Thread.sleep(forTimeInterval: workDur)
+                }
+            }
+            Thread.sleep(forTimeInterval: duration)
+            if shouldAbort {
+                NSLog("App Aborting session span")
+                sessionSpan = nil
+            } else {
+                NSLog("App Ending session span")
+                sessionSpan?.end()
+            }
+            sessionSpan = nil
+            waitForBrowserstack()
+        }
+    }
+    func toPascalCase(_ input: String) -> String {
+        let acronyms: Set<String> = ["cpu", "gpu", "api", "url", "id"]
+        return input
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .map { word in
+                if acronyms.contains(word.lowercased()) {
+                    return word.uppercased()
+                }
+                return word.prefix(1).uppercased() + word.dropFirst()
+            }
+            .joined()
+    }
+    func doBusyWork(forDuration duration: TimeInterval) {
+        let end = Date(timeIntervalSinceNow: duration)
+        var value: Double = 0
+        while Date() < end {
+            for i in 0..<10000 {
+                value += sqrt(Double(i))
+            }
+        }
+        _ = value
+    }
+}

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -475,3 +475,21 @@ When("I relaunch the app after shutdown") do
 
   manager.activate
 end
+
+And('I close the app') do
+  begin
+    manager = Maze::Api::Appium::AppManager.new
+    manager.terminate
+  rescue NoMethodError
+    begin
+      Maze.driver.terminate_app('com.bugsnag.fixture')
+    rescue NoMethodError
+      driver = Maze.driver.respond_to?(:driver) ? Maze.driver.driver : Maze.driver
+      driver.terminate_app('com.bugsnag.fixture')
+    end
+  end
+end
+Then('I should receive no spans') do
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  raise Test::Unit::AssertionFailedError, "Expected 0 spans but received #{spans.size}" unless spans.empty?
+end


### PR DESCRIPTION
## Goal

Introduce App Session Spans that aggregate CPU and memory metrics (min/max/mean) over customer-defined session windows, giving mobile users session-level resource usage visibility without manual trace correlation.


## Design

Session spans are implemented as standard un-nested spans with a dedicated app_session category, reusing existing span infrastructure across SDK, ClickHouse pipeline, Rails, and frontend — avoiding the complexity of a new first-class entity or trace merging.


## Testing

Covered by SDK Unit tests and Maze runner.