### PR TITLE
Resource Usage Aggregation Writing Additional MazeRunner Test Scenarious

### DIFF
--- a/features/default/resource-usage-aggregation.feature
+++ b/features/default/resource-usage-aggregation.feature
@@ -1,4 +1,4 @@
-Feature: Foreground App Session Span - Happy Path
+Feature: Foreground App Session Span
 
 Scenario: App session span sends app-session attributes
     Given I load scenario "AppSessionResourceUsageScenario"
@@ -20,17 +20,20 @@ Scenario: App session span contains memory aggregate attributes
     And I wait to receive at least 1 span
     Then a span field "name" equals "[AppSession/MemorySession]"
     * a span string attribute "bugsnag.span.category" equals "app_session"
-    * a span integer attribute "bugsnag.system.memory.spaces.device.size" is greater than 0
-    * a span integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
-    * a span integer attribute "bugsnag.system.memory.spaces.device.min" is greater than 0
-    * a span integer attribute "bugsnag.system.memory.spaces.device.max" is greater than 0
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * span integer attribute "bugsnag.system.memory.spaces.device.size" should be greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.mean" should be greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.min" should be greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.max" should be greater than 0
+    
 
 Scenario: App session span contains CPU aggregate attributes
     Given I load scenario "AppSessionResourceUsageScenario"
     And I configure bugsnag "cpuMetrics" to "true"
-    And I configure scenario "session_type" to "cpu session"
-    And I configure scenario "span_duration" to "2.5"
-    And I configure scenario "work_duration" to "2.0"
+    And I configure bugsnag "memoryMetrics" to "false"
+    And I configure scenario "session_type" to "CPUSession"
+    And I configure scenario "span_duration" to "4.0"
+    And I configure scenario "work_duration" to "3.0"
     And I configure scenario "work_on_thread" to "main"
     And I configure scenario "variant_name" to "CPU"
     And I start bugsnag
@@ -38,9 +41,9 @@ Scenario: App session span contains CPU aggregate attributes
     And I wait to receive at least 1 span
     Then a span field "name" equals "[AppSession/CPUSession]"
     * a span string attribute "bugsnag.span.category" equals "app_session"
-    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_min_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_max_total" is greater than 0.0
+    * span float attribute "bugsnag.system.cpu_mean_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_min_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_max_total" should be greater than 0.0
 
 Scenario: App session type is sanitized
     Given I load scenario "AppSessionResourceUsageScenario"
@@ -87,7 +90,11 @@ Scenario: Normal custom span is not treated as app session span
     Then a span field "name" equals "MemoryMetricsScenarioCustomRegression"
     * every span string attribute "bugsnag.span.category" equals "custom"
     * every span attribute "bugsnag.app_session.name" does not exist
-    * a span integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.mean" should be greater than 0
+    * every span attribute "bugsnag.system.memory.spaces.device.min" does not exist
+    * every span attribute "bugsnag.system.memory.spaces.device.max" does not exist
+    * every span attribute "bugsnag.system.cpu_min_total" does not exist
+    * every span attribute "bugsnag.system.cpu_max_total" does not exist
 
 Scenario: Aborted app session span is not sent
     Given I load scenario "AppSessionResourceUsageScenario"
@@ -99,7 +106,7 @@ Scenario: Aborted app session span is not sent
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 5 seconds
-    
+
 Scenario: Force-terminated app session span is not sent
     Given I load scenario "AppSessionResourceUsageScenario"
     And I configure bugsnag "memoryMetrics" to "true"
@@ -112,7 +119,7 @@ Scenario: Force-terminated app session span is not sent
     And I close the app
     And I wait for 5 seconds
     Then I should receive no spans
-    
+
 Scenario: CPU and memory aggregates satisfy min ≤ mean ≤ max
     Given I load scenario "AppSessionResourceUsageScenario"
     And I configure bugsnag "memoryMetrics" to "true"
@@ -127,13 +134,17 @@ Scenario: CPU and memory aggregates satisfy min ≤ mean ≤ max
     And I wait to receive at least 1 span
     Then a span field "name" equals "[AppSession/FullMetricsSession]"
     * a span string attribute "bugsnag.span.category" equals "app_session"
-    * a span integer attribute "bugsnag.system.memory.spaces.device.min" is greater than 0
-    * a span integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
-    * a span integer attribute "bugsnag.system.memory.spaces.device.max" is greater than 0
-    * a span float attribute "bugsnag.system.cpu_min_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_max_total" is greater than 0.0
-    
+    * span integer attribute "bugsnag.system.memory.spaces.device.min" should be greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.mean" should be greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.max" should be greater than 0
+    * span float attribute "bugsnag.system.cpu_min_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_mean_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_max_total" should be greater than 0.0
+    * a span integer attribute "bugsnag.system.memory.spaces.device.min" is less than or equal to span integer attribute "bugsnag.system.memory.spaces.device.mean"
+    * a span integer attribute "bugsnag.system.memory.spaces.device.mean" is less than or equal to span integer attribute "bugsnag.system.memory.spaces.device.max"
+    * a span float attribute "bugsnag.system.cpu_min_total" is less than or equal to span float attribute "bugsnag.system.cpu_mean_total"
+    * a span float attribute "bugsnag.system.cpu_mean_total" is less than or equal to span float attribute "bugsnag.system.cpu_max_total"
+
 Scenario: Single sample produces min equals max equals mean
     Given I load scenario "AppSessionResourceUsageScenario"
     And I configure bugsnag "memoryMetrics" to "true"
@@ -148,13 +159,15 @@ Scenario: Single sample produces min equals max equals mean
     And I wait to receive at least 1 span
     Then a span field "name" equals "[AppSession/SingleSampleSession]"
     * a span string attribute "bugsnag.span.category" equals "app_session"
-    * a span integer attribute "bugsnag.system.memory.spaces.device.min" is greater than 0
-    * a span integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
-    * a span integer attribute "bugsnag.system.memory.spaces.device.max" is greater than 0
-    * a span float attribute "bugsnag.system.cpu_min_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_max_total" is greater than 0.0
-    
+    * span integer attribute "bugsnag.system.memory.spaces.device.min" should be greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.mean" should be greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.max" should be greater than 0
+    * span float attribute "bugsnag.system.cpu_min_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_mean_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_max_total" should be greater than 0.0
+    * a span integer attribute "bugsnag.system.memory.spaces.device.min" is less than or equal to span integer attribute "bugsnag.system.memory.spaces.device.max"
+    * a span float attribute "bugsnag.system.cpu_min_total" is less than or equal to span float attribute "bugsnag.system.cpu_max_total"
+
 Scenario: CPU disabled but memory enabled produces CPU absent and memory present
     Given I load scenario "AppSessionResourceUsageScenario"
     And I configure bugsnag "memoryMetrics" to "true"
@@ -167,13 +180,13 @@ Scenario: CPU disabled but memory enabled produces CPU absent and memory present
     And I wait to receive at least 1 span
     Then a span field "name" equals "[AppSession/MemoryOnlySession]"
     * a span string attribute "bugsnag.span.category" equals "app_session"
-    * a span integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
-    * a span integer attribute "bugsnag.system.memory.spaces.device.min" is greater than 0
-    * a span integer attribute "bugsnag.system.memory.spaces.device.max" is greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.mean" should be greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.min" should be greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.max" should be greater than 0
     * every span attribute "bugsnag.system.cpu_mean_total" does not exist
     * every span attribute "bugsnag.system.cpu_min_total" does not exist
     * every span attribute "bugsnag.system.cpu_max_total" does not exist
-    
+
 Scenario: Memory disabled but CPU enabled produces memory absent and CPU present
     Given I load scenario "AppSessionResourceUsageScenario"
     And I configure bugsnag "cpuMetrics" to "true"
@@ -186,20 +199,20 @@ Scenario: Memory disabled but CPU enabled produces memory absent and CPU present
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[AppSession/CPUOnlySession]"
+    Then a span field "name" equals "[AppSession/CpuOnlySession]"
     * a span string attribute "bugsnag.span.category" equals "app_session"
-    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_min_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_max_total" is greater than 0.0
+    * span float attribute "bugsnag.system.cpu_mean_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_min_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_max_total" should be greater than 0.0
     * every span attribute "bugsnag.system.memory.spaces.device.mean" does not exist
     * every span attribute "bugsnag.system.memory.spaces.device.min" does not exist
     * every span attribute "bugsnag.system.memory.spaces.device.max" does not exist
-    
+
 Scenario: App session span contains all CPU sub-metrics
     Given I load scenario "AppSessionResourceUsageScenario"
     And I configure bugsnag "cpuMetrics" to "true"
     And I configure bugsnag "memoryMetrics" to "false"
-    And I configure scenario "session_type" to "cpu sub-metrics session"
+    And I configure scenario "session_type" to "CPUSubMetricsSession"
     And I configure scenario "span_duration" to "3.0"
     And I configure scenario "work_duration" to "2.5"
     And I configure scenario "work_on_thread" to "main"
@@ -209,16 +222,21 @@ Scenario: App session span contains all CPU sub-metrics
     And I wait to receive at least 1 span
     Then a span field "name" equals "[AppSession/CPUSubMetricsSession]"
     * a span string attribute "bugsnag.span.category" equals "app_session"
-    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_min_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_max_total" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_mean_main_thread" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_min_main_thread" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_max_main_thread" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_mean_overhead" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_min_overhead" is greater than 0.0
-    * a span float attribute "bugsnag.system.cpu_max_overhead" is greater than 0.0
+    * span float attribute "bugsnag.system.cpu_mean_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_min_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_max_total" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_mean_main_thread" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_max_main_thread" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_mean_overhead" should be greater than 0.0
+    * span float attribute "bugsnag.system.cpu_max_overhead" should be greater than 0.0
+    * a span float attribute "bugsnag.system.cpu_min_total" is less than or equal to span float attribute "bugsnag.system.cpu_mean_total"
+    * a span float attribute "bugsnag.system.cpu_min_main_thread" is less than or equal to span float attribute "bugsnag.system.cpu_mean_main_thread"
+    * a span float attribute "bugsnag.system.cpu_min_overhead" is less than or equal to span float attribute "bugsnag.system.cpu_mean_overhead"
+    * span float attribute "bugsnag.system.cpu_mean_total" should be less than 100.0
+    * span float attribute "bugsnag.system.cpu_mean_main_thread" should be less than 100.0
+    * span float attribute "bugsnag.system.cpu_mean_overhead" should be less than 100.0
     
+
 Scenario: Two concurrent app sessions deliver independently with separate metrics
     Given I load scenario "AppSessionResourceUsageScenario"
     And I configure bugsnag "memoryMetrics" to "true"
@@ -234,9 +252,59 @@ Scenario: Two concurrent app sessions deliver independently with separate metric
     And I wait to receive at least 2 spans
     Then a span field "name" equals "[AppSession/ConcurrentSessionA]"
     * a span string attribute "bugsnag.span.category" equals "app_session"
-    * a span integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
-    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
+    * span integer attribute "bugsnag.system.memory.spaces.device.mean" should be greater than 0
+    * span float attribute "bugsnag.system.cpu_mean_total" should be greater than 0.0
     And a span field "name" equals "[AppSession/ConcurrentSessionB]"
     * a span string attribute "bugsnag.span.category" equals "app_session"
-    * a span integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
-    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
+    * span integer attribute "bugsnag.system.memory.spaces.device.mean" should be greater than 0
+    * span float attribute "bugsnag.system.cpu_mean_total" should be greater than 0.0
+
+Scenario: High CPU load during session produces higher cpu_max_total
+    Given I load scenario "AppSessionResourceUsageScenario"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure bugsnag "memoryMetrics" to "false"
+    And I configure scenario "session_type" to "high cpu load session"
+    And I configure scenario "span_duration" to "3.0"
+    And I configure scenario "work_duration" to "2.5"
+    And I configure scenario "work_on_thread" to "main"
+    And I configure scenario "variant_name" to "HighCPU"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[AppSession/HighCpuLoadSession]"
+    * a span string attribute "bugsnag.span.category" equals "app_session"
+    * span float attribute "bugsnag.system.cpu_mean_total" should be greater than 1.0
+
+Scenario: Memory allocation during session produces higher memory max than min
+    Given I load scenario "AppSessionResourceUsageScenario"
+    And I configure bugsnag "memoryMetrics" to "true"
+    And I configure bugsnag "cpuMetrics" to "false"
+    And I configure scenario "session_type" to "memory allocation session"
+    And I configure scenario "span_duration" to "3.0"
+    And I configure scenario "variant_name" to "MemoryAllocation"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[AppSession/MemoryAllocationSession]"
+    * a span string attribute "bugsnag.span.category" equals "app_session"
+    * span integer attribute "bugsnag.system.memory.spaces.device.min" should be greater than 0
+    * span integer attribute "bugsnag.system.memory.spaces.device.max" should be greater than 0
+    * a span integer attribute "bugsnag.system.memory.spaces.device.min" is less than or equal to span integer attribute "bugsnag.system.memory.spaces.device.max"
+
+Scenario: App session span does not parent other spans
+    Given I load scenario "AppSessionResourceUsageScenario"
+    And I configure bugsnag "memoryMetrics" to "true"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure scenario "session_type" to "parent check session"
+    And I configure scenario "span_duration" to "2.0"
+    And I configure scenario "create_child_span" to "true"
+    And I configure scenario "work_duration" to "1.0"
+    And I configure scenario "work_on_thread" to "main"
+    And I configure scenario "variant_name" to "ParentCheck"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 2 spans
+    Then a span field "name" equals "[AppSession/ParentCheckSession]"
+    * a span string attribute "bugsnag.span.category" equals "app_session"
+    And a span field "name" equals "ChildSpanInsideSession"
+    * a span string attribute "bugsnag.span.category" equals "custom"

--- a/features/fixtures/ios/Scenarios/AppSessionResourceUsageScenario.swift
+++ b/features/fixtures/ios/Scenarios/AppSessionResourceUsageScenario.swift
@@ -63,6 +63,7 @@ class AppSessionResourceUsageScenario: Scenario {
                 Thread.sleep(forTimeInterval: 0.5)
                 childSpan.end()
             }
+            
             Thread.sleep(forTimeInterval: duration)
             if shouldAbort {
                 sessionSpan = nil
@@ -72,11 +73,10 @@ class AppSessionResourceUsageScenario: Scenario {
             sessionSpan = nil
             // --- End concurrent session span ---
             if let activeConc = concurrentSpan {
-                // Delay to let SDK flush first span
-                Thread.sleep(forTimeInterval: 2.0)
                 activeConc.end()
                 concurrentSpan = nil
             }
+            
             // Give SDK time to flush all spans before Maze Runner checks
             Thread.sleep(forTimeInterval: 5.0)
             waitForBrowserstack()

--- a/features/fixtures/ios/Scenarios/AppSessionResourceUsageScenario.swift
+++ b/features/fixtures/ios/Scenarios/AppSessionResourceUsageScenario.swift
@@ -11,11 +11,10 @@ import BugsnagPerformance
 class AppSessionResourceUsageScenario: Scenario {
     var sessionSpan: BugsnagPerformanceSpan?
     override func run() {
-        // Read config from scenarioConfig dictionary (NOT instance properties)
         let sessionType = scenarioConfig["session_type"] ?? "manual session"
         let duration = toDouble(string: scenarioConfig["span_duration"]) > 0
-            ? toDouble(string: scenarioConfig["span_duration"])
-            : 5.0
+        ? toDouble(string: scenarioConfig["span_duration"])
+        : 5.0
         let shouldAbort = toBool(string: scenarioConfig["abort_span"])
         let workDur = toDouble(string: scenarioConfig["work_duration"])
         let workThread = scenarioConfig["work_on_thread"] ?? "main"
@@ -33,34 +32,15 @@ class AppSessionResourceUsageScenario: Scenario {
             sessionSpan?.end()
             waitForBrowserstack()
         } else {
-            // Scenarios 2-5, 7: app session spans
-            let sessionTypeId = toPascalCase(sessionType)
-            let appSessionSpanName = "[AppSession/\(sessionTypeId)]"
-            NSLog("App Starting session span: \(appSessionSpanName)")
-            let opts = BugsnagPerformanceSpanOptions()
-            _ = opts.setFirstClass(.yes)
-            _ = opts.setMakeCurrentContext(false)
-            self.sessionSpan = BugsnagPerformance.startSpan(
-                name: appSessionSpanName,
-                options: opts
-            )
-            sessionSpan?.setAttribute("bugsnag.span.category", withValue: "app_session")
-            sessionSpan?.setAttribute("bugsnag.app_session.name", withValue: sessionTypeId)
+            // Use the real app session API — SDK handles span name, category,
+            // and attaches resource usage aggregation (mean, min, max)
+            NSLog("App Starting app session span with type: \(sessionType)")
+            self.sessionSpan = BugsnagPerformance.startAppSessionSpan(sessionType)
             // --- Concurrent session support ---
             var concurrentSpan: BugsnagPerformanceSpan?
             if let concurrentType = concurrentSessionType, !concurrentType.isEmpty {
-                let concurrentTypeId = toPascalCase(concurrentType)
-                let concurrentSpanName = "[AppSession/\(concurrentTypeId)]"
-                NSLog("App Starting concurrent session span: \(concurrentSpanName)")
-                let concurrentOpts = BugsnagPerformanceSpanOptions()
-                _ = concurrentOpts.setFirstClass(.yes)
-                _ = concurrentOpts.setMakeCurrentContext(false)
-                concurrentSpan = BugsnagPerformance.startSpan(
-                    name: concurrentSpanName,
-                    options: concurrentOpts
-                )
-                concurrentSpan?.setAttribute("bugsnag.span.category", withValue: "app_session")
-                concurrentSpan?.setAttribute("bugsnag.app_session.name", withValue: concurrentTypeId)
+                NSLog("App Starting concurrent app session span with type: \(concurrentType)")
+                concurrentSpan = BugsnagPerformance.startAppSessionSpan(concurrentType)
             }
             // CPU work if configured
             if workDur > 0 {
@@ -74,6 +54,21 @@ class AppSessionResourceUsageScenario: Scenario {
                     Thread.sleep(forTimeInterval: workDur)
                 }
             }
+            // Child span support (for parent check scenario)
+            if toBool(string: scenarioConfig["create_child_span"]) {
+                NSLog("App Creating independent child span")
+                let childOpts = BugsnagPerformanceSpanOptions()
+                _ = childOpts.setFirstClass(.yes)
+                _ = childOpts.setMakeCurrentContext(false)
+                let childSpan = BugsnagPerformance.startSpan(
+                    name: "ChildSpanInsideSession",
+                    options: childOpts
+                )
+                childSpan.setAttribute("bugsnag.span.category", withValue: "custom")
+                Thread.sleep(forTimeInterval: 0.5)
+                childSpan.end()
+                NSLog("App Child span ended")
+            }
             Thread.sleep(forTimeInterval: duration)
             if shouldAbort {
                 NSLog("App Aborting session span")
@@ -85,25 +80,16 @@ class AppSessionResourceUsageScenario: Scenario {
             sessionSpan = nil
             // --- End concurrent session span ---
             if let activeConc = concurrentSpan {
+                // Delay to let SDK flush first span
+                Thread.sleep(forTimeInterval: 2.0)
                 NSLog("App Ending concurrent session span")
                 activeConc.end()
                 concurrentSpan = nil
             }
+            // Give SDK time to flush all spans before Maze Runner checks
+            Thread.sleep(forTimeInterval: 5.0)
             waitForBrowserstack()
         }
-    }
-    func toPascalCase(_ input: String) -> String {
-        let acronyms: Set<String> = ["cpu", "gpu", "api", "url", "id"]
-        return input
-            .components(separatedBy: CharacterSet.alphanumerics.inverted)
-            .filter { !$0.isEmpty }
-            .map { word in
-                if acronyms.contains(word.lowercased()) {
-                    return word.uppercased()
-                }
-                return word.prefix(1).uppercased() + word.dropFirst()
-            }
-            .joined()
     }
     func doBusyWork(forDuration duration: TimeInterval) {
         let end = Date(timeIntervalSinceNow: duration)

--- a/features/fixtures/ios/Scenarios/AppSessionResourceUsageScenario.swift
+++ b/features/fixtures/ios/Scenarios/AppSessionResourceUsageScenario.swift
@@ -19,7 +19,6 @@ class AppSessionResourceUsageScenario: Scenario {
         let workDur = toDouble(string: scenarioConfig["work_duration"])
         let workThread = scenarioConfig["work_on_thread"] ?? "main"
         let concurrentSessionType = scenarioConfig["concurrent_session_type"]
-        NSLog("App session_type=\(sessionType), duration=\(duration), abort=\(shouldAbort)")
         if sessionType == "manual session" {
             // Scenario 1: simple manual span
             let opts = BugsnagPerformanceSpanOptions()
@@ -34,17 +33,14 @@ class AppSessionResourceUsageScenario: Scenario {
         } else {
             // Use the real app session API — SDK handles span name, category,
             // and attaches resource usage aggregation (mean, min, max)
-            NSLog("App Starting app session span with type: \(sessionType)")
             self.sessionSpan = BugsnagPerformance.startAppSessionSpan(sessionType)
             // --- Concurrent session support ---
             var concurrentSpan: BugsnagPerformanceSpan?
             if let concurrentType = concurrentSessionType, !concurrentType.isEmpty {
-                NSLog("App Starting concurrent app session span with type: \(concurrentType)")
                 concurrentSpan = BugsnagPerformance.startAppSessionSpan(concurrentType)
             }
             // CPU work if configured
             if workDur > 0 {
-                NSLog("App Doing CPU work for \(workDur)s on \(workThread)")
                 if workThread == "main" {
                     doBusyWork(forDuration: workDur)
                 } else {
@@ -56,7 +52,6 @@ class AppSessionResourceUsageScenario: Scenario {
             }
             // Child span support (for parent check scenario)
             if toBool(string: scenarioConfig["create_child_span"]) {
-                NSLog("App Creating independent child span")
                 let childOpts = BugsnagPerformanceSpanOptions()
                 _ = childOpts.setFirstClass(.yes)
                 _ = childOpts.setMakeCurrentContext(false)
@@ -67,14 +62,11 @@ class AppSessionResourceUsageScenario: Scenario {
                 childSpan.setAttribute("bugsnag.span.category", withValue: "custom")
                 Thread.sleep(forTimeInterval: 0.5)
                 childSpan.end()
-                NSLog("App Child span ended")
             }
             Thread.sleep(forTimeInterval: duration)
             if shouldAbort {
-                NSLog("App Aborting session span")
                 sessionSpan = nil
             } else {
-                NSLog("App Ending session span")
                 sessionSpan?.end()
             }
             sessionSpan = nil
@@ -82,7 +74,6 @@ class AppSessionResourceUsageScenario: Scenario {
             if let activeConc = concurrentSpan {
                 // Delay to let SDK flush first span
                 Thread.sleep(forTimeInterval: 2.0)
-                NSLog("App Ending concurrent session span")
                 activeConc.end()
                 concurrentSpan = nil
             }

--- a/features/steps/span_integer_steps.rb
+++ b/features/steps/span_integer_steps.rb
@@ -1,0 +1,98 @@
+# features/steps/span_integer_steps.rb
+# Custom steps using the same Maze::Server API as app_steps.rb
+
+# Integer attribute > value
+Then('span integer attribute {string} should be greater than {int}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') } }.compact
+  Maze.check.false(selected_attributes.empty?, "No span found with attribute '#{attribute}'")
+  selected_attributes.each do |a|
+    val = a['value']['intValue'].to_i
+    Maze.check.true(val > expected, "Expected #{attribute} (#{val}) > #{expected}")
+  end
+end
+
+# Float attribute > value
+Then('span float attribute {string} should be greater than {float}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('doubleValue') } }.compact
+  Maze.check.false(selected_attributes.empty?, "No span found with attribute '#{attribute}'")
+  selected_attributes.each do |a|
+    val = a['value']['doubleValue'].to_f
+    Maze.check.true(val > expected, "Expected #{attribute} (#{val}) > #{expected}")
+  end
+end
+
+# Cross-attribute comparison: integer A <= integer B
+Then('a span integer attribute {string} is less than or equal to span integer attribute {string}') do |attr_a, attr_b|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  found = false
+  spans.each do |span|
+    attrs = span['attributes'] || []
+    val_a = attrs.find { |a| a['key'] == attr_a }&.dig('value', 'intValue')&.to_i
+    val_b = attrs.find { |a| a['key'] == attr_b }&.dig('value', 'intValue')&.to_i
+    next if val_a.nil? || val_b.nil?
+    Maze.check.true(val_a <= val_b, "Expected #{attr_a} (#{val_a}) <= #{attr_b} (#{val_b})")
+    found = true
+  end
+  raise "No span found with both '#{attr_a}' and '#{attr_b}'" unless found
+end
+
+# Cross-attribute comparison: float A <= float B
+Then('a span float attribute {string} is less than or equal to span float attribute {string}') do |attr_a, attr_b|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  found = false
+  spans.each do |span|
+    attrs = span['attributes'] || []
+    val_a = attrs.find { |a| a['key'] == attr_a }&.dig('value', 'doubleValue')&.to_f
+    val_b = attrs.find { |a| a['key'] == attr_b }&.dig('value', 'doubleValue')&.to_f
+    next if val_a.nil? || val_b.nil?
+    Maze.check.true(val_a <= val_b, "Expected #{attr_a} (#{val_a}) <= #{attr_b} (#{val_b})")
+    found = true
+  end
+  raise "No span found with both '#{attr_a}' and '#{attr_b}'" unless found
+end
+
+# Cross-attribute equality: integer A == integer B
+Then('a span integer attribute {string} equals span integer attribute {string}') do |attr_a, attr_b|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  found = false
+  spans.each do |span|
+    attrs = span['attributes'] || []
+    val_a = attrs.find { |a| a['key'] == attr_a }&.dig('value', 'intValue')&.to_i
+    val_b = attrs.find { |a| a['key'] == attr_b }&.dig('value', 'intValue')&.to_i
+    next if val_a.nil? || val_b.nil?
+    Maze.check.true(val_a == val_b, "Expected #{attr_a} (#{val_a}) == #{attr_b} (#{val_b})")
+    found = true
+  end
+  raise "No span found with both '#{attr_a}' and '#{attr_b}'" unless found
+end
+
+# Cross-attribute equality: float A == float B
+Then('a span float attribute {string} equals span float attribute {string}') do |attr_a, attr_b|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  found = false
+  spans.each do |span|
+    attrs = span['attributes'] || []
+    val_a = attrs.find { |a| a['key'] == attr_a }&.dig('value', 'doubleValue')&.to_f
+    val_b = attrs.find { |a| a['key'] == attr_b }&.dig('value', 'doubleValue')&.to_f
+    next if val_a.nil? || val_b.nil?
+    Maze.check.true(val_a == val_b, "Expected #{attr_a} (#{val_a}) == #{attr_b} (#{val_b})")
+    found = true
+  end
+  raise "No span found with both '#{attr_a}' and '#{attr_b}'" unless found
+end
+
+Then('span float attribute {string} should be less than {float}') do |attribute, max_val|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  found = false
+  spans.each do |span|
+    attrs = span['attributes'] || []
+    attr = attrs.find { |a| a['key'] == attribute }
+    next unless attr
+    val = attr['value']['doubleValue'].to_f
+    found = true
+    Maze.check.true(val < max_val, "Expected #{attribute} (#{val}) < #{max_val}.")
+  end
+  Maze.check.true(found, "No span found with attribute '#{attribute}'.")
+end


### PR DESCRIPTION
Resource Usage Aggregation Writing Additional MazeRunner Test Scenarious.

## Goal

Introduce App Session Spans that aggregate CPU and memory metrics (min/max/mean) over customer-defined session windows, giving mobile users session-level resource usage visibility without manual trace correlation.

## Design

Session spans are implemented as standard un-nested spans with a dedicated app_session category, reusing existing span infrastructure across SDK, ClickHouse pipeline, Rails, and frontend — avoiding the complexity of a new first-class entity or trace merging.

## Testing

Covered by SDK Unit tests and Maze runner.