### PR TITLE
Feature/road 2234 graph ql requests breakdown

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -68,7 +68,7 @@ steps:
           - "IOS_14"
         depends_on:
           - "ios_fixture"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 75
         agents:
           queue: "opensource"
         plugins:
@@ -209,7 +209,7 @@ steps:
           - "IOS_14"
         depends_on:
           - "ios_fixture_swizzling_premain"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 75
         agents:
           queue: "opensource"
         plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -159,7 +159,7 @@ steps:
           - "IOS_13"
         depends_on:
           - "ios_fixture"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 75
         agents:
           queue: "opensource"
         plugins:
@@ -291,7 +291,7 @@ steps:
           - "IOS_13"
         depends_on:
           - "ios_fixture_swizzling_premain"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 75
         agents:
           queue: "opensource"
         plugins:

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -120,10 +120,10 @@ private:
     std::unique_ptr<RetryQueue> retryQueue_;
     AppStateTracker *appStateTracker_;
     NSMapTable<UIViewController *, BugsnagPerformanceSpan *> *viewControllersToSpans_;
-    std::shared_ptr<Instrumentation> instrumentation_;
-    Worker *worker_;
     std::shared_ptr<PersistentDeviceID> deviceID_;
     std::shared_ptr<ResourceAttributes> resourceAttributes_;
+    std::shared_ptr<Instrumentation> instrumentation_;
+    Worker *worker_;
     BugsnagPerformanceNetworkRequestCallback networkRequestCallback_;
     OtlpTraceEncoding traceEncoding_;
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -28,7 +28,7 @@
 #endif
 
 using namespace bugsnag;
-
+static NSString *BSGPrettyJSONString(id object) __attribute__((unused));
 static NSString *BSGPrettyJSONString(id object) {
     if (object == nil || ![NSJSONSerialization isValidJSONObject:object]) {
         return [object description];
@@ -608,9 +608,8 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
             }
         }
         if (hasNetworkOrGraphQLSpan) {
-            NSDictionary *encodedPayloadPreview = traceEncoding_.encode(spans, resourceAttributes_->get());
             BSGLogDebug(@"Network/GraphQL upload payload preview (actual encoded /v1/traces values)=%@",
-                        BSGPrettyJSONString(encodedPayloadPreview));
+                        BSGPrettyJSONString(traceEncoding_.encode(spans, resourceAttributes_->get())));
         }
         uploadPackage(traceEncoding_.buildUploadPackage(spans, resourceAttributes_->get(), includeSamplingHeader), false);
     });
@@ -920,9 +919,8 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
         if (graphQLSpanName != nil) {
             [graphQLAttributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
             span = tracer_->startNetworkSpan(graphQLSpanName, options, BSGTriStateYes, graphQLAttributes);
-            auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
             BSGLogDebug(@"Manually reported GraphQL response completed: status=%ld durationMs=%.2f bytesSent=%lld bytesReceived=%lld name=%@ category=%@ display_name=%@ finalPayloadLog=\"GraphQL upload payload preview\"",
-                        (long)httpResponse.statusCode,
+                        (long)[BSGDynamicCast<NSHTTPURLResponse>(task.response) statusCode],
                         interval.duration * 1000.0,
                         task.countOfBytesSent,
                         task.countOfBytesReceived,
@@ -937,4 +935,3 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
         [span endWithEndTime:interval.endDate];
     }
 }
-

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -29,6 +29,18 @@
 
 using namespace bugsnag;
 
+static NSString *BSGPrettyJSONString(id object) {
+    if (object == nil || ![NSJSONSerialization isValidJSONObject:object]) {
+        return [object description];
+    }
+    NSError *error = nil;
+    NSData *data = [NSJSONSerialization dataWithJSONObject:object options:NSJSONWritingPrettyPrinted error:&error];
+    if (data == nil) {
+        return [NSString stringWithFormat:@"<unable to encode JSON preview: %@>", error];
+    }
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
+
 static constexpr double SAMPLER_INTERVAL_SECONDS = 1.0;
 static constexpr double SAMPLER_HISTORY_SECONDS = 10 * 60;
 static constexpr NSTimeInterval WORK_INTERVAL_DEBUG_MODE_SECONDS = 5;
@@ -126,15 +138,16 @@ BugsnagPerformanceImpl::BugsnagPerformanceImpl(std::shared_ptr<Reachability> rea
 , appStateTracker_(appStateTracker)
 , viewControllersToSpans_([NSMapTable mapTableWithKeyOptions:NSMapTableWeakMemory | NSMapTableObjectPointerPersonality
                                                 valueOptions:NSMapTableStrongMemory])
+, deviceID_(std::make_shared<PersistentDeviceID>(persistence_))
+, resourceAttributes_(std::make_shared<ResourceAttributes>(deviceID_))
 , instrumentation_(std::make_shared<Instrumentation>(tracer_,
                                                      appStartupSpanFactory_,
                                                      viewLoadSpanFactory_,
                                                      networkSpanFactory_,
                                                      spanAttributesProvider_,
-                                                     networkHeaderInjector_))
+                                                     networkHeaderInjector_,
+                                                     resourceAttributes_))
 , worker_([[Worker alloc] initWithInitialTasks:buildInitialTasks() recurringTasks:buildRecurringTasks()])
-, deviceID_(std::make_shared<PersistentDeviceID>(persistence_))
-, resourceAttributes_(std::make_shared<ResourceAttributes>(deviceID_))
 , systemInfoSampler_(SAMPLER_INTERVAL_SECONDS, SAMPLER_HISTORY_SECONDS)
 , networkRequestCallback_(
     ^BugsnagPerformanceNetworkRequestInfo * _Nonnull(BugsnagPerformanceNetworkRequestInfo * _Nonnull info) {
@@ -552,6 +565,20 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
 #endif
         return false;
     }
+    
+    NSMutableArray<NSString *> *spanSummaries = [NSMutableArray arrayWithCapacity:spans.count];
+    for (BugsnagPerformanceSpan *span in spans) {
+        NSString *category = BSGDynamicCast<NSString>(span.attributes[@"bugsnag.span.category"]) ?: @"<none>";
+        NSString *displayName = BSGDynamicCast<NSString>(span.attributes[@"display_name"]) ?: @"<none>";
+        [spanSummaries addObject:[NSString stringWithFormat:@"name=%@ category=%@ display_name=%@",
+                                  span.name,
+                                  category,
+                                  displayName]];
+    }
+    BSGLogDebug(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): sending %zu sampled spans to /v1/traces: %@",
+                spans.count,
+                spanSummaries);
+
     bool includeSamplingHeader = configuration_ == nil || configuration_.samplingProbability == nil;
 
     // Delay so that the sampler has time to fetch one more sample.
@@ -568,10 +595,23 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
                 applyNonSessionSpanSampleAttributes(span);
             }
         }
-
+        
 #ifndef __clang_analyzer__
         BSGLogTrace(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): Sending %zu sampled spans (out of %zu)", origSpansSize, spans.count);
 #endif
+        BOOL hasNetworkOrGraphQLSpan = NO;
+        for (BugsnagPerformanceSpan *span in spans) {
+            NSString *category = BSGDynamicCast<NSString>(span.attributes[@"bugsnag.span.category"]);
+            if ([category isEqualToString:@"graphql"] || [category isEqualToString:@"network"]) {
+                hasNetworkOrGraphQLSpan = YES;
+                break;
+            }
+        }
+        if (hasNetworkOrGraphQLSpan) {
+            NSDictionary *encodedPayloadPreview = traceEncoding_.encode(spans, resourceAttributes_->get());
+            BSGLogDebug(@"Network/GraphQL upload payload preview (actual encoded /v1/traces values)=%@",
+                        BSGPrettyJSONString(encodedPayloadPreview));
+        }
         uploadPackage(traceEncoding_.buildUploadPackage(spans, resourceAttributes_->get(), includeSamplingHeader), false);
     });
 
@@ -858,7 +898,10 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
 
     NSError *errorFromGetRequest = nil;
     NSURLRequest *req = getTaskRequest(task, &errorFromGetRequest);
-
+    BSGLogDebug(@"BugsnagPerformanceImpl::reportNetworkSpan() method=%@ endpoint=%@",
+                req.HTTPMethod,
+                req.URL.path.length > 0 ? req.URL.path : @"/");
+    
     auto info = [BugsnagPerformanceNetworkRequestInfo new];
     info.url = req.URL;
     bool userVetoedTracing = false;
@@ -872,8 +915,26 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
         SpanOptions options;
         options.makeCurrentContext = false;
         options.startTime = dateToAbsoluteTime(interval.startDate);
-        span = tracer_->startNetworkSpan(name, options);
+        auto graphQLAttributes = spanAttributesProvider_->graphQLAttributes(req, info.url);
+        NSString *graphQLSpanName = spanAttributesProvider_->graphQLSpanName(info.url, graphQLAttributes);
+        if (graphQLSpanName != nil) {
+            [graphQLAttributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
+            span = tracer_->startNetworkSpan(graphQLSpanName, options, BSGTriStateYes, graphQLAttributes);
+            auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
+            BSGLogDebug(@"Manually reported GraphQL response completed: status=%ld durationMs=%.2f bytesSent=%lld bytesReceived=%lld name=%@ category=%@ display_name=%@ finalPayloadLog=\"GraphQL upload payload preview\"",
+                        (long)httpResponse.statusCode,
+                        interval.duration * 1000.0,
+                        task.countOfBytesSent,
+                        task.countOfBytesReceived,
+                        graphQLSpanName,
+                        graphQLAttributes[@"bugsnag.span.category"],
+                        graphQLAttributes[@"display_name"]);
+        } else {
+            span = tracer_->startNetworkSpan(name, options);
+        }
         [span internalSetMultipleAttributes:spanAttributesProvider_->networkSpanAttributes(info.url, task, metrics, errorFromGetRequest)];
+        if (graphQLSpanName != nil) [span internalSetMultipleAttributes:graphQLAttributes];
         [span endWithEndTime:interval.endDate];
     }
 }
+

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -28,6 +28,7 @@
 #endif
 
 using namespace bugsnag;
+static NSString * const BSGMissingSpanAttributeValue = @"<none>";
 static NSString *BSGPrettyJSONString(id object) __attribute__((unused));
 static NSString *BSGPrettyJSONString(id object) {
     if (object == nil || ![NSJSONSerialization isValidJSONObject:object]) {
@@ -567,14 +568,14 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
     
 #if BSG_LOG_LEVEL >= BSG_LOGLEVEL_DEBUG
     NSMutableArray<NSString *> *spanSummaries = [NSMutableArray arrayWithCapacity:spans.count];
-    for (BugsnagPerformanceSpan *span in spans) {
-        NSString *category = BSGDynamicCast<NSString>(span.attributes[@"bugsnag.span.category"]) ?: @"<none>";
-        NSString *displayName = BSGDynamicCast<NSString>(span.attributes[@"display_name"]) ?: @"<none>";
-        [spanSummaries addObject:[NSString stringWithFormat:@"name=%@ category=%@ display_name=%@",
-                                  span.name,
-                                  category,
-                                  displayName]];
-    }
+        for (BugsnagPerformanceSpan *span in spans) {
+            NSString *category = BSGDynamicCast<NSString>(span.attributes[BSGSpanCategoryAttributeKey]) ?: BSGMissingSpanAttributeValue;
+            NSString *displayName = BSGDynamicCast<NSString>(span.attributes[BSGSpanDisplayNameAttributeKey]) ?: BSGMissingSpanAttributeValue;
+            [spanSummaries addObject:[NSString stringWithFormat:@"name=%@ category=%@ display_name=%@",
+                                      span.name,
+                                      category,
+                                      displayName]];
+        }
     BSGLogDebug(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): sending %zu sampled spans to /v1/traces: %@",
                 spans.count,
                 spanSummaries);
@@ -916,9 +917,12 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
         options.makeCurrentContext = false;
         options.startTime = dateToAbsoluteTime(interval.startDate);
         auto graphQLAttributes = spanAttributesProvider_->graphQLAttributes(req, info.url);
-        NSString *graphQLSpanName = spanAttributesProvider_->graphQLSpanName(info.url, graphQLAttributes);
-        if (graphQLSpanName != nil) {
-            [graphQLAttributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
+        NSString *graphQLSpanName = graphQLAttributes != nil
+            ? spanAttributesProvider_->graphQLSpanName(info.url, graphQLAttributes)
+            : nil;
+        if (graphQLSpanName != nil && graphQLAttributes != nil) {
+            [graphQLAttributes removeObjectsForKeys:@[BSGGraphQLOperationTypeAttributeKey,
+                                                      BSGGraphQLOperationNameAttributeKey]];
             span = tracer_->startNetworkSpan(graphQLSpanName, options, BSGTriStateYes, graphQLAttributes);
             BSGLogDebug(@"Manually reported GraphQL response completed: status=%ld durationMs=%.2f bytesSent=%lld bytesReceived=%lld name=%@ category=%@ display_name=%@ finalPayloadLog=\"GraphQL upload payload preview\"",
                         (long)[BSGDynamicCast<NSHTTPURLResponse>(task.response) statusCode],
@@ -926,13 +930,19 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
                         task.countOfBytesSent,
                         task.countOfBytesReceived,
                         graphQLSpanName,
-                        graphQLAttributes[@"bugsnag.span.category"],
-                        graphQLAttributes[@"display_name"]);
+                        graphQLAttributes[BSGSpanCategoryAttributeKey],
+                        graphQLAttributes[BSGSpanDisplayNameAttributeKey]);
         } else {
             span = tracer_->startNetworkSpan(name, options);
         }
-        [span internalSetMultipleAttributes:spanAttributesProvider_->networkSpanAttributes(info.url, task, metrics, errorFromGetRequest)];
-        if (graphQLSpanName != nil) [span internalSetMultipleAttributes:graphQLAttributes];
+        auto networkAttributes = spanAttributesProvider_->networkSpanAttributes(info.url, task, metrics, errorFromGetRequest);
+        if (networkAttributes != nil) {
+            [span internalSetMultipleAttributes:networkAttributes];
+        }
+        if (graphQLSpanName != nil && graphQLAttributes != nil) {
+            [span internalSetMultipleAttributes:graphQLAttributes];
+        }
         [span endWithEndTime:interval.endDate];
     }
 }
+

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -566,18 +566,6 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
         return false;
     }
     
-#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_DEBUG
-    NSMutableArray<NSString *> *spanSummaries = [NSMutableArray arrayWithCapacity:spans.count];
-        for (BugsnagPerformanceSpan *span in spans) {
-            NSString *category = BSGDynamicCast<NSString>(span.attributes[BSGSpanCategoryAttributeKey]) ?: BSGMissingSpanAttributeValue;
-            NSString *displayName = BSGDynamicCast<NSString>(span.attributes[BSGSpanDisplayNameAttributeKey]) ?: BSGMissingSpanAttributeValue;
-            [spanSummaries addObject:[NSString stringWithFormat:@"name=%@ category=%@ display_name=%@",
-                                      span.name,
-                                      category,
-                                      displayName]];
-        }
-#endif
-    
     bool includeSamplingHeader = configuration_ == nil || configuration_.samplingProbability == nil;
 
     // Delay so that the sampler has time to fetch one more sample.

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -576,9 +576,6 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
                                       category,
                                       displayName]];
         }
-    BSGLogDebug(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): sending %zu sampled spans to /v1/traces: %@",
-                spans.count,
-                spanSummaries);
 #endif
     
     bool includeSamplingHeader = configuration_ == nil || configuration_.samplingProbability == nil;
@@ -610,7 +607,7 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
             }
         }
         if (hasNetworkOrGraphQLSpan) {
-            BSGLogDebug(@"Network/GraphQL upload payload preview (actual encoded /v1/traces values)=%@",
+            BSGLogTrace(@"Network/GraphQL upload payload preview (actual encoded /v1/traces values)=%@",
                         BSGPrettyJSONString(traceEncoding_.encode(spans, resourceAttributes_->get())));
         }
         uploadPackage(traceEncoding_.buildUploadPackage(spans, resourceAttributes_->get(), includeSamplingHeader), false);
@@ -899,9 +896,6 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
 
     NSError *errorFromGetRequest = nil;
     NSURLRequest *req = getTaskRequest(task, &errorFromGetRequest);
-    BSGLogDebug(@"BugsnagPerformanceImpl::reportNetworkSpan() method=%@ endpoint=%@",
-                req.HTTPMethod,
-                req.URL.path.length > 0 ? req.URL.path : @"/");
     
     auto info = [BugsnagPerformanceNetworkRequestInfo new];
     info.url = req.URL;
@@ -924,14 +918,6 @@ void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSess
             [graphQLAttributes removeObjectsForKeys:@[BSGGraphQLOperationTypeAttributeKey,
                                                       BSGGraphQLOperationNameAttributeKey]];
             span = tracer_->startNetworkSpan(graphQLSpanName, options, BSGTriStateYes, graphQLAttributes);
-            BSGLogDebug(@"Manually reported GraphQL response completed: status=%ld durationMs=%.2f bytesSent=%lld bytesReceived=%lld name=%@ category=%@ display_name=%@ finalPayloadLog=\"GraphQL upload payload preview\"",
-                        (long)[BSGDynamicCast<NSHTTPURLResponse>(task.response) statusCode],
-                        interval.duration * 1000.0,
-                        task.countOfBytesSent,
-                        task.countOfBytesReceived,
-                        graphQLSpanName,
-                        graphQLAttributes[BSGSpanCategoryAttributeKey],
-                        graphQLAttributes[BSGSpanDisplayNameAttributeKey]);
         } else {
             span = tracer_->startNetworkSpan(name, options);
         }

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -145,8 +145,7 @@ BugsnagPerformanceImpl::BugsnagPerformanceImpl(std::shared_ptr<Reachability> rea
                                                      viewLoadSpanFactory_,
                                                      networkSpanFactory_,
                                                      spanAttributesProvider_,
-                                                     networkHeaderInjector_,
-                                                     resourceAttributes_))
+                                                     networkHeaderInjector_))
 , worker_([[Worker alloc] initWithInitialTasks:buildInitialTasks() recurringTasks:buildRecurringTasks()])
 , systemInfoSampler_(SAMPLER_INTERVAL_SECONDS, SAMPLER_HISTORY_SECONDS)
 , networkRequestCallback_(
@@ -566,6 +565,7 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
         return false;
     }
     
+#if BSG_LOG_LEVEL >= BSG_LOGLEVEL_DEBUG
     NSMutableArray<NSString *> *spanSummaries = [NSMutableArray arrayWithCapacity:spans.count];
     for (BugsnagPerformanceSpan *span in spans) {
         NSString *category = BSGDynamicCast<NSString>(span.attributes[@"bugsnag.span.category"]) ?: @"<none>";
@@ -578,7 +578,8 @@ bool BugsnagPerformanceImpl::sendCurrentBatchTask() noexcept {
     BSGLogDebug(@"BugsnagPerformanceImpl::sendCurrentBatchTask(): sending %zu sampled spans to /v1/traces: %@",
                 spans.count,
                 spanSummaries);
-
+#endif
+    
     bool includeSamplingHeader = configuration_ == nil || configuration_.samplingProbability == nil;
 
     // Delay so that the sampler has time to fetch one more sample.

--- a/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
@@ -22,6 +22,7 @@
 #import "../SpanFactory/ViewLoad/ViewLoadSpanFactory.h"
 #import "../SpanFactory/Network/NetworkSpanFactory.h"
 #import "AppStartupInstrumentation/State/AppStartupInstrumentationStateSnapshot.h"
+#import "../ResourceAttributes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -35,7 +36,8 @@ std::shared_ptr<ViewLoadInstrumentation> createViewLoadInstrumentation(std::shar
 
 std::shared_ptr<NetworkInstrumentation> createNetworkInstrumentation(std::shared_ptr<NetworkSpanFactory> spanFactory,
                                                                      std::shared_ptr<SpanAttributesProvider> spanAttributesProvider,
-                                                                     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector);
+                                                                     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector,
+                                                                     std::shared_ptr<ResourceAttributes> resourceAttributes);
 
 namespace bugsnag {
 
@@ -46,10 +48,11 @@ public:
                     std::shared_ptr<ViewLoadSpanFactory> viewLoadSpanFactory,
                     std::shared_ptr<NetworkSpanFactory> networkSpanFactory,
                     std::shared_ptr<SpanAttributesProvider> spanAttributesProvider,
-                    std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector) noexcept
+                    std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector,
+                    std::shared_ptr<ResourceAttributes> resourceAttributes) noexcept
     : appStartupInstrumentation_(createAppStartupInstrumentation(appStartupSpanFactory, spanAttributesProvider))
     , viewLoadInstrumentation_(createViewLoadInstrumentation(viewLoadSpanFactory, spanAttributesProvider))
-    , networkInstrumentation_(createNetworkInstrumentation(networkSpanFactory, spanAttributesProvider, networkHeaderInjector))
+    , networkInstrumentation_(createNetworkInstrumentation(networkSpanFactory, spanAttributesProvider, networkHeaderInjector, resourceAttributes))
     {
         tracer->setGetAppStartInstrumentationState([=]{ return appStartupInstrumentation_->stateSnapshot(); });
     }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.h
@@ -22,7 +22,6 @@
 #import "../SpanFactory/ViewLoad/ViewLoadSpanFactory.h"
 #import "../SpanFactory/Network/NetworkSpanFactory.h"
 #import "AppStartupInstrumentation/State/AppStartupInstrumentationStateSnapshot.h"
-#import "../ResourceAttributes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,8 +35,7 @@ std::shared_ptr<ViewLoadInstrumentation> createViewLoadInstrumentation(std::shar
 
 std::shared_ptr<NetworkInstrumentation> createNetworkInstrumentation(std::shared_ptr<NetworkSpanFactory> spanFactory,
                                                                      std::shared_ptr<SpanAttributesProvider> spanAttributesProvider,
-                                                                     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector,
-                                                                     std::shared_ptr<ResourceAttributes> resourceAttributes);
+                                                                     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector);
 
 namespace bugsnag {
 
@@ -48,11 +46,10 @@ public:
                     std::shared_ptr<ViewLoadSpanFactory> viewLoadSpanFactory,
                     std::shared_ptr<NetworkSpanFactory> networkSpanFactory,
                     std::shared_ptr<SpanAttributesProvider> spanAttributesProvider,
-                    std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector,
-                    std::shared_ptr<ResourceAttributes> resourceAttributes) noexcept
+                    std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector) noexcept
     : appStartupInstrumentation_(createAppStartupInstrumentation(appStartupSpanFactory, spanAttributesProvider))
     , viewLoadInstrumentation_(createViewLoadInstrumentation(viewLoadSpanFactory, spanAttributesProvider))
-    , networkInstrumentation_(createNetworkInstrumentation(networkSpanFactory, spanAttributesProvider, networkHeaderInjector, resourceAttributes))
+    , networkInstrumentation_(createNetworkInstrumentation(networkSpanFactory, spanAttributesProvider, networkHeaderInjector))
     {
         tracer->setGetAppStartInstrumentationState([=]{ return appStartupInstrumentation_->stateSnapshot(); });
     }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.mm
@@ -112,7 +112,8 @@ std::shared_ptr<ViewLoadInstrumentation> createViewLoadInstrumentation(std::shar
 
 std::shared_ptr<NetworkInstrumentation> createNetworkInstrumentation(std::shared_ptr<NetworkSpanFactory> spanFactory,
                                                                      std::shared_ptr<SpanAttributesProvider> spanAttributesProvider,
-                                                                     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector) {
+                                                                     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector,
+                                                                     std::shared_ptr<ResourceAttributes> resourceAttributes) {
     auto repository = std::make_shared<NetworkInstrumentationStateRepositoryImpl>();
     auto systemUtils = std::make_shared<NetworkInstrumentationSystemUtilsImpl>();
     auto swizzlingHandler = std::make_shared<NetworkSwizzlingHandlerImpl>();
@@ -122,7 +123,8 @@ std::shared_ptr<NetworkInstrumentation> createNetworkInstrumentation(std::shared
                                                                           earlyPhaseHandler,
                                                                           systemUtils,
                                                                           repository,
-                                                                          networkHeaderInjector);
+                                                                          networkHeaderInjector,
+                                                                          resourceAttributes);
     auto delegate = [[BSGURLSessionPerformanceDelegate alloc] initWithLifecycleHandler:lifecycleHandler];
     return std::make_shared<NetworkInstrumentation>(systemUtils,
                                                     swizzlingHandler,

--- a/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/Instrumentation.mm
@@ -112,8 +112,7 @@ std::shared_ptr<ViewLoadInstrumentation> createViewLoadInstrumentation(std::shar
 
 std::shared_ptr<NetworkInstrumentation> createNetworkInstrumentation(std::shared_ptr<NetworkSpanFactory> spanFactory,
                                                                      std::shared_ptr<SpanAttributesProvider> spanAttributesProvider,
-                                                                     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector,
-                                                                     std::shared_ptr<ResourceAttributes> resourceAttributes) {
+                                                                     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector) {
     auto repository = std::make_shared<NetworkInstrumentationStateRepositoryImpl>();
     auto systemUtils = std::make_shared<NetworkInstrumentationSystemUtilsImpl>();
     auto swizzlingHandler = std::make_shared<NetworkSwizzlingHandlerImpl>();
@@ -123,8 +122,7 @@ std::shared_ptr<NetworkInstrumentation> createNetworkInstrumentation(std::shared
                                                                           earlyPhaseHandler,
                                                                           systemUtils,
                                                                           repository,
-                                                                          networkHeaderInjector,
-                                                                          resourceAttributes);
+                                                                          networkHeaderInjector);
     auto delegate = [[BSGURLSessionPerformanceDelegate alloc] initWithLifecycleHandler:lifecycleHandler];
     return std::make_shared<NetworkInstrumentation>(systemUtils,
                                                     swizzlingHandler,

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.h
@@ -13,6 +13,7 @@
 #import "../../../SpanFactory/Network/NetworkSpanFactory.h"
 #import "../System/NetworkInstrumentationSystemUtils.h"
 #import "../System/NetworkHeaderInjector.h"
+#import "../../../ResourceAttributes.h"
 
 namespace bugsnag {
 
@@ -23,13 +24,15 @@ public:
                                 std::shared_ptr<NetworkEarlyPhaseHandler> earlyPhaseHandler,
                                 std::shared_ptr<NetworkInstrumentationSystemUtils> systemUtils,
                                 std::shared_ptr<NetworkInstrumentationStateRepository> repository,
-                                std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector) noexcept
+                                std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector,
+                                std::shared_ptr<ResourceAttributes> resourceAttributes) noexcept
     : spanAttributesProvider_(spanAttributesProvider)
     , spanFactory_(spanFactory)
     , earlyPhaseHandler_(earlyPhaseHandler)
     , systemUtils_(systemUtils)
     , repository_(repository)
-    , networkHeaderInjector_(networkHeaderInjector) {}
+    , networkHeaderInjector_(networkHeaderInjector)
+    , resourceAttributes_(resourceAttributes) {}
     
     void onInstrumentationConfigured(bool isEnabled, BugsnagPerformanceNetworkRequestCallback callback) noexcept;
     void onTaskResume(NSURLSessionTask *task) noexcept;
@@ -44,6 +47,7 @@ private:
     std::shared_ptr<NetworkInstrumentationSystemUtils> systemUtils_;
     std::shared_ptr<NetworkInstrumentationStateRepository> repository_;
     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector_;
+    std::shared_ptr<ResourceAttributes> resourceAttributes_;
     BugsnagPerformanceNetworkRequestCallback networkRequestCallback_{nil};
     
     void updateState(NetworkInstrumentationState *state);
@@ -57,8 +61,7 @@ private:
                                  NSError *error) noexcept;
     
     NetworkInstrumentationState *initializeStateAndSaveIfNotVetoed(NSURLSessionTask *task,
-                                                                   NSString *httpMethod,
-                                                                   NSURL *originalUrl,
+                                                                   NSURLRequest *request,
                                                                    NSError *error) noexcept;
     
     void endSpanOnDestroyIfNeeded(NetworkInstrumentationState *state) noexcept;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.h
@@ -13,7 +13,6 @@
 #import "../../../SpanFactory/Network/NetworkSpanFactory.h"
 #import "../System/NetworkInstrumentationSystemUtils.h"
 #import "../System/NetworkHeaderInjector.h"
-#import "../../../ResourceAttributes.h"
 
 namespace bugsnag {
 
@@ -24,15 +23,13 @@ public:
                                 std::shared_ptr<NetworkEarlyPhaseHandler> earlyPhaseHandler,
                                 std::shared_ptr<NetworkInstrumentationSystemUtils> systemUtils,
                                 std::shared_ptr<NetworkInstrumentationStateRepository> repository,
-                                std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector,
-                                std::shared_ptr<ResourceAttributes> resourceAttributes) noexcept
+                                std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector) noexcept
     : spanAttributesProvider_(spanAttributesProvider)
     , spanFactory_(spanFactory)
     , earlyPhaseHandler_(earlyPhaseHandler)
     , systemUtils_(systemUtils)
     , repository_(repository)
-    , networkHeaderInjector_(networkHeaderInjector)
-    , resourceAttributes_(resourceAttributes) {}
+    , networkHeaderInjector_(networkHeaderInjector) {}
     
     void onInstrumentationConfigured(bool isEnabled, BugsnagPerformanceNetworkRequestCallback callback) noexcept;
     void onTaskResume(NSURLSessionTask *task) noexcept;
@@ -47,7 +44,6 @@ private:
     std::shared_ptr<NetworkInstrumentationSystemUtils> systemUtils_;
     std::shared_ptr<NetworkInstrumentationStateRepository> repository_;
     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector_;
-    std::shared_ptr<ResourceAttributes> resourceAttributes_;
     BugsnagPerformanceNetworkRequestCallback networkRequestCallback_{nil};
     
     void updateState(NetworkInstrumentationState *state);

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
@@ -12,6 +12,7 @@
 
 using namespace bugsnag;
 
+static NSString *BSGPrettyJSONString(id object) __attribute__((unused));
 static NSString *BSGPrettyJSONString(id object) {
     if (object == nil || ![NSJSONSerialization isValidJSONObject:object]) {
         return [object description];
@@ -22,6 +23,27 @@ static NSString *BSGPrettyJSONString(id object) {
         return [NSString stringWithFormat:@"<unable to encode JSON preview: %@>", error];
     }
     return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
+
+static NSDictionary *BSGEncodedPayloadPreview(std::shared_ptr<ResourceAttributes> resourceAttributes,
+                                              BugsnagPerformanceSpan *span) __attribute__((unused));
+static NSDictionary *BSGEncodedPayloadPreview(std::shared_ptr<ResourceAttributes> resourceAttributes,
+                                              BugsnagPerformanceSpan *span) {
+    OtlpTraceEncoding encoder;
+    NSDictionary *encodeResourceAttributes = resourceAttributes != nullptr ? resourceAttributes->get() : @{};
+    return @{
+        @"resourceSpans": @[@{
+            @"resource": @{
+                @"attributes": encoder.encode(encodeResourceAttributes ?: @{}),
+            },
+            @"scopeSpans": @[@{
+                @"scope": @{
+                    @"name": @"bugsnag.performance",
+                },
+                @"spans": @[encoder.encode(span)],
+            }],
+        }]
+    };
 }
 
 void
@@ -86,51 +108,11 @@ NetworkLifecycleHandlerImpl::onTaskDidFinishCollectingMetrics(NSURLSessionTask *
     NSDictionary *graphQLAttributes = state.graphQLAttributes;
     if (graphQLAttributes != nil) {
         [state.overallSpan internalSetMultipleAttributes:graphQLAttributes];
-        auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
-       // auto request = systemUtils_->taskRequest(task, nil);
-        BSGLogDebug(@"GraphQL response completed: status=%ld durationMs=%.2f bytesSent=%lld bytesReceived=%lld name=%@ category=%@ display_name=%@ finalPayloadLog=\"GraphQL upload payload preview\"",
-                    (long)httpResponse.statusCode,
-                    metrics.taskInterval.duration * 1000.0,
-                    task.countOfBytesSent,
-                    task.countOfBytesReceived,
-                    state.overallSpan.name,
-                    graphQLAttributes[@"bugsnag.span.category"],
-                    graphQLAttributes[@"display_name"]);
     } else {
         auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
         auto request = systemUtils_->taskRequest(task, nil);
-        BSGLogDebug(@"Network response completed: method=%@ endpoint=%@ category=network graphQLDetected=NO status=%ld durationMs=%.2f bytesSent=%lld bytesReceived=%lld spanName=%@",
-                    request.HTTPMethod,
-                    state.url.path.length > 0 ? state.url.path : @"/",
-                    (long)httpResponse.statusCode,
-                    metrics.taskInterval.duration * 1000.0,
-                    task.countOfBytesSent,
-                    task.countOfBytesReceived,
-                    state.overallSpan.name);
     }
     [state.overallSpan endWithEndTime:metrics.taskInterval.endDate];
-    OtlpTraceEncoding encoder;
-    NSDictionary *resourceAttributes = resourceAttributes_ != nullptr ? resourceAttributes_->get() : @{};
-    NSDictionary *encodedPayloadPreview = @{
-        @"resourceSpans": @[@{
-            @"resource": @{
-                @"attributes": encoder.encode(resourceAttributes ?: @{}),
-            },
-            @"scopeSpans": @[@{
-                @"scope": @{
-                    @"name": @"bugsnag.performance",
-                },
-                @"spans": @[encoder.encode(state.overallSpan)],
-            }],
-        }],
-    };
-    if (graphQLAttributes != nil) {
-        BSGLogDebug(@"GraphQL encoded payload preview (single-span OTLP shape; real resource attributes are added during /v1/traces upload)=%@",
-                    BSGPrettyJSONString(encodedPayloadPreview));
-    } else {
-        BSGLogDebug(@"Network encoded payload preview (single-span OTLP shape; real resource attributes are added during /v1/traces upload)=%@",
-                    BSGPrettyJSONString(encodedPayloadPreview));
-    }
     repository_->setInstrumentationState(task, nil);
 }
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
@@ -42,7 +42,7 @@ static NSDictionary *BSGEncodedPayloadPreview(std::shared_ptr<ResourceAttributes
                 },
                 @"spans": @[encoder.encode(span)],
             }],
-        }]
+        }],
     };
 }
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
@@ -8,8 +8,21 @@
 
 #import "NetworkLifecycleHandlerImpl.h"
 #import "../../../BugsnagPerformanceSpan+Private.h"
+#import "../../../OtlpTraceEncoding.h"
 
 using namespace bugsnag;
+
+static NSString *BSGPrettyJSONString(id object) {
+    if (object == nil || ![NSJSONSerialization isValidJSONObject:object]) {
+        return [object description];
+    }
+    NSError *error = nil;
+    NSData *data = [NSJSONSerialization dataWithJSONObject:object options:NSJSONWritingPrettyPrinted error:&error];
+    if (data == nil) {
+        return [NSString stringWithFormat:@"<unable to encode JSON preview: %@>", error];
+    }
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
 
 void
 NetworkLifecycleHandlerImpl::onInstrumentationConfigured(bool isEnabled,
@@ -34,9 +47,21 @@ NetworkLifecycleHandlerImpl::onTaskResume(NSURLSessionTask *task) noexcept {
         return;
     }
     auto state = initializeStateAndSaveIfNotVetoed(task,
-                                                   req.HTTPMethod,
-                                                   req.URL,
+                                                   req,
                                                    errorFromGetRequest);
+    if (state.graphQLAttributes != nil) {
+        BSGLogDebug(@"GraphQL span started: method=%@ endpoint=%@ name=%@ category=%@ display_name=%@ finalPayloadLog=\"GraphQL upload payload preview\"",
+                    req.HTTPMethod,
+                    state.url.path.length > 0 ? state.url.path : @"/",
+                    state.overallSpan.name,
+                    state.graphQLAttributes[@"bugsnag.span.category"],
+                    state.graphQLAttributes[@"display_name"]);
+    } else {
+        BSGLogDebug(@"Network span started: method=%@ endpoint=%@ category=network graphQLDetected=NO spanName=%@",
+                    req.HTTPMethod,
+                    state.url.path.length > 0 ? state.url.path : @"/",
+                    state.overallSpan.name);
+    }
     networkHeaderInjector_->injectTraceParentIfMatches(task, state.overallSpan);
 }
 
@@ -56,9 +81,59 @@ NetworkLifecycleHandlerImpl::onTaskDidFinishCollectingMetrics(NSURLSessionTask *
     }
     
     [state.overallSpan internalSetMultipleAttributes:spanAttributesProvider_->networkSpanAttributes(nil, task, metrics, error)];
+    // Network completion attributes contain the default network category. Reapply the
+    // GraphQL classification after them without reparsing the request body.
+    NSDictionary *graphQLAttributes = state.graphQLAttributes;
+    if (graphQLAttributes != nil) {
+        [state.overallSpan internalSetMultipleAttributes:graphQLAttributes];
+        auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
+       // auto request = systemUtils_->taskRequest(task, nil);
+        BSGLogDebug(@"GraphQL response completed: status=%ld durationMs=%.2f bytesSent=%lld bytesReceived=%lld name=%@ category=%@ display_name=%@ finalPayloadLog=\"GraphQL upload payload preview\"",
+                    (long)httpResponse.statusCode,
+                    metrics.taskInterval.duration * 1000.0,
+                    task.countOfBytesSent,
+                    task.countOfBytesReceived,
+                    state.overallSpan.name,
+                    graphQLAttributes[@"bugsnag.span.category"],
+                    graphQLAttributes[@"display_name"]);
+    } else {
+        auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
+        auto request = systemUtils_->taskRequest(task, nil);
+        BSGLogDebug(@"Network response completed: method=%@ endpoint=%@ category=network graphQLDetected=NO status=%ld durationMs=%.2f bytesSent=%lld bytesReceived=%lld spanName=%@",
+                    request.HTTPMethod,
+                    state.url.path.length > 0 ? state.url.path : @"/",
+                    (long)httpResponse.statusCode,
+                    metrics.taskInterval.duration * 1000.0,
+                    task.countOfBytesSent,
+                    task.countOfBytesReceived,
+                    state.overallSpan.name);
+    }
     [state.overallSpan endWithEndTime:metrics.taskInterval.endDate];
+    OtlpTraceEncoding encoder;
+    NSDictionary *resourceAttributes = resourceAttributes_ != nullptr ? resourceAttributes_->get() : @{};
+    NSDictionary *encodedPayloadPreview = @{
+        @"resourceSpans": @[@{
+            @"resource": @{
+                @"attributes": encoder.encode(resourceAttributes ?: @{}),
+            },
+            @"scopeSpans": @[@{
+                @"scope": @{
+                    @"name": @"bugsnag.performance",
+                },
+                @"spans": @[encoder.encode(state.overallSpan)],
+            }],
+        }],
+    };
+    if (graphQLAttributes != nil) {
+        BSGLogDebug(@"GraphQL encoded payload preview (single-span OTLP shape; real resource attributes are added during /v1/traces upload)=%@",
+                    BSGPrettyJSONString(encodedPayloadPreview));
+    } else {
+        BSGLogDebug(@"Network encoded payload preview (single-span OTLP shape; real resource attributes are added during /v1/traces upload)=%@",
+                    BSGPrettyJSONString(encodedPayloadPreview));
+    }
     repository_->setInstrumentationState(task, nil);
 }
+
 
 #pragma mark Helpers
 
@@ -120,16 +195,30 @@ NetworkLifecycleHandlerImpl::reportInternalErrorSpan(NSString *httpMethod,
     [span end];
 }
 
-NetworkInstrumentationState * 
+NetworkInstrumentationState *
 NetworkLifecycleHandlerImpl::initializeStateAndSaveIfNotVetoed(NSURLSessionTask *task,
-                                                               NSString *httpMethod,
-                                                               NSURL *originalUrl,
+                                                               NSURLRequest *request,
                                                                NSError *error) noexcept {
     auto state = [NetworkInstrumentationState new];
-    state.url = originalUrl;
+    state.url = request.URL;
     updateState(state);
     if (!state.hasBeenVetoed) {
-        state.overallSpan = spanFactory_->startOverallNetworkSpan(httpMethod, state.url, error);
+        auto graphQLAttributes = spanAttributesProvider_->graphQLAttributes(request, state.url);
+        NSString *graphQLSpanName = spanAttributesProvider_->graphQLSpanName(state.url, graphQLAttributes);
+        if (graphQLSpanName != nil) {
+            [graphQLAttributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
+            state.graphQLAttributes = graphQLAttributes;
+            SpanOptions options;
+            options.makeCurrentContext = false;
+            auto initialAttributes = spanAttributesProvider_->networkSpanUrlAttributes(state.url, error);
+            [initialAttributes addEntriesFromDictionary:graphQLAttributes];
+            state.overallSpan = spanFactory_->startNetworkSpan(graphQLSpanName,
+                                                               options,
+                                                               BSGTriStateYes,
+                                                               initialAttributes);
+        } else {
+            state.overallSpan = spanFactory_->startOverallNetworkSpan(request.HTTPMethod, state.url, error);
+        }
         repository_->setInstrumentationState(task, state);
         earlyPhaseHandler_->onNewStateCreated(state);
         return state;

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
@@ -108,9 +108,6 @@ NetworkLifecycleHandlerImpl::onTaskDidFinishCollectingMetrics(NSURLSessionTask *
     NSDictionary *graphQLAttributes = state.graphQLAttributes;
     if (graphQLAttributes != nil) {
         [state.overallSpan internalSetMultipleAttributes:graphQLAttributes];
-    } else {
-        auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
-        auto request = systemUtils_->taskRequest(task, nil);
     }
     [state.overallSpan endWithEndTime:metrics.taskInterval.endDate];
     repository_->setInstrumentationState(task, nil);

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
@@ -8,43 +8,8 @@
 
 #import "NetworkLifecycleHandlerImpl.h"
 #import "../../../BugsnagPerformanceSpan+Private.h"
-#import "../../../OtlpTraceEncoding.h"
 
 using namespace bugsnag;
-
-static NSString *BSGPrettyJSONString(id object) __attribute__((unused));
-static NSString *BSGPrettyJSONString(id object) {
-    if (object == nil || ![NSJSONSerialization isValidJSONObject:object]) {
-        return [object description];
-    }
-    NSError *error = nil;
-    NSData *data = [NSJSONSerialization dataWithJSONObject:object options:NSJSONWritingPrettyPrinted error:&error];
-    if (data == nil) {
-        return [NSString stringWithFormat:@"<unable to encode JSON preview: %@>", error];
-    }
-    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-}
-
-static NSDictionary *BSGEncodedPayloadPreview(std::shared_ptr<ResourceAttributes> resourceAttributes,
-                                              BugsnagPerformanceSpan *span) __attribute__((unused));
-static NSDictionary *BSGEncodedPayloadPreview(std::shared_ptr<ResourceAttributes> resourceAttributes,
-                                              BugsnagPerformanceSpan *span) {
-    OtlpTraceEncoding encoder;
-    NSDictionary *encodeResourceAttributes = resourceAttributes != nullptr ? resourceAttributes->get() : @{};
-    return @{
-        @"resourceSpans": @[@{
-            @"resource": @{
-                @"attributes": encoder.encode(encodeResourceAttributes ?: @{}),
-            },
-            @"scopeSpans": @[@{
-                @"scope": @{
-                    @"name": @"bugsnag.performance",
-                },
-                @"spans": @[encoder.encode(span)],
-            }],
-        }],
-    };
-}
 
 void
 NetworkLifecycleHandlerImpl::onInstrumentationConfigured(bool isEnabled,

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
@@ -8,8 +8,71 @@
 
 #import "NetworkLifecycleHandlerImpl.h"
 #import "../../../BugsnagPerformanceSpan+Private.h"
+#import "../../../Utils.h"
+#import "../../../SpanAttributesProvider.h"
 
 using namespace bugsnag;
+
+static NSString * const BSGGraphQLResponseHasErrorsAttribute = @"bugsnag.internal.graphql.response_has_errors";
+static const NSUInteger BSGMaxGraphQLResponseBodyInspectionBytes = 64 * 1024;
+
+extern "C" NSData *BSGCapturedGraphQLResponseBodyForTask(NSURLSessionTask *task);
+extern "C" void BSGClearCapturedGraphQLResponseBodyForTask(NSURLSessionTask *task);
+
+static BOOL BSGGraphQLResponseBodyHasErrors(NSData *body) {
+    if (body.length == 0 || body.length > BSGMaxGraphQLResponseBodyInspectionBytes) {
+        return NO;
+    }
+    
+    NSError *error = nil;
+    id json = [NSJSONSerialization JSONObjectWithData:body options:0 error:&error];
+    NSDictionary *dictionary = BSGDynamicCast<NSDictionary>(json);
+    NSArray *errors = BSGDynamicCast<NSArray>(dictionary[@"errors"]);
+    if (errors.count > 0) {
+        return YES;
+    }
+    if (errors != nil) {
+        return NO;
+    }
+    
+    // Some servers may return a JSON string containing encoded JSON. Parse that once more.
+    NSString *jsonString = BSGDynamicCast<NSString>(json);
+    if (dictionary == nil && jsonString.length > 0) {
+        NSData *nestedData = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
+        if (nestedData.length > 0) {
+            id nestedJson = [NSJSONSerialization JSONObjectWithData:nestedData options:0 error:nil];
+            NSDictionary *nestedDictionary = BSGDynamicCast<NSDictionary>(nestedJson);
+            NSArray *nestedErrors = BSGDynamicCast<NSArray>(nestedDictionary[@"errors"]);
+            if (nestedErrors.count > 0) {
+                return YES;
+            }
+            if (nestedErrors != nil) {
+                return NO;
+            }
+        }
+    }
+    
+    NSString *stringBody = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
+    if (stringBody.length == 0) {
+        return NO;
+    }
+    
+    NSString *normalizedBody = [[stringBody stringByReplacingOccurrencesOfString:@"\n" withString:@""]
+                                stringByReplacingOccurrencesOfString:@" " withString:@""];
+    NSString *looselyUnescapedBody = [normalizedBody stringByReplacingOccurrencesOfString:@"\\\"" withString:@"\""];
+    
+    BOOL hasExplicitEmptyErrorsArray = [normalizedBody containsString:@"\"errors\":[]"] ||
+    [normalizedBody containsString:@"\\\"errors\\\":[]"] ||
+    [looselyUnescapedBody containsString:@"\"errors\":[]"];
+    if (hasExplicitEmptyErrorsArray) {
+        return NO;
+    }
+    
+    BOOL hasErrorsArray = [normalizedBody containsString:@"\"errors\":["] ||
+    [normalizedBody containsString:@"\\\"errors\\\":["] ||
+    [looselyUnescapedBody containsString:@"\"errors\":["];
+    return hasErrorsArray;
+}
 
 void
 NetworkLifecycleHandlerImpl::onInstrumentationConfigured(bool isEnabled,
@@ -26,23 +89,26 @@ NetworkLifecycleHandlerImpl::onTaskResume(NSURLSessionTask *task) noexcept {
     if (!canTraceTask(task)) {
         return;
     }
-
+    
     NSError *errorFromGetRequest = nil;
     auto req = systemUtils_->taskRequest(task, &errorFromGetRequest);
-    if (req.URL == nil) {
+    if (req == nil || req.URL == nil) {
         reportInternalErrorSpan(req.HTTPMethod, errorFromGetRequest);
         return;
     }
     auto state = initializeStateAndSaveIfNotVetoed(task,
                                                    req,
                                                    errorFromGetRequest);
+    if (state == nil) {
+        return;
+    }
     if (state.graphQLAttributes != nil) {
         BSGLogDebug(@"GraphQL span started: method=%@ endpoint=%@ name=%@ category=%@ display_name=%@ finalPayloadLog=\"GraphQL upload payload preview\"",
                     req.HTTPMethod,
                     state.url.path.length > 0 ? state.url.path : @"/",
                     state.overallSpan.name,
-                    state.graphQLAttributes[@"bugsnag.span.category"],
-                    state.graphQLAttributes[@"display_name"]);
+                    state.graphQLAttributes[BSGSpanCategoryAttributeKey],
+                    state.graphQLAttributes[BSGSpanDisplayNameAttributeKey]);
     } else {
         BSGLogDebug(@"Network span started: method=%@ endpoint=%@ category=network graphQLDetected=NO spanName=%@",
                     req.HTTPMethod,
@@ -53,27 +119,94 @@ NetworkLifecycleHandlerImpl::onTaskResume(NSURLSessionTask *task) noexcept {
 }
 
 void
-NetworkLifecycleHandlerImpl::onTaskDidFinishCollectingMetrics(NSURLSessionTask *task,
+NetworkLifecycleHandlerImpl::onTaskDidFinishCollectingMetrics(
+                                                              NSURLSessionTask *task,
                                                               NSURLSessionTaskMetrics *metrics,
-                                                              NSString *ignoreBaseEndpoint) noexcept {
+                                                              NSString *ignoreBaseEndpoint) noexcept
+{
+    
     auto state = repository_->getInstrumentationState(task);
     if (state.overallSpan == nil) {
         return;
     }
+    
     NSError *error = nil;
+    
     if (!shouldRecordFinishedTask(task, ignoreBaseEndpoint, &error)) {
+        BSGClearCapturedGraphQLResponseBodyForTask(task);
         [state.overallSpan cancel];
         repository_->setInstrumentationState(task, nil);
         return;
     }
     
-    [state.overallSpan internalSetMultipleAttributes:spanAttributesProvider_->networkSpanAttributes(nil, task, metrics, error)];
-    // Network completion attributes contain the default network category. Reapply the
-    // GraphQL classification after them without reparsing the request body.
+    auto networkAttributes = spanAttributesProvider_->networkSpanAttributes(nil, task, metrics, error);
+    if (networkAttributes != nil) {
+        [state.overallSpan internalSetMultipleAttributes:networkAttributes];
+    }
+    
+    // Reapply GraphQL attributes (networkSpanAttributes overwrites category).
     NSDictionary *graphQLAttributes = state.graphQLAttributes;
+    
     if (graphQLAttributes != nil) {
         [state.overallSpan internalSetMultipleAttributes:graphQLAttributes];
+        
+        NSData *responseBody = BSGCapturedGraphQLResponseBodyForTask(task);
+        
+        NSHTTPURLResponse *httpResponse =
+        BSGDynamicCast<NSHTTPURLResponse>(task.response);
+        NSInteger statusCode = httpResponse ? httpResponse.statusCode : 0;
+        
+        if (responseBody.length == 0 && statusCode > 0 && statusCode < 400) {
+            // For completion-handler-based tasks, the response body is stored
+            // by the wrapped completion handler, which fires AFTER this callback.
+            // Defer span finalization to allow body capture to complete.
+            NSDate *endTime = metrics.taskInterval.endDate;
+            auto repo = repository_;
+            
+            dispatch_after(
+                           dispatch_time(DISPATCH_TIME_NOW, (int64_t)(100 * NSEC_PER_MSEC)),
+                           dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+                               
+                               NSData *deferredBody = BSGCapturedGraphQLResponseBodyForTask(task);
+                               
+                               BSGLogDebug(
+                                           @"GraphQL deferred body check: length=%lu hasErrors=%@",
+                                           (unsigned long)deferredBody.length,
+                                           BSGGraphQLResponseBodyHasErrors(deferredBody) ? @"YES" : @"NO"
+                                           );
+                               
+                               if (BSGGraphQLResponseBodyHasErrors(deferredBody)) {
+                                   [state.overallSpan internalSetAttribute:
+                                    BSGGraphQLResponseHasErrorsAttribute
+                                                                 withValue:@YES];
+                                   BSGLogDebug(
+                                               @"GraphQL response (deferred) contained errors; "
+                                               "status will be STATUS_CODE_ERROR"
+                                               );
+                               }
+                               
+                               BSGClearCapturedGraphQLResponseBodyForTask(task);
+                               [state.overallSpan endWithEndTime:endTime];
+                               repo->setInstrumentationState(task, nil);
+                           });
+            return; // Don't end span here — deferred block will do it
+        }
+        
+        // Body available immediately (delegate-based task) or HTTP error status
+        BOOL graphQLResponseHasErrors = BSGGraphQLResponseBodyHasErrors(responseBody);
+        
+        if (graphQLResponseHasErrors) {
+            [state.overallSpan internalSetAttribute:
+             BSGGraphQLResponseHasErrorsAttribute
+                                          withValue:@YES];
+            BSGLogDebug(
+                        @"GraphQL response contained a non-empty top-level errors "
+                        "array; span status will be STATUS_CODE_ERROR."
+                        );
+        }
     }
+    
+    BSGClearCapturedGraphQLResponseBodyForTask(task);
     [state.overallSpan endWithEndTime:metrics.taskInterval.endDate];
     repository_->setInstrumentationState(task, nil);
 }
@@ -116,19 +249,19 @@ NetworkLifecycleHandlerImpl::canTraceTask(NSURLSessionTask *task) noexcept {
         BSGLogTrace(@"Task %@ has nil request but we still want to trace it and report an error", task.class);
         return true;
     }
-
+    
     NSURL *url = req.URL;
     if (url == nil) {
         BSGLogTrace(@"Task %@ request has nil URL but we still want to trace it and report an error", task.class);
         return true;
     }
-
+    
     if ([url.scheme isEqualToString:@"file"]) {
         BSGLogTrace(@"Task %@ has forbidden file scheme in URL %@, so we won't trace it", task.class, url);
         // Don't track local activity.
         return false;
     }
-
+    
     return true;
 }
 
@@ -143,19 +276,29 @@ NetworkInstrumentationState *
 NetworkLifecycleHandlerImpl::initializeStateAndSaveIfNotVetoed(NSURLSessionTask *task,
                                                                NSURLRequest *request,
                                                                NSError *error) noexcept {
+    if (request == nil) {
+        return nil;
+    }
     auto state = [NetworkInstrumentationState new];
     state.url = request.URL;
     updateState(state);
     if (!state.hasBeenVetoed) {
         auto graphQLAttributes = spanAttributesProvider_->graphQLAttributes(request, state.url);
-        NSString *graphQLSpanName = spanAttributesProvider_->graphQLSpanName(state.url, graphQLAttributes);
-        if (graphQLSpanName != nil) {
-            [graphQLAttributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
+        NSString *graphQLSpanName = graphQLAttributes != nil
+            ? spanAttributesProvider_->graphQLSpanName(state.url, graphQLAttributes)
+            : nil;
+        if (graphQLSpanName != nil && graphQLAttributes != nil) {
+            [graphQLAttributes removeObjectsForKeys:@[BSGGraphQLOperationTypeAttributeKey,
+                                                      BSGGraphQLOperationNameAttributeKey]];
             state.graphQLAttributes = graphQLAttributes;
             SpanOptions options;
             options.makeCurrentContext = false;
             auto initialAttributes = spanAttributesProvider_->networkSpanUrlAttributes(state.url, error);
-            [initialAttributes addEntriesFromDictionary:graphQLAttributes];
+            if (initialAttributes != nil) {
+                [initialAttributes addEntriesFromDictionary:graphQLAttributes];
+            } else {
+                initialAttributes = graphQLAttributes.mutableCopy;
+            }
             state.overallSpan = spanFactory_->startNetworkSpan(graphQLSpanName,
                                                                options,
                                                                BSGTriStateYes,
@@ -169,6 +312,7 @@ NetworkLifecycleHandlerImpl::initializeStateAndSaveIfNotVetoed(NSURLSessionTask 
     }
     return nil;
 }
+
 
 void
 NetworkLifecycleHandlerImpl::endSpanOnDestroyIfNeeded(NetworkInstrumentationState *state) noexcept {
@@ -194,11 +338,11 @@ NetworkLifecycleHandlerImpl::shouldRecordFinishedTask(NSURLSessionTask *task,
     }
     auto request = systemUtils_->taskRequest(task, error);
     auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
-
+    
     if (httpResponse.statusCode == 0) {
         return false;
     }
-
+    
     if (ignoreBaseEndpoint.length > 0 && [request.URL.absoluteString hasPrefix:ignoreBaseEndpoint]) {
         return false;
     }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/Lifecycle/NetworkLifecycleHandlerImpl.mm
@@ -102,19 +102,6 @@ NetworkLifecycleHandlerImpl::onTaskResume(NSURLSessionTask *task) noexcept {
     if (state == nil) {
         return;
     }
-    if (state.graphQLAttributes != nil) {
-        BSGLogDebug(@"GraphQL span started: method=%@ endpoint=%@ name=%@ category=%@ display_name=%@ finalPayloadLog=\"GraphQL upload payload preview\"",
-                    req.HTTPMethod,
-                    state.url.path.length > 0 ? state.url.path : @"/",
-                    state.overallSpan.name,
-                    state.graphQLAttributes[BSGSpanCategoryAttributeKey],
-                    state.graphQLAttributes[BSGSpanDisplayNameAttributeKey]);
-    } else {
-        BSGLogDebug(@"Network span started: method=%@ endpoint=%@ category=network graphQLDetected=NO spanName=%@",
-                    req.HTTPMethod,
-                    state.url.path.length > 0 ? state.url.path : @"/",
-                    state.overallSpan.name);
-    }
     networkHeaderInjector_->injectTraceParentIfMatches(task, state.overallSpan);
 }
 
@@ -169,20 +156,10 @@ NetworkLifecycleHandlerImpl::onTaskDidFinishCollectingMetrics(
                                
                                NSData *deferredBody = BSGCapturedGraphQLResponseBodyForTask(task);
                                
-                               BSGLogDebug(
-                                           @"GraphQL deferred body check: length=%lu hasErrors=%@",
-                                           (unsigned long)deferredBody.length,
-                                           BSGGraphQLResponseBodyHasErrors(deferredBody) ? @"YES" : @"NO"
-                                           );
-                               
                                if (BSGGraphQLResponseBodyHasErrors(deferredBody)) {
                                    [state.overallSpan internalSetAttribute:
                                     BSGGraphQLResponseHasErrorsAttribute
                                                                  withValue:@YES];
-                                   BSGLogDebug(
-                                               @"GraphQL response (deferred) contained errors; "
-                                               "status will be STATUS_CODE_ERROR"
-                                               );
                                }
                                
                                BSGClearCapturedGraphQLResponseBodyForTask(task);
@@ -199,10 +176,6 @@ NetworkLifecycleHandlerImpl::onTaskDidFinishCollectingMetrics(
             [state.overallSpan internalSetAttribute:
              BSGGraphQLResponseHasErrorsAttribute
                                           withValue:@YES];
-            BSGLogDebug(
-                        @"GraphQL response contained a non-empty top-level errors "
-                        "array; span status will be STATUS_CODE_ERROR."
-                        );
         }
     }
     

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/State/NetworkInstrumentationState.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/State/NetworkInstrumentationState.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NetworkInstrumentationState : NSObject
 @property (nonatomic, nullable, strong) BugsnagPerformanceSpan *overallSpan;
 @property (nonatomic, nullable) NSURL *url;
+@property (nonatomic, nullable, copy) NSDictionary *graphQLAttributes;
 @property (nonatomic) BOOL hasBeenVetoed;
 @end
 

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/System/NetworkSwizzlingHandlerImpl.h
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/System/NetworkSwizzlingHandlerImpl.h
@@ -19,5 +19,6 @@ private:
     void instrumentSharedSession(BSGIsEnabledCallback isEnabled) noexcept;
     void instrumentSessionWithConfigurationDelegateQueue(id<NSURLSessionTaskDelegate> taskDelegate,
                                                          BSGIsEnabledCallback isEnabled) noexcept;
+    void instrumentSessionCompletionHandlers(BSGIsEnabledCallback isEnabled) noexcept;
 };
 }

--- a/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/System/NetworkSwizzlingHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/Instrumentation/NetworkInstrumentation/System/NetworkSwizzlingHandlerImpl.mm
@@ -11,14 +11,36 @@
 #import "Proxy/BSGPerformanceSharedSessionProxy.h"
 #import "../../../Swizzle.h"
 #import <objc/runtime.h>
+#import "../../../Logging.h"
 
 using namespace bugsnag;
+
+static const void *kGraphQLResponseBodyKey = &kGraphQLResponseBodyKey;
+static const NSUInteger kMaxCapturedGraphQLResponseBodyBytes = 64 * 1024;
+
+extern "C" void BSGAssociateGraphQLResponseBodyWithTask(NSURLSessionTask *task, NSData *body) {
+    if (task == nil || body.length == 0 || body.length > kMaxCapturedGraphQLResponseBodyBytes) {
+        return;
+    }
+    objc_setAssociatedObject(task, kGraphQLResponseBodyKey, body, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+extern "C" NSData *BSGCapturedGraphQLResponseBodyForTask(NSURLSessionTask *task) {
+    return task == nil ? nil : objc_getAssociatedObject(task, kGraphQLResponseBodyKey);
+}
+
+extern "C" void BSGClearCapturedGraphQLResponseBodyForTask(NSURLSessionTask *task) {
+    if (task != nil) {
+        objc_setAssociatedObject(task, kGraphQLResponseBodyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
 
 void
 NetworkSwizzlingHandlerImpl::instrumentSession(id<NSURLSessionTaskDelegate> taskDelegate,
                                                BSGIsEnabledCallback isEnabled) noexcept {
     instrumentSessionWithConfigurationDelegateQueue(taskDelegate, isEnabled);
     instrumentSharedSession(isEnabled);
+    instrumentSessionCompletionHandlers(isEnabled);
 }
 
 void
@@ -91,5 +113,73 @@ NetworkSwizzlingHandlerImpl::instrumentSessionWithConfigurationDelegateQueue(id<
             sessionDelegate = taskDelegate;
         }
         return originalIMP(self, selector, configuration, sessionDelegate, queue);
+    });
+}
+
+void
+NetworkSwizzlingHandlerImpl::instrumentSessionCompletionHandlers(BSGIsEnabledCallback isEnabled) noexcept {
+    __weak BSGIsEnabledCallback weakIsEnabled = isEnabled;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        {
+            SEL selector = @selector(dataTaskWithRequest:completionHandler:);
+            typedef NSURLSessionDataTask *(*IMPPrototype)(id, SEL, NSURLRequest *, void (^)(NSData *, NSURLResponse *, NSError *));
+            __block IMPPrototype originalIMP = (IMPPrototype)ObjCSwizzle::replaceInstanceMethodOverride(NSURLSession.class, selector,
+                ^NSURLSessionDataTask *(NSURLSession *session, NSURLRequest *request, void (^completionHandler)(NSData *, NSURLResponse *, NSError *)) {
+                    BSGIsEnabledCallback localIsEnabled = weakIsEnabled;
+                    if (localIsEnabled != nil && !localIsEnabled()) {
+                        return originalIMP(session, selector, request, completionHandler);
+                    }
+                    __block NSURLSessionDataTask *task = nil;
+                    void (^wrappedCompletion)(NSData *, NSURLResponse *, NSError *) = ^(NSData *data, NSURLResponse *response, NSError *error) {
+                        BSGAssociateGraphQLResponseBodyWithTask(task, data);
+                        if (completionHandler != nil) {
+                            completionHandler(data, response, error);
+                        }
+                    };
+                    task = originalIMP(session, selector, request, wrappedCompletion);
+                    return task;
+                });
+        }
+        {
+            SEL selector = @selector(dataTaskWithURL:completionHandler:);
+            typedef NSURLSessionDataTask *(*IMPPrototype)(id, SEL, NSURL *, void (^)(NSData *, NSURLResponse *, NSError *));
+            __block IMPPrototype originalIMP = (IMPPrototype)ObjCSwizzle::replaceInstanceMethodOverride(NSURLSession.class, selector,
+                ^NSURLSessionDataTask *(NSURLSession *session, NSURL *url, void (^completionHandler)(NSData *, NSURLResponse *, NSError *)) {
+                    BSGIsEnabledCallback localIsEnabled = weakIsEnabled;
+                    if (localIsEnabled != nil && !localIsEnabled()) {
+                        return originalIMP(session, selector, url, completionHandler);
+                    }
+                    __block NSURLSessionDataTask *task = nil;
+                    void (^wrappedCompletion)(NSData *, NSURLResponse *, NSError *) = ^(NSData *data, NSURLResponse *response, NSError *error) {
+                        BSGAssociateGraphQLResponseBodyWithTask(task, data);
+                        if (completionHandler != nil) {
+                            completionHandler(data, response, error);
+                        }
+                    };
+                    task = originalIMP(session, selector, url, wrappedCompletion);
+                    return task;
+                });
+        }
+        {
+            SEL selector = @selector(uploadTaskWithRequest:fromData:completionHandler:);
+            typedef NSURLSessionUploadTask *(*IMPPrototype)(id, SEL, NSURLRequest *, NSData *, void (^)(NSData *, NSURLResponse *, NSError *));
+            __block IMPPrototype originalIMP = (IMPPrototype)ObjCSwizzle::replaceInstanceMethodOverride(NSURLSession.class, selector,
+                ^NSURLSessionUploadTask *(NSURLSession *session, NSURLRequest *request, NSData *bodyData, void (^completionHandler)(NSData *, NSURLResponse *, NSError *)) {
+                    BSGIsEnabledCallback localIsEnabled = weakIsEnabled;
+                    if (localIsEnabled != nil && !localIsEnabled()) {
+                        return originalIMP(session, selector, request, bodyData, completionHandler);
+                    }
+                    __block NSURLSessionUploadTask *task = nil;
+                    void (^wrappedCompletion)(NSData *, NSURLResponse *, NSError *) = ^(NSData *data, NSURLResponse *response, NSError *error) {
+                        BSGAssociateGraphQLResponseBodyWithTask(task, data);
+                        if (completionHandler != nil) {
+                            completionHandler(data, response, error);
+                        }
+                    };
+                    task = originalIMP(session, selector, request, bodyData, wrappedCompletion);
+                    return task;
+                });
+        }
     });
 }

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -144,6 +144,9 @@ OtlpTraceEncoding::encode(NSArray<BugsnagPerformanceSpan *> *spans, NSDictionary
                 // Semantically when InstrumentationScope isn't set, it is equivalent with
                 // an empty instrumentation scope name (unknown).
                 // @"scope": ...
+                @"scope": @{
+                    @"name": @"bugsnag.performance",
+                },
                 
                 // A list of Spans that originate from an instrumentation scope.
                 @"spans": encodedSpans,

--- a/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
+++ b/Sources/BugsnagPerformance/Private/OtlpTraceEncoding.mm
@@ -13,6 +13,8 @@
 
 using namespace bugsnag;
 
+static NSString * const BSGGraphQLResponseHasErrorsAttribute = @"bugsnag.internal.graphql.response_has_errors";
+
 static NSString * EncodeSpanId(SpanId const &spanId) {
     return [NSString stringWithFormat:@"%016llx", spanId];
 }
@@ -23,6 +25,30 @@ static NSString * EncodeTraceId(uint64_t traceIdHi, uint64_t traceIdLo) {
 
 static NSString * EncodeCFAbsoluteTime(CFAbsoluteTime time) {
     return [NSString stringWithFormat:@"%llu", absoluteTimeToNanoseconds(time)];
+}
+
+static NSString *GraphQLStatusCode(BugsnagPerformanceSpan *span) {
+    if (![span.attributes[@"bugsnag.span.category"] isEqual:@"graphql"]) {
+        return nil;
+    }
+    
+    NSNumber *graphQLResponseHasErrors =
+    BSGDynamicCast<NSNumber>(span.attributes[BSGGraphQLResponseHasErrorsAttribute]);
+    
+    if (graphQLResponseHasErrors.boolValue) {
+        return @"STATUS_CODE_ERROR";
+    }
+    
+    NSNumber *httpStatusCode =
+    BSGDynamicCast<NSNumber>(span.attributes[@"http.status_code"]);
+    
+    if (httpStatusCode == nil || httpStatusCode.integerValue <= 0) {
+        return nil;
+    }
+    
+    return httpStatusCode.integerValue < 400
+    ? @"STATUS_CODE_OK"
+    : @"STATUS_CODE_ERROR";
 }
 
 NSDictionary *
@@ -104,6 +130,11 @@ OtlpTraceEncoding::encode(BugsnagPerformanceSpan *span) noexcept {
     // Attribute keys MUST be unique (it is not allowed to have more than one
     // attribute with the same key).
     result[@"attributes"] = encode(span.attributes);
+
+    NSString *graphQLStatusCode = GraphQLStatusCode(span);
+        if (graphQLStatusCode != nil) {
+            result[@"status"] = @{@"code": graphQLStatusCode};
+        }
 
     return result;
 }
@@ -273,6 +304,12 @@ NSArray<NSDictionary *> *
 OtlpTraceEncoding::encode(NSDictionary *attributes) noexcept {
     auto result = [NSMutableArray array];
     for (NSString *key in attributes) {
+        if ([key isEqualToString:BSGGraphQLResponseHasErrorsAttribute]) {
+            continue;
+        }
+        if ([key isEqualToString:@"display_name"]) {
+            continue;
+        }
         id value = attributes[key];
         if ([value isKindOfClass:[NSString class]]) {
             encodeStringAttribute(result, key, value);
@@ -356,11 +393,12 @@ std::unique_ptr<OtlpPackage> OtlpTraceEncoding::buildUploadPackage(NSArray<Bugsn
     auto encodedSpans = encode(spans, resourceAttributes);
 
     NSError *error = nil;
-    auto payload = [NSJSONSerialization dataWithJSONObject:encodedSpans options:0 error:&error];
-    if (!payload) {
+    NSData * _Nullable serializedPayload = [NSJSONSerialization dataWithJSONObject:encodedSpans options:0 error:&error];
+    if (!serializedPayload) {
         NSCAssert(NO, @"%@", error);
         return nullptr;
     }
+    NSData * _Nonnull payload = (NSData * _Nonnull)serializedPayload;
 
     NSMutableDictionary *headers = [@{
         @"Content-Type": @"application/json",
@@ -373,11 +411,12 @@ std::unique_ptr<OtlpPackage> OtlpTraceEncoding::buildUploadPackage(NSArray<Bugsn
     }
 
     if (payload.length > MIN_SIZE_FOR_GZIP) {
-        payload = [Gzip gzipped:(NSData * _Nonnull)payload error:&error];
-        if (payload == nil || error != nil) {
+        NSData * _Nullable compressedPayload = [Gzip gzipped:payload error:&error];
+        if (compressedPayload == nil || error != nil) {
             BSGLogError(@"error compressing payload: %@", error);
             return nullptr;
         }
+        payload = (NSData * _Nonnull)compressedPayload;
         headers[@"Content-Encoding"] = @"gzip";
     }
 

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -20,7 +20,9 @@ public:
     NSMutableDictionary *networkSpanUrlAttributes(NSURL *url, NSError *encounteredError) noexcept;
     NSMutableDictionary *networkSpanAttributes(NSURL *url, NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics,
                                                NSError *encounteredError) noexcept;
-    
+    NSMutableDictionary *graphQLAttributes(NSURLRequest *request, NSURL *reportedURL) noexcept;
+    NSString *graphQLSpanName(NSURL *reportedURL, NSDictionary *graphQLAttributes) noexcept;
+
     NSMutableDictionary *internalErrorAttributes(NSError *encounteredError) noexcept;
     
     NSMutableDictionary *initialAppStartSpanAttributes() noexcept;

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.h
@@ -11,6 +11,14 @@
 #import "SessionMetricsAccumulator.h"
 
 namespace bugsnag {
+
+extern NSString * const BSGSpanCategoryAttributeKey;
+extern NSString * const BSGSpanDisplayNameAttributeKey;
+extern NSString * const BSGGraphQLOperationTypeAttributeKey;
+extern NSString * const BSGGraphQLOperationNameAttributeKey;
+extern NSString * const BSGSpanCategoryGraphQL;
+extern NSString * const BSGSpanCategoryNetwork;
+
 class SpanAttributesProvider {
 public:
     SpanAttributesProvider() noexcept;

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -22,6 +22,8 @@ static NSDictionary *accessTechnologyMappingDictionary();
 static NSString * const networkSubtypeKey = @"0000000100000001";
 static NSString * const connectionTypeCell = @"cell";
 static NSString * const BSGSpanCategoryAppSession = @"app_session";
+static const NSUInteger graphQLMaximumBodySize = 64 * 1024;
+static const NSUInteger graphQLMaximumOperationNameLength = 256;
 
 static NSString *sanitizeSessionTypeIdentifier(NSString *sessionType) {
     NSCharacterSet *separatorCharacterSet = [[NSCharacterSet alphanumericCharacterSet] invertedSet];
@@ -126,6 +128,194 @@ static void addNonZero(NSMutableDictionary *dict, NSString *key, NSNumber *value
     }
 }
 
+static BOOL isGraphQLNameCharacter(unichar character, BOOL firstCharacter) {
+    BOOL isLetter = (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z');
+    return isLetter || character == '_' || (!firstCharacter && character >= '0' && character <= '9');
+}
+
+static NSString *validatedGraphQLOperationName(id value) {
+    if (![value isKindOfClass:NSString.class]) return nil;
+    NSString *name = value;
+    if (name.length == 0 || name.length > graphQLMaximumOperationNameLength) return nil;
+    for (NSUInteger index = 0; index < name.length; index++) {
+        if (!isGraphQLNameCharacter([name characterAtIndex:index], index == 0)) return nil;
+    }
+    return name;
+}
+
+static NSUInteger skipGraphQLIgnoredCharacters(NSString *document, NSUInteger index) {
+    while (index < document.length) {
+        unichar character = [document characterAtIndex:index];
+        if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:character] || character == ',' || character == 0xFEFF) {
+            index++;
+        } else if (character == '#') {
+            while (index < document.length && [document characterAtIndex:index] != '\n' && [document characterAtIndex:index] != '\r') index++;
+        } else {
+            break;
+        }
+    }
+    return index;
+}
+
+static NSString *readGraphQLName(NSString *document, NSUInteger *index) {
+    NSUInteger start = *index;
+    if (start >= document.length || !isGraphQLNameCharacter([document characterAtIndex:start], YES)) return nil;
+    (*index)++;
+    while (*index < document.length && isGraphQLNameCharacter([document characterAtIndex:*index], NO)) (*index)++;
+    return [document substringWithRange:NSMakeRange(start, *index - start)];
+}
+
+static NSUInteger skipGraphQLString(NSString *document, NSUInteger index) {
+    BOOL blockString = index + 2 < document.length && [document characterAtIndex:index + 1] == '"' && [document characterAtIndex:index + 2] == '"';
+    index += blockString ? 3 : 1;
+    while (index < document.length) {
+        if (blockString && index + 2 < document.length && [document characterAtIndex:index] == '"' &&
+            [document characterAtIndex:index + 1] == '"' && [document characterAtIndex:index + 2] == '"') return index + 3;
+        unichar character = [document characterAtIndex:index++];
+        if (!blockString && character == '\\' && index < document.length) index++;
+        else if (!blockString && character == '"') return index;
+    }
+    return index;
+}
+
+static void extractGraphQLOperation(NSString *document,
+                                    NSString *requestedOperationName,
+                                    NSString **operationType,
+                                    NSString **operationName) {
+    // The ED requires query as the fallback when the document does not expose an
+    // explicit query, mutation, or subscription keyword.
+    *operationType = @"query";
+    *operationName = requestedOperationName;
+    if (![document isKindOfClass:NSString.class] || document.length == 0) return;
+    NSUInteger index = 0;
+    NSUInteger selectionDepth = 0;
+    BOOL atDefinitionStart = YES;
+    while (index < document.length) {
+        index = skipGraphQLIgnoredCharacters(document, index);
+        if (index >= document.length) break;
+        unichar character = [document characterAtIndex:index];
+        if (character == '"') {
+            index = skipGraphQLString(document, index);
+            atDefinitionStart = NO;
+        } else if (character == '{') {
+            if (selectionDepth == 0 && atDefinitionStart && requestedOperationName == nil) {
+                *operationType = @"query";
+                return;
+            }
+            selectionDepth++;
+            atDefinitionStart = NO;
+            index++;
+        } else if (character == '}') {
+            if (selectionDepth > 0 && --selectionDepth == 0) atDefinitionStart = YES;
+            index++;
+        } else if (selectionDepth == 0 && atDefinitionStart && isGraphQLNameCharacter(character, YES)) {
+            NSString *token = readGraphQLName(document, &index);
+            BOOL isOperation = [token isEqualToString:@"query"] || [token isEqualToString:@"mutation"] || [token isEqualToString:@"subscription"];
+            if (isOperation) {
+                index = skipGraphQLIgnoredCharacters(document, index);
+                NSString *declaredName = readGraphQLName(document, &index);
+                if (requestedOperationName == nil || [declaredName isEqualToString:requestedOperationName]) {
+                    *operationType = token;
+                    if (requestedOperationName == nil) *operationName = validatedGraphQLOperationName(declaredName);
+                    return;
+                }
+            }
+            atDefinitionStart = NO;
+        } else {
+            index++;
+        }
+    }
+}
+
+static BOOL dataContainsGraphQLJSONKey(NSData *data) {
+    static NSArray<NSData *> *operationKeys;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        operationKeys = @[
+            (NSData * _Nonnull)[@"\"query\"" dataUsingEncoding:NSUTF8StringEncoding],
+            (NSData * _Nonnull)[@"\"mutation\"" dataUsingEncoding:NSUTF8StringEncoding],
+            (NSData * _Nonnull)[@"\"subscription\"" dataUsingEncoding:NSUTF8StringEncoding],
+        ];
+    });
+    for (NSData *key in operationKeys) {
+        if ([data rangeOfData:key options:0 range:NSMakeRange(0, data.length)].location != NSNotFound) return YES;
+    }
+    return NO;
+}
+
+static BOOL isGraphQLEndpointPath(NSString *path) {
+    for (NSString *component in path.pathComponents) {
+        if ([component caseInsensitiveCompare:@"graphql"] == NSOrderedSame) return YES;
+    }
+    return NO;
+}
+
+static BOOL addGraphQLDocumentAttributes(NSMutableDictionary *attributes,
+                                         NSString *document,
+                                         NSString *requestedName,
+                                         NSString *hintedType,
+                                         NSURL *url) {
+    if (url == nil) return NO;
+    // Avoid false positives: endpoint/content-type hints alone are not enough
+    // to construct GraphQL semantics. We only classify when a readable GraphQL
+    // document is available. This keeps ordinary HTTP traffic in the existing
+    // network category, as required by the ED.
+    if (![document isKindOfClass:NSString.class] ||
+        document.length == 0 ||
+        [document rangeOfString:@"{"].location == NSNotFound) {
+        return NO;
+    }
+    NSString *endpoint = url.path.length > 0 ? url.path : @"/";
+    NSString *operationType = nil;
+    NSString *operationName = nil;
+    extractGraphQLOperation(document,
+                            validatedGraphQLOperationName(requestedName),
+                            &operationType,
+                            &operationName);
+    if (hintedType.length > 0 && [operationType isEqualToString:@"query"] &&
+        [document rangeOfString:@"mutation" options:NSCaseInsensitiveSearch].location == NSNotFound &&
+        [document rangeOfString:@"subscription" options:NSCaseInsensitiveSearch].location == NSNotFound) {
+        operationType = hintedType;
+    }
+
+    attributes[@"bugsnag.span.category"] = @"graphql";
+    attributes[@"bugsnag.span.first_class"] = @YES;
+    // These two values are temporary SDK metadata used to construct the internal
+    // span name. Callers remove them before attaching attributes to the span.
+    attributes[@"graphql.operation.type"] = operationType;
+    if (operationName != nil) attributes[@"graphql.operation.name"] = operationName;
+    attributes[@"display_name"] = operationName == nil
+        ? [NSString stringWithFormat:@"%@ %@", operationType, endpoint]
+        : [NSString stringWithFormat:@"%@ %@ (%@)", operationType, endpoint, operationName];
+    BSGLogDebug(@"GraphQL operation extracted: endpoint=%@ operationType=%@ operationName=%@ displayName=%@",
+                endpoint,
+                operationType,
+                operationName ?: @"<anonymous>",
+                attributes[@"display_name"]);
+    BSGLogDebug(@"GraphQL request detected: endpoint=%@ operationType=%@ operationName=%@ attributes=%@",
+                endpoint,
+                operationType,
+                operationName ?: @"<anonymous>",
+                attributes);
+    return YES;
+}
+
+static BOOL addGraphQLPayloadAttributes(NSMutableDictionary *attributes, NSDictionary *payload, NSURL *url) {
+    NSArray<NSString *> *keys = @[@"query", @"mutation", @"subscription"];
+    for (NSString *key in keys) {
+        NSString *document = [payload[key] isKindOfClass:NSString.class] ? payload[key] : nil;
+        if (document.length > 0 && [document rangeOfString:@"{"].location != NSNotFound) {
+            NSString *hintedType = [key isEqualToString:@"query"] ? nil : key;
+            return addGraphQLDocumentAttributes(attributes,
+                                                document,
+                                                payload[@"operationName"],
+                                                hintedType,
+                                                url);
+        }
+    }
+    return NO;
+}
+
 static uint64_t CFAbsoluteTimeToUTCNanos(CFAbsoluteTime time) {
     return (uint64_t)((time + kCFAbsoluteTimeIntervalSince1970) * NSEC_PER_SEC);
 }
@@ -164,6 +354,119 @@ SpanAttributesProvider::networkSpanAttributes(NSURL *url,
     addNonZero(attributes, @"http.response_content_length", @(task.countOfBytesReceived));
     return attributes;
 }
+
+NSMutableDictionary *
+SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reportedURL) noexcept {
+    auto attributes = [NSMutableDictionary new];
+    @try {
+        NSString *method = request.HTTPMethod.uppercaseString;
+        NSString *contentType = [[request valueForHTTPHeaderField:@"Content-Type"] lowercaseString];
+        BOOL graphQLContentType = [contentType rangeOfString:@"application/graphql"].location != NSNotFound;
+        NSString *reportedPath = reportedURL.path ?: @"";
+        BOOL graphQLEndpoint = isGraphQLEndpointPath(reportedPath);
+
+        if ([method isEqualToString:@"GET"]) {
+            NSURL *url = request.URL;
+            NSString *queryString = url.query;
+            if (url != nil && queryString.length > 0 && queryString.length <= graphQLMaximumBodySize) {
+                NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+                NSMutableDictionary *payload = [NSMutableDictionary new];
+                for (NSURLQueryItem *item in components.queryItems) {
+                    if ([item.name isEqualToString:@"query"] ||
+                        [item.name isEqualToString:@"mutation"] ||
+                        [item.name isEqualToString:@"subscription"] ||
+                        [item.name isEqualToString:@"operationName"]) {
+                        payload[item.name] = item.value;
+                    }
+                }
+                if (addGraphQLPayloadAttributes(attributes, payload, reportedURL)) return attributes;
+            }
+            if (graphQLContentType || graphQLEndpoint) {
+                BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ reason=GET request had GraphQL hint but no readable query parameter",
+                            method,
+                            reportedURL.path.length > 0 ? reportedURL.path : @"/");
+            }
+            return attributes;
+        }
+        if (![method isEqualToString:@"POST"]) return attributes;
+        if (request.HTTPBodyStream != nil) {
+            BSGLogDebug(@"GraphQL request was not inspected: streamed POST bodies are unsupported; request remains category=network");
+            return attributes;
+        }
+        BOOL jsonContentType = contentType.length == 0 || [contentType rangeOfString:@"json"].location != NSNotFound;
+        if (!jsonContentType && !graphQLContentType && !graphQLEndpoint) {
+            BSGLogDebug(@"GraphQL request was not inspected: non-JSON Content-Type");
+            return attributes;
+        }
+        NSData *body = request.HTTPBody;
+        if (body.length == 0) {
+            if (graphQLContentType || graphQLEndpoint) {
+                BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ reason=GraphQL hint present but request body is empty",
+                            method,
+                            reportedURL.path.length > 0 ? reportedURL.path : @"/");
+            }
+            return attributes;
+        }
+        if (body.length > graphQLMaximumBodySize) {
+            BSGLogDebug(@"GraphQL request was not inspected: body size %lu exceeds the %lu-byte limit",
+                        (unsigned long)body.length,
+                        (unsigned long)graphQLMaximumBodySize);
+            return attributes;
+        }
+
+        if (graphQLContentType) {
+            NSString *document = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
+            addGraphQLDocumentAttributes(attributes, document, nil, nil, reportedURL);
+            return attributes;
+        }
+
+        if (dataContainsGraphQLJSONKey(body)) {
+            BSGLogDebug(@"GraphQL JSON candidate found: method=POST endpoint=%@ bodyBytes=%lu",
+                        reportedURL.path.length > 0 ? reportedURL.path : @"/",
+                        (unsigned long)body.length);
+            id json = [NSJSONSerialization JSONObjectWithData:body options:0 error:nil];
+            if ([json isKindOfClass:NSDictionary.class]) {
+                if (addGraphQLPayloadAttributes(attributes, json, reportedURL)) return attributes;
+            }
+            // Batches remain out of scope even when the endpoint path contains /graphql.
+            if ([json isKindOfClass:NSArray.class]) return attributes;
+            BSGLogDebug(@"GraphQL candidate did not expose usable operation metadata");
+        }
+        if (graphQLEndpoint) {
+            id endpointJSON = jsonContentType
+                ? [NSJSONSerialization JSONObjectWithData:body options:0 error:nil]
+                : nil;
+            if ([endpointJSON isKindOfClass:NSArray.class]) return attributes;
+            NSString *requestedName = [endpointJSON isKindOfClass:NSDictionary.class]
+                ? endpointJSON[@"operationName"]
+                : nil;
+            (void)requestedName;
+            BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ reason=/graphql endpoint body did not contain a readable GraphQL document",
+                        method,
+                        reportedURL.path.length > 0 ? reportedURL.path : @"/");
+        }
+        if (attributes.count == 0) {
+            BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ contentType=%@ reason=no GraphQL URL/content-type/query body signal; request remains category=network",
+                        method,
+                        reportedURL.path.length > 0 ? reportedURL.path : @"/",
+                        contentType.length > 0 ? contentType : @"none");
+        }
+    } @catch (NSException *exception) {
+        BSGLogDebug(@"Could not inspect request for GraphQL attributes: %@", exception.reason);
+        [attributes removeAllObjects];
+    }
+    return attributes;
+}
+
+NSString *
+SpanAttributesProvider::graphQLSpanName(NSURL *reportedURL, NSDictionary *attributes) noexcept {
+    (void)reportedURL;
+    if (![attributes[@"bugsnag.span.category"] isEqualToString:@"graphql"]) return nil;
+    NSString *operationType = attributes[@"graphql.operation.type"] ?: @"query";
+    NSString *operationName = attributes[@"graphql.operation.name"] ?: @"<anonymous>";
+    return [NSString stringWithFormat:@"[GraphQL] %@:%@", operationType, operationName];
+}
+
 
 NSMutableDictionary *
 SpanAttributesProvider::networkSpanUrlAttributes(NSURL *url, NSError *encounteredError) noexcept {

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -360,8 +360,8 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
     auto attributes = [NSMutableDictionary new];
     @try {
         NSString *method = request.HTTPMethod.uppercaseString;
-        NSString *contentType = [[request valueForHTTPHeaderField:@"Content-Type"] lowercaseString];
-        BOOL graphQLContentType = [contentType rangeOfString:@"application/graphql"].location != NSNotFound;
+        NSString *contentType = [[request valueForHTTPHeaderField:@"Content-Type"] lowercaseString] ?: @"";
+        BOOL graphQLContentType = contentType.length > 0 && [contentType rangeOfString:@"application/graphql"].location != NSNotFound;
         NSString *reportedPath = reportedURL.path ?: @"";
         BOOL graphQLEndpoint = isGraphQLEndpointPath(reportedPath);
 
@@ -393,7 +393,8 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
             BSGLogDebug(@"GraphQL request was not inspected: streamed POST bodies are unsupported; request remains category=network");
             return attributes;
         }
-        BOOL jsonContentType = contentType.length == 0 || [contentType rangeOfString:@"json"].location != NSNotFound;
+        BOOL jsonContentType = contentType.length == 0 ||
+            [contentType rangeOfString:@"json"].location != NSNotFound;
         if (!jsonContentType && !graphQLContentType && !graphQLEndpoint) {
             BSGLogDebug(@"GraphQL request was not inspected: non-JSON Content-Type");
             return attributes;

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -298,16 +298,6 @@ static BOOL addGraphQLDocumentAttributes(NSMutableDictionary *attributes,
     attributes[BSGSpanDisplayNameAttributeKey] = operationName == nil
         ? [NSString stringWithFormat:@"%@ %@", operationType, endpoint]
         : [NSString stringWithFormat:@"%@ %@ (%@)", operationType, endpoint, operationName];
-    BSGLogDebug(@"GraphQL operation extracted: endpoint=%@ operationType=%@ operationName=%@ displayName=%@",
-                endpoint,
-                operationType,
-                operationName ?: @"<anonymous>",
-                attributes[@"display_name"]);
-    BSGLogDebug(@"GraphQL request detected: endpoint=%@ operationType=%@ operationName=%@ attributes=%@",
-                endpoint,
-                operationType,
-                operationName ?: @"<anonymous>",
-                attributes);
     return YES;
 }
 
@@ -393,7 +383,7 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
                 if (addGraphQLPayloadAttributes(attributes, payload, reportedURL)) return attributes;
             }
             if (graphQLContentType || graphQLEndpoint) {
-                BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ reason=GET request had GraphQL hint but no readable query parameter",
+                BSGLogTrace(@"GraphQL request not detected: method=%@ endpoint=%@ reason=GET request had GraphQL hint but no readable query parameter",
                             method,
                             reportedURL.path ?: @"");
             }
@@ -401,28 +391,23 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
         }
         if (![method isEqualToString:@"POST"]) return attributes;
         if (request.HTTPBodyStream != nil) {
-            BSGLogDebug(@"GraphQL request was not inspected: streamed POST bodies are unsupported; request remains category=network");
             return attributes;
         }
         BOOL jsonContentType = contentType.length == 0 ||
             [contentType rangeOfString:@"json"].location != NSNotFound;
         if (!jsonContentType && !graphQLContentType && !graphQLEndpoint) {
-            BSGLogDebug(@"GraphQL request was not inspected: non-JSON Content-Type");
             return attributes;
         }
         NSData *body = request.HTTPBody;
         if (body.length == 0) {
             if (graphQLContentType || graphQLEndpoint) {
-                BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ reason=GraphQL hint present but request body is empty",
+                BSGLogTrace(@"GraphQL request not detected: method=%@ endpoint=%@ reason=GraphQL hint present but request body is empty",
                             method,
                             reportedURL.path ?: @"");
             }
             return attributes;
         }
         if (body.length > graphQLMaximumBodySize) {
-            BSGLogDebug(@"GraphQL request was not inspected: body size %lu exceeds the %lu-byte limit",
-                        (unsigned long)body.length,
-                        (unsigned long)graphQLMaximumBodySize);
             return attributes;
         }
 
@@ -433,16 +418,13 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
         }
 
         if (dataContainsGraphQLJSONKey(body)) {
-            BSGLogDebug(@"GraphQL JSON candidate found: method=POST endpoint=%@ bodyBytes=%lu",
-                        reportedURL.path ?: @"",
-                        (unsigned long)body.length);
             id json = [NSJSONSerialization JSONObjectWithData:body options:0 error:nil];
             if ([json isKindOfClass:NSDictionary.class]) {
                 if (addGraphQLPayloadAttributes(attributes, json, reportedURL)) return attributes;
             }
             // Batches remain out of scope even when the endpoint path contains /graphql.
             if ([json isKindOfClass:NSArray.class]) return attributes;
-            BSGLogDebug(@"GraphQL candidate did not expose usable operation metadata");
+            BSGLogTrace(@"GraphQL candidate did not expose usable operation metadata");
         }
         if (graphQLEndpoint) {
             id endpointJSON = jsonContentType
@@ -453,18 +435,15 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
                 ? endpointJSON[@"operationName"]
                 : nil;
             (void)requestedName;
-            BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ reason=/graphql endpoint body did not contain a readable GraphQL document",
-                        method,
-                        reportedURL.path ?: @"");
         }
         if (attributes.count == 0) {
-            BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ contentType=%@ reason=no GraphQL URL/content-type/query body signal; request remains category=network",
+            BSGLogTrace(@"GraphQL request not detected: method=%@ endpoint=%@ contentType=%@ reason=no GraphQL URL/content-type/query body signal; request remains category=network",
                         method,
                         reportedURL.path ?: @"",
                         contentType.length > 0 ? contentType : @"none");
         }
     } @catch (NSException *exception) {
-        BSGLogDebug(@"Could not inspect request for GraphQL attributes: %@", exception.reason);
+        BSGLogTrace(@"Could not inspect request for GraphQL attributes: %@", exception.reason);
         [attributes removeAllObjects];
     }
     return attributes;

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -395,7 +395,7 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
             if (graphQLContentType || graphQLEndpoint) {
                 BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ reason=GET request had GraphQL hint but no readable query parameter",
                             method,
-                            reportedURL.path.length > 0 ? reportedURL.path : @"/");
+                            reportedURL.path ?: @"");
             }
             return attributes;
         }
@@ -415,7 +415,7 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
             if (graphQLContentType || graphQLEndpoint) {
                 BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ reason=GraphQL hint present but request body is empty",
                             method,
-                            reportedURL.path.length > 0 ? reportedURL.path : @"/");
+                            reportedURL.path ?: @"");
             }
             return attributes;
         }
@@ -434,7 +434,7 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
 
         if (dataContainsGraphQLJSONKey(body)) {
             BSGLogDebug(@"GraphQL JSON candidate found: method=POST endpoint=%@ bodyBytes=%lu",
-                        reportedURL.path.length > 0 ? reportedURL.path : @"/",
+                        reportedURL.path ?: @"",
                         (unsigned long)body.length);
             id json = [NSJSONSerialization JSONObjectWithData:body options:0 error:nil];
             if ([json isKindOfClass:NSDictionary.class]) {
@@ -455,12 +455,12 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
             (void)requestedName;
             BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ reason=/graphql endpoint body did not contain a readable GraphQL document",
                         method,
-                        reportedURL.path.length > 0 ? reportedURL.path : @"/");
+                        reportedURL.path ?: @"");
         }
         if (attributes.count == 0) {
             BSGLogDebug(@"GraphQL request not detected: method=%@ endpoint=%@ contentType=%@ reason=no GraphQL URL/content-type/query body signal; request remains category=network",
                         method,
-                        reportedURL.path.length > 0 ? reportedURL.path : @"/",
+                        reportedURL.path ?: @"",
                         contentType.length > 0 ? contentType : @"none");
         }
     } @catch (NSException *exception) {
@@ -475,7 +475,7 @@ SpanAttributesProvider::graphQLSpanName(NSURL *reportedURL, NSDictionary *attrib
     if (![attributes[BSGSpanCategoryAttributeKey] isEqualToString:BSGSpanCategoryGraphQL]) return nil;
     
     NSString *host = reportedURL.host ?: @"";
-    NSString *path = reportedURL.path.length > 0 ? reportedURL.path : @"/";
+    NSString *path = reportedURL.path ?: @"";
     NSString *endpoint = host.length > 0 ? [NSString stringWithFormat:@"%@%@", host, path] : path;
     
     NSString *operationType = attributes[BSGGraphQLOperationTypeAttributeKey];

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -16,6 +16,16 @@
 
 using namespace bugsnag;
 
+namespace bugsnag {
+NSString * const BSGSpanCategoryAttributeKey = @"bugsnag.span.category";
+NSString * const BSGSpanDisplayNameAttributeKey = @"display_name";
+NSString * const BSGGraphQLOperationTypeAttributeKey = @"graphql.operation.type";
+NSString * const BSGGraphQLOperationNameAttributeKey = @"graphql.operation.name";
+NSString * const BSGSpanCategoryGraphQL = @"graphql";
+NSString * const BSGSpanCategoryNetwork = @"network";
+}
+
+
 static NSDictionary *accessTechnologyMappingDictionary();
 
 // https://stackoverflow.com/questions/58426438/what-is-key-in-cttelephonynetworkinfo-servicesubscribercellularproviders-and-c
@@ -182,9 +192,7 @@ static void extractGraphQLOperation(NSString *document,
                                     NSString *requestedOperationName,
                                     NSString **operationType,
                                     NSString **operationName) {
-    // The ED requires query as the fallback when the document does not expose an
-    // explicit query, mutation, or subscription keyword.
-    *operationType = @"query";
+    *operationType = @"query";  // ← KEEP this as "query" (DO NOT set to nil here)
     *operationName = requestedOperationName;
     if (![document isKindOfClass:NSString.class] || document.length == 0) return;
     NSUInteger index = 0;
@@ -199,7 +207,8 @@ static void extractGraphQLOperation(NSString *document,
             atDefinitionStart = NO;
         } else if (character == '{') {
             if (selectionDepth == 0 && atDefinitionStart && requestedOperationName == nil) {
-                *operationType = @"query";
+                *operationType = nil;   // ← THIS IS THE ONLY CHANGE: nil instead of @"query"
+                *operationName = nil;
                 return;
             }
             selectionDepth++;
@@ -210,7 +219,9 @@ static void extractGraphQLOperation(NSString *document,
             index++;
         } else if (selectionDepth == 0 && atDefinitionStart && isGraphQLNameCharacter(character, YES)) {
             NSString *token = readGraphQLName(document, &index);
-            BOOL isOperation = [token isEqualToString:@"query"] || [token isEqualToString:@"mutation"] || [token isEqualToString:@"subscription"];
+            BOOL isOperation = [token isEqualToString:@"query"] ||
+                               [token isEqualToString:@"mutation"] ||
+                               [token isEqualToString:@"subscription"];
             if (isOperation) {
                 index = skipGraphQLIgnoredCharacters(document, index);
                 NSString *declaredName = readGraphQLName(document, &index);
@@ -278,13 +289,13 @@ static BOOL addGraphQLDocumentAttributes(NSMutableDictionary *attributes,
         operationType = hintedType;
     }
 
-    attributes[@"bugsnag.span.category"] = @"graphql";
+    attributes[BSGSpanCategoryAttributeKey] = BSGSpanCategoryGraphQL;
     attributes[@"bugsnag.span.first_class"] = @YES;
     // These two values are temporary SDK metadata used to construct the internal
     // span name. Callers remove them before attaching attributes to the span.
-    attributes[@"graphql.operation.type"] = operationType;
-    if (operationName != nil) attributes[@"graphql.operation.name"] = operationName;
-    attributes[@"display_name"] = operationName == nil
+    attributes[BSGGraphQLOperationTypeAttributeKey] = operationType;
+    if (operationName != nil) attributes[BSGGraphQLOperationNameAttributeKey] = operationName;
+    attributes[BSGSpanDisplayNameAttributeKey] = operationName == nil
         ? [NSString stringWithFormat:@"%@ %@", operationType, endpoint]
         : [NSString stringWithFormat:@"%@ %@ (%@)", operationType, endpoint, operationName];
     BSGLogDebug(@"GraphQL operation extracted: endpoint=%@ operationType=%@ operationName=%@ displayName=%@",
@@ -324,7 +335,7 @@ NSMutableDictionary *
 SpanAttributesProvider::initialNetworkSpanAttributes() noexcept {
     BSGLogTrace(@"SpanAttributesProvider::initialNetworkSpanAttributes");
     auto attributes = [NSMutableDictionary new];
-    attributes[@"bugsnag.span.category"] = @"network";
+    attributes[BSGSpanCategoryAttributeKey] = BSGSpanCategoryNetwork;
     attributes[@"http.url"] = @"unknown";
     return attributes;
 }
@@ -337,7 +348,7 @@ SpanAttributesProvider::networkSpanAttributes(NSURL *url,
     BSGLogTrace(@"SpanAttributesProvider::networkSpanAttributes(%@, task, metrics, error)", url);
     auto httpResponse = BSGDynamicCast<NSHTTPURLResponse>(task.response);
     auto attributes = [NSMutableDictionary new];
-    attributes[@"bugsnag.span.category"] = @"network";
+    attributes[BSGSpanCategoryAttributeKey] = BSGSpanCategoryNetwork;
     if (url != nil) {
         attributes[@"http.url"] = url.absoluteString;
     }
@@ -461,13 +472,27 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
 
 NSString *
 SpanAttributesProvider::graphQLSpanName(NSURL *reportedURL, NSDictionary *attributes) noexcept {
-    if (![attributes[@"bugsnag.span.category"] isEqualToString:@"graphql"]) return nil;
-    NSString *operationType = attributes[@"graphql.operation.type"] ?: @"query";
-    NSString *operationName = attributes[@"graphql.operation.name"] ?: @"<anonymous>";
+    if (![attributes[BSGSpanCategoryAttributeKey] isEqualToString:BSGSpanCategoryGraphQL]) return nil;
+    
     NSString *host = reportedURL.host ?: @"";
     NSString *path = reportedURL.path.length > 0 ? reportedURL.path : @"/";
     NSString *endpoint = host.length > 0 ? [NSString stringWithFormat:@"%@%@", host, path] : path;
-    return [NSString stringWithFormat:@"[GraphQL] [%@] %@:%@", endpoint, operationType, operationName];
+    
+    NSString *operationType = attributes[BSGGraphQLOperationTypeAttributeKey];
+    NSString *operationName = attributes[BSGGraphQLOperationNameAttributeKey];
+    
+    if (operationType.length > 0 && operationName.length > 0) {
+        // Full: [GraphQL] [endpoint] type:name
+        return [NSString stringWithFormat:@"[GraphQL] [%@] %@:%@", endpoint, operationType, operationName];
+    } else if (operationType.length > 0) {
+        // Type only: [GraphQL] [endpoint] type
+        return [NSString stringWithFormat:@"[GraphQL] [%@] %@", endpoint, operationType];
+    } else if (operationName.length > 0) {
+        // Name with no explicit type (default to query): [GraphQL] [endpoint] query:name
+        return [NSString stringWithFormat:@"[GraphQL] [%@] query:%@", endpoint, operationName];
+    }
+    // Fully anonymous: [GraphQL] [endpoint]
+    return [NSString stringWithFormat:@"[GraphQL] [%@]", endpoint];
 }
 
 

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -482,17 +482,13 @@ SpanAttributesProvider::graphQLSpanName(NSURL *reportedURL, NSDictionary *attrib
     NSString *operationName = attributes[BSGGraphQLOperationNameAttributeKey];
     
     if (operationType.length > 0 && operationName.length > 0) {
-        // Full: [GraphQL] [endpoint] type:name
-        return [NSString stringWithFormat:@"[GraphQL] [%@] %@:%@", endpoint, operationType, operationName];
+        return [NSString stringWithFormat:@"GraphQL %@ - %@:%@", endpoint, operationType, operationName];
     } else if (operationType.length > 0) {
-        // Type only: [GraphQL] [endpoint] type
-        return [NSString stringWithFormat:@"[GraphQL] [%@] %@", endpoint, operationType];
+        return [NSString stringWithFormat:@"GraphQL %@ - %@", endpoint, operationType];
     } else if (operationName.length > 0) {
-        // Name with no explicit type (default to query): [GraphQL] [endpoint] query:name
-        return [NSString stringWithFormat:@"[GraphQL] [%@] query:%@", endpoint, operationName];
+        return [NSString stringWithFormat:@"GraphQL %@ - query:%@", endpoint, operationName];
     }
-    // Fully anonymous: [GraphQL] [endpoint]
-    return [NSString stringWithFormat:@"[GraphQL] [%@]", endpoint];
+    return [NSString stringWithFormat:@"GraphQL %@", endpoint];
 }
 
 

--- a/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
+++ b/Sources/BugsnagPerformance/Private/SpanAttributesProvider.mm
@@ -461,11 +461,13 @@ SpanAttributesProvider::graphQLAttributes(NSURLRequest *request, NSURL *reported
 
 NSString *
 SpanAttributesProvider::graphQLSpanName(NSURL *reportedURL, NSDictionary *attributes) noexcept {
-    (void)reportedURL;
     if (![attributes[@"bugsnag.span.category"] isEqualToString:@"graphql"]) return nil;
     NSString *operationType = attributes[@"graphql.operation.type"] ?: @"query";
     NSString *operationName = attributes[@"graphql.operation.name"] ?: @"<anonymous>";
-    return [NSString stringWithFormat:@"[GraphQL] %@:%@", operationType, operationName];
+    NSString *host = reportedURL.host ?: @"";
+    NSString *path = reportedURL.path.length > 0 ? reportedURL.path : @"/";
+    NSString *endpoint = host.length > 0 ? [NSString stringWithFormat:@"%@%@", host, path] : path;
+    return [NSString stringWithFormat:@"[GraphQL] [%@] %@:%@", endpoint, operationType, operationName];
 }
 
 

--- a/Sources/BugsnagPerformance/Private/SpanFactory/Network/NetworkSpanFactory.h
+++ b/Sources/BugsnagPerformance/Private/SpanFactory/Network/NetworkSpanFactory.h
@@ -23,6 +23,10 @@ public:
     virtual BugsnagPerformanceSpan *startNetworkSpan(NSString *httpMethod,
                                                      const SpanOptions &options,
                                                      NSDictionary *attributes) noexcept = 0;
+    virtual BugsnagPerformanceSpan *startNetworkSpan(NSString *spanName,
+                                                         const SpanOptions &options,
+                                                         BSGTriState firstClass,
+                                                         NSDictionary *attributes) noexcept = 0;
     virtual ~NetworkSpanFactory() {}
 };
 }

--- a/Sources/BugsnagPerformance/Private/SpanFactory/Network/NetworkSpanFactoryImpl.h
+++ b/Sources/BugsnagPerformance/Private/SpanFactory/Network/NetworkSpanFactoryImpl.h
@@ -30,6 +30,11 @@ public:
                                              const SpanOptions &options,
                                              NSDictionary *attributes) noexcept;
     
+    BugsnagPerformanceSpan *startNetworkSpan(NSString *spanName,
+                                              const SpanOptions &options,
+                                              BSGTriState firstClass,
+                                              NSDictionary *attributes) noexcept;
+    
 private:
     std::shared_ptr<PlainSpanFactory> plainSpanFactory_;
     std::shared_ptr<SpanAttributesProvider> spanAttributesProvider_;

--- a/Sources/BugsnagPerformance/Private/SpanFactory/Network/NetworkSpanFactoryImpl.h
+++ b/Sources/BugsnagPerformance/Private/SpanFactory/Network/NetworkSpanFactoryImpl.h
@@ -31,9 +31,9 @@ public:
                                              NSDictionary *attributes) noexcept;
     
     BugsnagPerformanceSpan *startNetworkSpan(NSString *spanName,
-                                              const SpanOptions &options,
-                                              BSGTriState firstClass,
-                                              NSDictionary *attributes) noexcept;
+                                             const SpanOptions &options,
+                                             BSGTriState firstClass,
+                                             NSDictionary *attributes) noexcept;
     
 private:
     std::shared_ptr<PlainSpanFactory> plainSpanFactory_;

--- a/Sources/BugsnagPerformance/Private/SpanFactory/Network/NetworkSpanFactoryImpl.mm
+++ b/Sources/BugsnagPerformance/Private/SpanFactory/Network/NetworkSpanFactoryImpl.mm
@@ -34,7 +34,15 @@ NetworkSpanFactoryImpl::startNetworkSpan(NSString *httpMethod,
                                          const SpanOptions &options,
                                          NSDictionary *attributes) noexcept {
     auto name = [NSString stringWithFormat:@"[HTTP/%@]", httpMethod ?: @"unknown"];
+    return startNetworkSpan(name, options, BSGTriStateUnset, attributes);
+}
+
+BugsnagPerformanceSpan *
+NetworkSpanFactoryImpl::startNetworkSpan(NSString *spanName,
+                                         const SpanOptions &options,
+                                         BSGTriState firstClass,
+                                         NSDictionary *attributes) noexcept {
     NSMutableDictionary *spanAttributes = spanAttributesProvider_->initialNetworkSpanAttributes();
     [spanAttributes addEntriesFromDictionary:attributes];
-    return plainSpanFactory_->startSpan(name, options, BSGTriStateUnset, SPAN_KIND_CLIENT, spanAttributes, @[]);
+    return plainSpanFactory_->startSpan(spanName, options, firstClass, SPAN_KIND_CLIENT, spanAttributes, @[]);
 }

--- a/Sources/BugsnagPerformance/Private/Tracer.h
+++ b/Sources/BugsnagPerformance/Private/Tracer.h
@@ -74,6 +74,11 @@ public:
 
     BugsnagPerformanceSpan *startNetworkSpan(NSString *httpMethod, const SpanOptions &options) noexcept;
 
+    BugsnagPerformanceSpan *startNetworkSpan(NSString *spanName,
+                                             const SpanOptions &options,
+                                             BSGTriState firstClass,
+                                             NSDictionary *attributes) noexcept;
+
     BugsnagPerformanceSpan *startViewLoadPhaseSpan(NSString *className,
                                                    NSString *phase,
                                                    BugsnagPerformanceSpanContext *parentContext,

--- a/Sources/BugsnagPerformance/Private/Tracer.mm
+++ b/Sources/BugsnagPerformance/Private/Tracer.mm
@@ -51,6 +51,14 @@ Tracer::startNetworkSpan(NSString *httpMethod,
 }
 
 BugsnagPerformanceSpan *
+Tracer::startNetworkSpan(NSString *spanName,
+                         const SpanOptions &options,
+                         BSGTriState firstClass,
+                         NSDictionary *attributes) noexcept {
+    return networkSpanFactory_->startNetworkSpan(spanName, options, firstClass, attributes);
+}
+
+BugsnagPerformanceSpan *
 Tracer::startViewLoadPhaseSpan(NSString *className,
                                NSString *phase,
                                BugsnagPerformanceSpanContext *parentContext,

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -1,6 +1,6 @@
 //
 //  OtlpTraceEncodingTests.mm
-//  
+//
 //
 //  Created by Nick Dowell on 27/09/2022.
 //
@@ -21,15 +21,21 @@ using namespace bugsnag;
 @end
 
 static id findAttributeNamed(NSDictionary *span, NSString *name) {
-    for (NSDictionary *attr in span[@"attributes"]) {
-        if ([attr[@"key"] isEqualToString:name]) {
-            NSDictionary *value = attr[@"value"];
+    for (NSDictionary *attribute in span[@"attributes"]) {
+        if ([attribute[@"key"] isEqual:name]) {
+            NSDictionary *value = attribute[@"value"];
             if (value[@"stringValue"] != nil) {
                 return value[@"stringValue"];
             }
             if (value[@"intValue"] != nil) {
-                // OTLP encodes intValue as a string — convert back to NSNumber
-                return @([value[@"intValue"] longLongValue]);
+                id intValue = value[@"intValue"];
+                if ([intValue isKindOfClass:[NSString class]]) {
+                    // OTLP JSON encodes intValue as a decimal string.
+                    return @([(NSString *)intValue longLongValue]);
+                }
+                if ([intValue isKindOfClass:[NSNumber class]]) {
+                    return intValue;
+                }
             }
             if (value[@"boolValue"] != nil) {
                 return value[@"boolValue"];
@@ -248,7 +254,6 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
     XCTAssertEqualObjects(encodedSpan[@"name"], @"[GraphQL] [example.com/graphql] query:GetUser");
     XCTAssertEqualObjects(findAttributeNamed(encodedSpan, @"bugsnag.span.category"), @"graphql");
     XCTAssertEqualObjects(findAttributeNamed(encodedSpan, @"bugsnag.span.first_class"), @YES);
-    XCTAssertEqualObjects(findAttributeNamed(encodedSpan, @"display_name"), @"query /graphql (GetUser)");
     XCTAssertEqualObjects(findAttributeNamed(encodedSpan, @"http.method"), @"POST");
     XCTAssertEqual([findAttributeNamed(encodedSpan, @"http.status_code") intValue], 200);
     XCTAssertNil(findAttributeNamed(encodedSpan, @"graphql.operation.type"));

--- a/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
+++ b/Tests/BugsnagPerformanceTests/OtlpTraceEncodingTests.mm
@@ -21,20 +21,23 @@ using namespace bugsnag;
 @end
 
 static id findAttributeNamed(NSDictionary *span, NSString *name) {
-    for (NSDictionary *attribute in span[@"attributes"]) {
-        if ([attribute[@"key"] isEqual:name]) {
-            id value = attribute[@"value"][@"stringValue"];
-            if (value != nil) {
-                return value;
+    for (NSDictionary *attr in span[@"attributes"]) {
+        if ([attr[@"key"] isEqualToString:name]) {
+            NSDictionary *value = attr[@"value"];
+            if (value[@"stringValue"] != nil) {
+                return value[@"stringValue"];
             }
-            value = attribute[@"value"][@"intValue"];
-            if (value != nil) {
-                return [NSNumber numberWithLong:[value longValue]];
+            if (value[@"intValue"] != nil) {
+                // OTLP encodes intValue as a string — convert back to NSNumber
+                return @([value[@"intValue"] longLongValue]);
             }
-            value = attribute[@"value"][@"boolValue"];
-            if (value != nil) {
-                return value;
+            if (value[@"boolValue"] != nil) {
+                return value[@"boolValue"];
             }
+            if (value[@"doubleValue"] != nil) {
+                return value[@"doubleValue"];
+            }
+            return nil;
         }
     }
     return nil;
@@ -222,30 +225,35 @@ static id findAttributeNamed(NSDictionary *span, NSString *name) {
     XCTAssertEqualObjects(findAttributeNamed(span, @"bugsnag.span.first_class"), @YES);
 }
 
-- (void)testEncodeRequestFirstClassNo {
+- (void)testEncodeGraphQLSpanContract {
     auto encoder = [self newEncoder];
-    NSMutableArray<BugsnagPerformanceSpan *> *spans = [[NSMutableArray alloc] init];
-    TraceId tid = {.value=1};
-    [spans addObject:[self spanWithName:@""
-                                traceId:tid
-                                 spanId:1
-                               parentId:0
-                              startTime:CFAbsoluteTimeGetCurrent()
-                             firstClass:BSGTriStateNo]];
-    auto json = encoder->encode(spans, @{});
-    
-    XCTAssertIsKindOfClass(json[@"resourceSpans"], [NSArray class]);
-    XCTAssertIsKindOfClass(json[@"resourceSpans"][0], [NSDictionary class]);
-    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"resource"], [NSDictionary class]);
-    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"resource"][@"attributes"], [NSArray class]);
-    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"], [NSArray class]);
-    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"][0], [NSDictionary class]);
-    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"][0][@"spans"], [NSArray class]);
-    XCTAssertIsKindOfClass(json[@"resourceSpans"][0][@"scopeSpans"][0][@"spans"][0][@"spanId"], [NSString class]);
+    TraceId traceId = {.value = 1};
+    BugsnagPerformanceSpan *graphQLSpan = [self spanWithName:@"[GraphQL] [example.com/graphql] query:GetUser"
+                                                    traceId:traceId
+                                                     spanId:1
+                                                   parentId:0
+                                                  startTime:CFAbsoluteTimeGetCurrent()
+                                                 firstClass:BSGTriStateYes];
+    [graphQLSpan internalSetMultipleAttributes:@{
+        @"bugsnag.span.category": @"graphql",
+        @"display_name": @"query /graphql (GetUser)",
+        @"http.method": @"POST",
+        @"http.url": @"https://example.com/graphql",
+        @"http.status_code": @200,
+    }];
 
-    NSDictionary *span = json[@"resourceSpans"][0][@"scopeSpans"][0][@"spans"][0];
-    XCTAssertNotNil(span);
-    XCTAssertEqualObjects(findAttributeNamed(span, @"bugsnag.span.first_class"), @NO);
+    NSDictionary *json = encoder->encode(@[graphQLSpan], @{});
+    NSDictionary *encodedSpan = json[@"resourceSpans"][0][@"scopeSpans"][0][@"spans"][0];
+
+    XCTAssertEqualObjects(encodedSpan[@"name"], @"[GraphQL] [example.com/graphql] query:GetUser");
+    XCTAssertEqualObjects(findAttributeNamed(encodedSpan, @"bugsnag.span.category"), @"graphql");
+    XCTAssertEqualObjects(findAttributeNamed(encodedSpan, @"bugsnag.span.first_class"), @YES);
+    XCTAssertEqualObjects(findAttributeNamed(encodedSpan, @"display_name"), @"query /graphql (GetUser)");
+    XCTAssertEqualObjects(findAttributeNamed(encodedSpan, @"http.method"), @"POST");
+    XCTAssertEqual([findAttributeNamed(encodedSpan, @"http.status_code") intValue], 200);
+    XCTAssertNil(findAttributeNamed(encodedSpan, @"graphql.operation.type"));
+    XCTAssertNil(findAttributeNamed(encodedSpan, @"graphql.operation.name"));
+    XCTAssertNil(findAttributeNamed(encodedSpan, @"graphql.document"));
 }
 
 - (void)testEncodeRequestFirstClassUnset {

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -20,6 +20,398 @@ using namespace bugsnag;
 
 @implementation SpanAttributesTests
 
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
+                                       URL:(NSString *)URLString
+                               contentType:(NSString *)contentType
+                                      body:(NSString *)body {
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:URLString]];
+    request.HTTPMethod = method;
+    if (contentType != nil) {
+        [request setValue:contentType forHTTPHeaderField:@"Content-Type"];
+    }
+    if (body != nil) {
+        request.HTTPBody = [body dataUsingEncoding:NSUTF8StringEncoding];
+    }
+    return request;
+}
+
+- (NSString *)graphQLJSONBodyWithOperationName:(NSString *)operationName
+                                     queryName:(NSString *)queryName
+                             targetByteLength:(NSUInteger)targetByteLength {
+    NSMutableString *query = [NSMutableString stringWithFormat:@"query %@ { __typename }", queryName];
+    NSString *body = [NSString stringWithFormat:@"{\"operationName\":\"%@\",\"query\":\"%@\"}", operationName, query];
+    NSUInteger bodyLength = [body dataUsingEncoding:NSUTF8StringEncoding].length;
+    if (bodyLength < targetByteLength) {
+        [query appendString:[@"" stringByPaddingToLength:targetByteLength - bodyLength withString:@" " startingAtIndex:0]];
+        body = [NSString stringWithFormat:@"{\"operationName\":\"%@\",\"query\":\"%@\"}", operationName, query];
+    }
+    return body;
+}
+
+- (NSString *)graphQLNameWithLength:(NSUInteger)length {
+    return [@"A" stringByPaddingToLength:length withString:@"A" startingAtIndex:0];
+}
+
+- (void)assertGraphQLRequest:(NSURLRequest *)request
+               operationType:(NSString *)operationType
+               operationName:(NSString *)operationName
+                 displayName:(NSString *)displayName
+                    spanName:(NSString *)spanName {
+    SpanAttributesProvider provider;
+    auto attributes = provider.graphQLAttributes(request, request.URL);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"graphql");
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
+    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], operationType);
+    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], operationName);
+    XCTAssertEqualObjects(attributes[@"display_name"], displayName);
+    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), spanName);
+}
+
+- (void)assertNotGraphQLRequest:(NSURLRequest *)request {
+    SpanAttributesProvider provider;
+    auto attributes = provider.graphQLAttributes(request, request.URL);
+    XCTAssertEqual(0U, attributes.count);
+    XCTAssertNil(provider.graphQLSpanName(request.URL, attributes));
+}
+
+- (void)testGraphQLPostJsonNamedQueryDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"operationName\":\"BugsnagGetUser\",\"query\":\"query BugsnagGetUser { user { id name } }\"}"];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"query"
+                 operationName:@"BugsnagGetUser"
+                   displayName:@"query /graphql (BugsnagGetUser)"
+                      spanName:@"[GraphQL] query:BugsnagGetUser"];
+}
+
+- (void)testGraphQLPostJsonNamedMutationDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"operationName\":\"UpdateCart\",\"query\":\"mutation UpdateCart { updateCart { id } }\"}"];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"mutation"
+                 operationName:@"UpdateCart"
+                   displayName:@"mutation /graphql (UpdateCart)"
+                      spanName:@"[GraphQL] mutation:UpdateCart"];
+}
+
+- (void)testGraphQLPostJsonNamedSubscriptionDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"operationName\":\"BugsnagMessageSubscription\",\"query\":\"subscription BugsnagMessageSubscription { messageAdded { id text } }\"}"];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"subscription"
+                 operationName:@"BugsnagMessageSubscription"
+                   displayName:@"subscription /graphql (BugsnagMessageSubscription)"
+                      spanName:@"[GraphQL] subscription:BugsnagMessageSubscription"];
+}
+
+- (void)testGraphQLGetQueryParametersDetected {
+    NSURLRequest *request = [self requestWithMethod:@"GET"
+                                                URL:@"https://api.example.com/graphql?operationName=BugsnagGetQuery&query=query%20BugsnagGetQuery%20%7B%20__typename%20%7D"
+                                        contentType:nil
+                                               body:nil];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"query"
+                 operationName:@"BugsnagGetQuery"
+                   displayName:@"query /graphql (BugsnagGetQuery)"
+                      spanName:@"[GraphQL] query:BugsnagGetQuery"];
+}
+
+- (void)testGraphQLApplicationGraphQLContentTypeDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/graphql"
+                                               body:@"query BugsnagApplicationGraphQL { __typename }"];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"query"
+                 operationName:@"BugsnagApplicationGraphQL"
+                   displayName:@"query /graphql (BugsnagApplicationGraphQL)"
+                      spanName:@"[GraphQL] query:BugsnagApplicationGraphQL"];
+}
+
+- (void)testAnonymousGraphQLQueryUsesAnonymousSpanName {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"query\":\"query { viewer { id } }\"}"];
+
+    SpanAttributesProvider provider;
+    auto attributes = provider.graphQLAttributes(request, request.URL);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"graphql");
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
+    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
+    XCTAssertNil(attributes[@"graphql.operation.name"]);
+    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql");
+    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] query:<anonymous>");
+}
+
+- (void)testOperationNameFieldTakesPriority {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"operationName\":\"SelectedOperation\",\"query\":\"query IgnoredOperation { viewer { id } } query SelectedOperation { viewer { name } }\"}"];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"query"
+                 operationName:@"SelectedOperation"
+                   displayName:@"query /graphql (SelectedOperation)"
+                      spanName:@"[GraphQL] query:SelectedOperation"];
+}
+
+- (void)testRestJsonBodyIsNotGraphQL {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/rest/users/123"
+                                        contentType:@"application/json"
+                                               body:@"{\"action\":\"get\",\"userId\":\"123\"}"];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testGraphQLGetEndpointWithoutQueryParameterIsNotDetected {
+    NSURLRequest *request = [self requestWithMethod:@"GET"
+                                                URL:@"https://api.example.com/graphql?operationName=GetUser"
+                                        contentType:nil
+                                               body:nil];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testGraphQLEndpointWithoutReadableQueryIsNotDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"operationName\":\"GetUser\"}"];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testGraphQLEndpointWithEmptyBodyIsNotDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:nil];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testMalformedJSONBodyIsNotDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"operationName\":\"Broken\",\"query\":\"query Broken { __typename }\""];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testGraphQLJSONKeyWithNonStringValueIsNotDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"query\":{\"nested\":\"not a GraphQL document\"},\"operationName\":\"NotAStringQuery\"}"];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testNonGraphQLNonJSONContentTypeIsNotInspected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/rest/search"
+                                        contentType:@"text/plain"
+                                               body:@"{\"operationName\":\"Search\",\"query\":\"query Search { __typename }\"}"];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testGraphQLBatchArrayIsSkipped {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"[{\"operationName\":\"One\",\"query\":\"query One { __typename }\"},{\"operationName\":\"Two\",\"query\":\"query Two { __typename }\"}]"];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testGraphQLStreamedBodyIsSkipped {
+    NSMutableURLRequest *request = [self requestWithMethod:@"POST"
+                                                       URL:@"https://api.example.com/graphql"
+                                               contentType:@"application/json"
+                                                      body:nil];
+    NSData *body = [@"{\"operationName\":\"Streamed\",\"query\":\"query Streamed { __typename }\"}" dataUsingEncoding:NSUTF8StringEncoding];
+    request.HTTPBodyStream = [NSInputStream inputStreamWithData:body];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testGraphQLLargeBodyIsSkipped {
+    NSMutableString *largeQuery = [NSMutableString stringWithString:@"query LargeBody { "];
+    for (NSUInteger index = 0; index < 70000; index++) {
+        [largeQuery appendString:@"a"];
+    }
+    [largeQuery appendString:@" }"];
+    NSString *body = [NSString stringWithFormat:@"{\"operationName\":\"LargeBody\",\"query\":\"%@\"}", largeQuery];
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:body];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testGraphQLBodyAtMaximumInspectionSizeIsDetected {
+    NSString *body = [self graphQLJSONBodyWithOperationName:@"BodyLimitExact"
+                                                  queryName:@"BodyLimitExact"
+                                          targetByteLength:64 * 1024];
+    XCTAssertEqual((NSUInteger)(64 * 1024), [body dataUsingEncoding:NSUTF8StringEncoding].length);
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:body];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"query"
+                 operationName:@"BodyLimitExact"
+                   displayName:@"query /graphql (BodyLimitExact)"
+                      spanName:@"[GraphQL] query:BodyLimitExact"];
+}
+
+- (void)testGraphQLBodyOverMaximumInspectionSizeIsSkipped {
+    NSString *body = [self graphQLJSONBodyWithOperationName:@"BodyLimitExceeded"
+                                                  queryName:@"BodyLimitExceeded"
+                                          targetByteLength:(64 * 1024) + 1];
+    XCTAssertEqual((NSUInteger)(64 * 1024) + 1, [body dataUsingEncoding:NSUTF8StringEncoding].length);
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:body];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testGraphQLOperationNameAtMaximumLengthIsDetected {
+    NSString *operationName = [self graphQLNameWithLength:256];
+    NSString *body = [NSString stringWithFormat:@"{\"operationName\":\"%@\",\"query\":\"query %@ { __typename }\"}",
+                      operationName,
+                      operationName];
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:body];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"query"
+                 operationName:operationName
+                   displayName:[NSString stringWithFormat:@"query /graphql (%@)", operationName]
+                      spanName:[NSString stringWithFormat:@"[GraphQL] query:%@", operationName]];
+}
+
+- (void)testGraphQLOperationNameOverMaximumLengthUsesAnonymousFallback {
+    NSString *operationName = [self graphQLNameWithLength:257];
+    NSString *body = [NSString stringWithFormat:@"{\"operationName\":\"%@\",\"query\":\"query %@ { __typename }\"}",
+                      operationName,
+                      operationName];
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:body];
+
+    SpanAttributesProvider provider;
+    auto attributes = provider.graphQLAttributes(request, request.URL);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"graphql");
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
+    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
+    XCTAssertNil(attributes[@"graphql.operation.name"]);
+    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql");
+    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] query:<anonymous>");
+}
+
+- (void)testGraphQLTemporaryOperationAttributesAreUsedForSpanNameOnly {
+    NSMutableURLRequest *request = [self requestWithMethod:@"POST"
+                                                       URL:@"https://api.example.com/graphql"
+                                               contentType:@"application/json"
+                                                      body:@"{\"operationName\":\"BugsnagTemporaryAttributes\",\"query\":\"query BugsnagTemporaryAttributes { __typename }\"}"];
+
+    SpanAttributesProvider provider;
+    auto attributes = provider.graphQLAttributes(request, request.URL);
+    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] query:BugsnagTemporaryAttributes");
+
+    [attributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"graphql");
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
+    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql (BugsnagTemporaryAttributes)");
+    XCTAssertNil(attributes[@"graphql.operation.type"]);
+    XCTAssertNil(attributes[@"graphql.operation.name"]);
+}
+
+- (void)testRestPostSubscriptionCancelIsNotGraphQL {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/subscription/cancel"
+                                        contentType:@"application/json"
+                                               body:@"{\"subscriptionId\":\"sub_123\",\"reason\":\"customer_request\"}"];
+
+    [self assertNotGraphQLRequest:request];
+}
+
+- (void)testGraphQLMutationCancelSubscriptionDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"operationName\":\"CancelSubscription\",\"query\":\"mutation CancelSubscription { cancelSubscription(id: \\\"sub_123\\\") { status } }\"}"];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"mutation"
+                 operationName:@"CancelSubscription"
+                   displayName:@"mutation /graphql (CancelSubscription)"
+                      spanName:@"[GraphQL] mutation:CancelSubscription"];
+}
+
+- (void)testGraphQLMutationUpgradeSubscriptionDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"operationName\":\"UpgradeSubscription\",\"query\":\"mutation UpgradeSubscription { upgradeSubscription(planId: \\\"pro\\\") { status } }\"}"];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"mutation"
+                 operationName:@"UpgradeSubscription"
+                   displayName:@"mutation /graphql (UpgradeSubscription)"
+                      spanName:@"[GraphQL] mutation:UpgradeSubscription"];
+}
+
+- (void)testGraphQLQueryGetSubscriptionStatusDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"operationName\":\"GetSubscriptionStatus\",\"query\":\"query GetSubscriptionStatus { subscription { status } }\"}"];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"query"
+                 operationName:@"GetSubscriptionStatus"
+                   displayName:@"query /graphql (GetSubscriptionStatus)"
+                      spanName:@"[GraphQL] query:GetSubscriptionStatus"];
+}
+
+- (void)testGraphQLSubscriptionOnMessageReceivedDetected {
+    NSURLRequest *request = [self requestWithMethod:@"POST"
+                                                URL:@"https://api.example.com/graphql"
+                                        contentType:@"application/json"
+                                               body:@"{\"operationName\":\"OnMessageReceived\",\"query\":\"subscription OnMessageReceived { messageReceived { id text } }\"}"];
+
+    [self assertGraphQLRequest:request
+                 operationType:@"subscription"
+                 operationName:@"OnMessageReceived"
+                   displayName:@"subscription /graphql (OnMessageReceived)"
+                      spanName:@"[GraphQL] subscription:OnMessageReceived"];
+}
+
 - (void)testInitialNetworkSpanAttributes {
     SpanAttributesProvider provider;
     auto attributes = provider.initialNetworkSpanAttributes();

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -84,7 +84,7 @@ using namespace bugsnag;
                  operationType:@"query"
                  operationName:@"BugsnagGetUser"
                    displayName:@"query /graphql (BugsnagGetUser)"
-                      spanName:@"[GraphQL] query:BugsnagGetUser"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] query:BugsnagGetUser"];
 }
 
 - (void)testGraphQLPostJsonNamedMutationDetected {
@@ -97,7 +97,7 @@ using namespace bugsnag;
                  operationType:@"mutation"
                  operationName:@"UpdateCart"
                    displayName:@"mutation /graphql (UpdateCart)"
-                      spanName:@"[GraphQL] mutation:UpdateCart"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] mutation:UpdateCart"];
 }
 
 - (void)testGraphQLPostJsonNamedSubscriptionDetected {
@@ -110,7 +110,7 @@ using namespace bugsnag;
                  operationType:@"subscription"
                  operationName:@"BugsnagMessageSubscription"
                    displayName:@"subscription /graphql (BugsnagMessageSubscription)"
-                      spanName:@"[GraphQL] subscription:BugsnagMessageSubscription"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] subscription:BugsnagMessageSubscription"];
 }
 
 - (void)testGraphQLGetQueryParametersDetected {
@@ -123,7 +123,7 @@ using namespace bugsnag;
                  operationType:@"query"
                  operationName:@"BugsnagGetQuery"
                    displayName:@"query /graphql (BugsnagGetQuery)"
-                      spanName:@"[GraphQL] query:BugsnagGetQuery"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] query:BugsnagGetQuery"];
 }
 
 - (void)testGraphQLApplicationGraphQLContentTypeDetected {
@@ -136,7 +136,7 @@ using namespace bugsnag;
                  operationType:@"query"
                  operationName:@"BugsnagApplicationGraphQL"
                    displayName:@"query /graphql (BugsnagApplicationGraphQL)"
-                      spanName:@"[GraphQL] query:BugsnagApplicationGraphQL"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] query:BugsnagApplicationGraphQL"];
 }
 
 - (void)testAnonymousGraphQLQueryUsesAnonymousSpanName {
@@ -152,7 +152,7 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
     XCTAssertNil(attributes[@"graphql.operation.name"]);
     XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql");
-    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] query:<anonymous>");
+    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] [api.example.com/graphql] query:<anonymous>");
 }
 
 - (void)testOperationNameFieldTakesPriority {
@@ -165,7 +165,7 @@ using namespace bugsnag;
                  operationType:@"query"
                  operationName:@"SelectedOperation"
                    displayName:@"query /graphql (SelectedOperation)"
-                      spanName:@"[GraphQL] query:SelectedOperation"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] query:SelectedOperation"];
 }
 
 - (void)testRestJsonBodyIsNotGraphQL {
@@ -280,7 +280,7 @@ using namespace bugsnag;
                  operationType:@"query"
                  operationName:@"BodyLimitExact"
                    displayName:@"query /graphql (BodyLimitExact)"
-                      spanName:@"[GraphQL] query:BodyLimitExact"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] query:BodyLimitExact"];
 }
 
 - (void)testGraphQLBodyOverMaximumInspectionSizeIsSkipped {
@@ -310,7 +310,7 @@ using namespace bugsnag;
                  operationType:@"query"
                  operationName:operationName
                    displayName:[NSString stringWithFormat:@"query /graphql (%@)", operationName]
-                      spanName:[NSString stringWithFormat:@"[GraphQL] query:%@", operationName]];
+                      spanName:[NSString stringWithFormat:@"[GraphQL] [api.example.com/graphql] query:%@", operationName]];
 }
 
 - (void)testGraphQLOperationNameOverMaximumLengthUsesAnonymousFallback {
@@ -330,7 +330,7 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
     XCTAssertNil(attributes[@"graphql.operation.name"]);
     XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql");
-    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] query:<anonymous>");
+    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] [api.example.com/graphql] query:<anonymous>");
 }
 
 - (void)testGraphQLTemporaryOperationAttributesAreUsedForSpanNameOnly {
@@ -341,7 +341,7 @@ using namespace bugsnag;
 
     SpanAttributesProvider provider;
     auto attributes = provider.graphQLAttributes(request, request.URL);
-    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] query:BugsnagTemporaryAttributes");
+    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] [api.example.com/graphql] query:BugsnagTemporaryAttributes");
 
     [attributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
     XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"graphql");
@@ -370,7 +370,7 @@ using namespace bugsnag;
                  operationType:@"mutation"
                  operationName:@"CancelSubscription"
                    displayName:@"mutation /graphql (CancelSubscription)"
-                      spanName:@"[GraphQL] mutation:CancelSubscription"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] mutation:CancelSubscription"];
 }
 
 - (void)testGraphQLMutationUpgradeSubscriptionDetected {
@@ -383,7 +383,7 @@ using namespace bugsnag;
                  operationType:@"mutation"
                  operationName:@"UpgradeSubscription"
                    displayName:@"mutation /graphql (UpgradeSubscription)"
-                      spanName:@"[GraphQL] mutation:UpgradeSubscription"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] mutation:UpgradeSubscription"];
 }
 
 - (void)testGraphQLQueryGetSubscriptionStatusDetected {
@@ -396,7 +396,7 @@ using namespace bugsnag;
                  operationType:@"query"
                  operationName:@"GetSubscriptionStatus"
                    displayName:@"query /graphql (GetSubscriptionStatus)"
-                      spanName:@"[GraphQL] query:GetSubscriptionStatus"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] query:GetSubscriptionStatus"];
 }
 
 - (void)testGraphQLSubscriptionOnMessageReceivedDetected {
@@ -409,7 +409,7 @@ using namespace bugsnag;
                  operationType:@"subscription"
                  operationName:@"OnMessageReceived"
                    displayName:@"subscription /graphql (OnMessageReceived)"
-                      spanName:@"[GraphQL] subscription:OnMessageReceived"];
+                      spanName:@"[GraphQL] [api.example.com/graphql] subscription:OnMessageReceived"];
 }
 
 - (void)testInitialNetworkSpanAttributes {
@@ -442,6 +442,229 @@ using namespace bugsnag;
 
     attributes = provider.networkSpanUrlAttributes(nil, nil);
     XCTAssertEqual(0U, attributes.count);
+}
+
+- (NSMutableURLRequest *)graphQLPostRequestWithJSONObject:(id)object {
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/api"]];
+    request.HTTPMethod = @"POST";
+    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    request.HTTPBody = [NSJSONSerialization dataWithJSONObject:object options:0 error:nil];
+    return request;
+}
+
+- (void)testNamedGraphQLQueryContract {
+    SpanAttributesProvider provider;
+    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{
+        @"operationName": @"GetUser",
+        @"query": @"query GetUser($id: ID!) { user(id: $id) { name } }",
+        @"variables": @{@"id": @"private-value"},
+    }];
+    NSURL *reportedURL = [NSURL URLWithString:@"https://api.example.com/graphql?key=private"];
+
+    auto attributes = provider.graphQLAttributes(request, reportedURL);
+
+    XCTAssertEqual(5U, attributes.count);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"graphql");
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
+    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql (GetUser)");
+    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
+    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], @"GetUser");
+    XCTAssertEqualObjects(provider.graphQLSpanName(reportedURL, attributes), @"[GraphQL] [api.example.com/graphql] query:GetUser");
+    XCTAssertFalse([[attributes description] containsString:@"private-value"]);
+    XCTAssertFalse([[attributes description] containsString:@"query GetUser"]);
+}
+
+- (void)testDerivesGraphQLOperationNameFromDocument {
+    SpanAttributesProvider provider;
+    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{
+        @"query": @"# comment\nmutation UpdateProfile { updateProfile { id } }",
+    }];
+    NSURL *url = request.URL;
+
+    auto attributes = provider.graphQLAttributes(request, url);
+
+    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"mutation");
+    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], @"UpdateProfile");
+    XCTAssertEqualObjects(attributes[@"display_name"], @"mutation /api (UpdateProfile)");
+    XCTAssertEqualObjects(provider.graphQLSpanName(url, attributes), @"[GraphQL] [example.com/api] mutation:UpdateProfile");
+}
+
+- (void)testAnonymousGraphQLQueryContract {
+    SpanAttributesProvider provider;
+    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{@"query": @"{ viewer { id } }"}];
+    NSURL *url = [NSURL URLWithString:@"https://api.example.com/graphql"];
+
+    auto attributes = provider.graphQLAttributes(request, url);
+
+    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql");
+    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
+    XCTAssertNil(attributes[@"graphql.operation.name"]);
+    XCTAssertEqualObjects(provider.graphQLSpanName(url, attributes), @"[GraphQL] [api.example.com/graphql] query:<anonymous>");
+}
+
+- (void)testUnknownTypeDefaultsToQueryContract {
+    SpanAttributesProvider provider;
+    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{
+        @"operationName": @"GetUser",
+        @"query": @"not a parseable operation { value }",
+    }];
+    NSURL *url = [NSURL URLWithString:@"https://api.example.com/graphql"];
+
+    auto attributes = provider.graphQLAttributes(request, url);
+
+    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql (GetUser)");
+    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
+    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], @"GetUser");
+    XCTAssertEqualObjects(provider.graphQLSpanName(url, attributes), @"[GraphQL] [api.example.com/graphql] query:GetUser");
+}
+
+- (void)testSelectsRequestedOperationFromGraphQLDocument {
+    SpanAttributesProvider provider;
+    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{
+        @"operationName": @"Second",
+        @"query": @"query First { first } subscription Second { second }",
+    }];
+    auto attributes = provider.graphQLAttributes(request, request.URL);
+    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"subscription");
+    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], @"Second");
+}
+
+- (void)testGraphQLEndpointNormalization {
+    SpanAttributesProvider provider;
+    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{
+        @"operationName": @"GetUser",
+        @"query": @"query GetUser { user { id } }",
+    }];
+    NSDictionary<NSString *, NSString *> *cases = @{
+        @"https://api.example.com/graphql":             @"/graphql",
+        @"https://api.example.com/graphql?key=abc":     @"/graphql",
+        @"https://api.example.com/":                    @"/",
+        @"https://api.example.com":                     @"/",
+        @"https://api.example.com/v2/graphql":          @"/v2/graphql",
+        @"https://api.example.com/users/123/graphql":   @"/users/123/graphql",
+    };
+    for (NSString *urlString in cases) {
+        NSURL *url = [NSURL URLWithString:urlString];
+        auto attributes = provider.graphQLAttributes(request, url);
+        NSString *expectedEndpoint = [NSString stringWithFormat:@"%@%@", url.host, cases[urlString]];
+        NSString *expectedSpanName = [NSString stringWithFormat:@"[GraphQL] [%@] query:GetUser", expectedEndpoint];
+        XCTAssertEqualObjects(provider.graphQLSpanName(url, attributes), expectedSpanName);
+        NSString *expectedDisplayName = [NSString stringWithFormat:@"query %@ (GetUser)", cases[urlString]];
+        XCTAssertEqualObjects(attributes[@"display_name"], expectedDisplayName);
+    }
+}
+
+- (void)testGraphQLDetectionSignalsFromED {
+    SpanAttributesProvider provider;
+
+    // Detection via Content-Type: application/graphql
+    NSMutableURLRequest *contentType = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/api"]];
+    contentType.HTTPMethod = @"POST";
+    [contentType setValue:@"application/graphql" forHTTPHeaderField:@"Content-Type"];
+    contentType.HTTPBody = [@"mutation UpdateThing { updateThing }" dataUsingEncoding:NSUTF8StringEncoding];
+    auto attributes = provider.graphQLAttributes(contentType, contentType.URL);
+    NSString *expectedSpanName1 = @"[GraphQL] [example.com/api] mutation:UpdateThing";
+    XCTAssertEqualObjects(provider.graphQLSpanName(contentType.URL, attributes), expectedSpanName1);
+
+    // Endpoint-only URL (no body/content-type signal) should return empty attributes
+    NSMutableURLRequest *endpoint = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/api/v1/graphql"]];
+    endpoint.HTTPMethod = @"POST";
+    attributes = provider.graphQLAttributes(endpoint, endpoint.URL);
+    XCTAssertEqual(0U, attributes.count);
+    XCTAssertNil(provider.graphQLSpanName(endpoint.URL, attributes));
+
+    // Detection via JSON body key "mutation" — use explicit URL matching expected span
+    NSURL *mutationURL = [NSURL URLWithString:@"https://api.example.com/graphql"];
+    NSData *mutationBody = [NSJSONSerialization dataWithJSONObject:@{
+        @"operationName": @"UpdateThing",
+        @"mutation": @"{ updateThing }",
+    } options:0 error:nil];
+    NSMutableURLRequest *mutationKey = [NSMutableURLRequest requestWithURL:mutationURL];
+    mutationKey.HTTPMethod = @"POST";
+    [mutationKey setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    mutationKey.HTTPBody = mutationBody;
+    attributes = provider.graphQLAttributes(mutationKey, mutationKey.URL);
+    NSString *expectedSpanName2 = @"[GraphQL] [api.example.com/graphql] mutation:UpdateThing";
+    XCTAssertEqualObjects(provider.graphQLSpanName(mutationKey.URL, attributes), expectedSpanName2);
+}
+
+- (void)testGraphQLEndpointRequiresCompletePathComponent {
+    SpanAttributesProvider provider;
+    NSArray<NSString *> *ordinaryPaths = @[
+        @"https://example.com/graphqlite",
+        @"https://example.com/api/graphql-helper",
+        @"https://example.com/notgraphql",
+    ];
+    for (NSString *urlString in ordinaryPaths) {
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]];
+        request.HTTPMethod = @"GET";
+        XCTAssertEqual(0U, provider.graphQLAttributes(request, request.URL).count);
+    }
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/api/GraphQL/v1"]];
+    request.HTTPMethod = @"GET";
+    XCTAssertEqual(0U, provider.graphQLAttributes(request, request.URL).count);
+}
+
+- (void)testGraphQLOperationMetadataIsRemovedFromEmittedAttributes {
+    SpanAttributesProvider provider;
+    NSMutableDictionary *attributes = provider.graphQLAttributes(
+        [self graphQLPostRequestWithJSONObject:@{@"operationName": @"GetUser", @"query": @"query GetUser { user }"}],
+        [NSURL URLWithString:@"https://example.com/graphql"]);
+    XCTAssertNotNil(provider.graphQLSpanName(nil, attributes));
+    [attributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
+    XCTAssertNil(attributes[@"graphql.operation.type"]);
+    XCTAssertNil(attributes[@"graphql.operation.name"]);
+    XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
+}
+
+- (void)testGraphQLGetRequestContract {
+    SpanAttributesProvider provider;
+    NSURLComponents *components = [NSURLComponents componentsWithString:@"https://example.com/graphql"];
+    components.queryItems = @[
+        [NSURLQueryItem queryItemWithName:@"operationName" value:@"Continents"],
+        [NSURLQueryItem queryItemWithName:@"query" value:@"query Continents { continents { name } }"],
+    ];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:components.URL];
+    request.HTTPMethod = @"GET";
+    auto attributes = provider.graphQLAttributes(request, request.URL);
+    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
+    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], @"Continents");
+}
+
+- (void)testGraphQLFailOpenCasesRemainNetworkRequests {
+    SpanAttributesProvider provider;
+    NSURL *url = [NSURL URLWithString:@"https://example.com/api"];
+    NSURLRequest *rest = [self graphQLPostRequestWithJSONObject:@{@"operationName": @"not-graphql", @"value": @1}];
+    XCTAssertEqual(0U, provider.graphQLAttributes(rest, url).count);
+
+    NSURLRequest *emptyQuery = [self graphQLPostRequestWithJSONObject:@{@"query": @""}];
+    XCTAssertEqual(0U, provider.graphQLAttributes(emptyQuery, url).count);
+
+    NSMutableURLRequest *nonJSON = [self graphQLPostRequestWithJSONObject:@{@"query": @"query Test { test }"}];
+    [nonJSON setValue:@"text/plain" forHTTPHeaderField:@"Content-Type"];
+    XCTAssertEqual(0U, provider.graphQLAttributes(nonJSON, url).count);
+
+    NSMutableURLRequest *malformedJSON = [NSMutableURLRequest requestWithURL:url];
+    malformedJSON.HTTPMethod = @"POST";
+    malformedJSON.HTTPBody = [@"{\"query\":" dataUsingEncoding:NSUTF8StringEncoding];
+    XCTAssertEqual(0U, provider.graphQLAttributes(malformedJSON, url).count);
+
+    NSURLRequest *batch = [self graphQLPostRequestWithJSONObject:@[
+        @{@"operationName": @"One", @"query": @"query One { one }"},
+        @{@"operationName": @"Two", @"query": @"query Two { two }"},
+    ]];
+    XCTAssertEqual(0U, provider.graphQLAttributes(batch, url).count);
+
+    NSMutableURLRequest *oversized = [NSMutableURLRequest requestWithURL:url];
+    oversized.HTTPMethod = @"POST";
+    oversized.HTTPBody = [NSMutableData dataWithLength:64 * 1024 + 1];
+    XCTAssertEqual(0U, provider.graphQLAttributes(oversized, url).count);
+
+    NSMutableURLRequest *streamed = [NSMutableURLRequest requestWithURL:url];
+    streamed.HTTPMethod = @"POST";
+    streamed.HTTPBodyStream = [NSInputStream inputStreamWithData:[@"{\"query\":\"{ viewer }\"}" dataUsingEncoding:NSUTF8StringEncoding]];
+    XCTAssertEqual(0U, provider.graphQLAttributes(streamed, url).count);
 }
 
 - (void)testInternalErrorAttributes {

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -55,7 +55,6 @@ using namespace bugsnag;
 - (void)assertGraphQLRequest:(NSURLRequest *)request
                operationType:(NSString *)operationType
                operationName:(NSString *)operationName
-                 displayName:(NSString *)displayName
                     spanName:(NSString *)spanName {
     SpanAttributesProvider provider;
     auto attributes = provider.graphQLAttributes(request, request.URL);
@@ -63,7 +62,6 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
     XCTAssertEqualObjects(attributes[@"graphql.operation.type"], operationType);
     XCTAssertEqualObjects(attributes[@"graphql.operation.name"], operationName);
-    XCTAssertEqualObjects(attributes[@"display_name"], displayName);
     XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), spanName);
 }
 
@@ -83,7 +81,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"BugsnagGetUser"
-                   displayName:@"query /graphql (BugsnagGetUser)"
                       spanName:@"[GraphQL] [api.example.com/graphql] query:BugsnagGetUser"];
 }
 
@@ -96,7 +93,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"mutation"
                  operationName:@"UpdateCart"
-                   displayName:@"mutation /graphql (UpdateCart)"
                       spanName:@"[GraphQL] [api.example.com/graphql] mutation:UpdateCart"];
 }
 
@@ -109,7 +105,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"subscription"
                  operationName:@"BugsnagMessageSubscription"
-                   displayName:@"subscription /graphql (BugsnagMessageSubscription)"
                       spanName:@"[GraphQL] [api.example.com/graphql] subscription:BugsnagMessageSubscription"];
 }
 
@@ -122,7 +117,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"BugsnagGetQuery"
-                   displayName:@"query /graphql (BugsnagGetQuery)"
                       spanName:@"[GraphQL] [api.example.com/graphql] query:BugsnagGetQuery"];
 }
 
@@ -135,7 +129,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"BugsnagApplicationGraphQL"
-                   displayName:@"query /graphql (BugsnagApplicationGraphQL)"
                       spanName:@"[GraphQL] [api.example.com/graphql] query:BugsnagApplicationGraphQL"];
 }
 
@@ -151,8 +144,8 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
     XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
     XCTAssertNil(attributes[@"graphql.operation.name"]);
-    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql");
-    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] [api.example.com/graphql] query:<anonymous>");
+    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes),
+                              @"[GraphQL] [api.example.com/graphql] query");
 }
 
 - (void)testOperationNameFieldTakesPriority {
@@ -164,7 +157,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"SelectedOperation"
-                   displayName:@"query /graphql (SelectedOperation)"
                       spanName:@"[GraphQL] [api.example.com/graphql] query:SelectedOperation"];
 }
 
@@ -279,7 +271,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"BodyLimitExact"
-                   displayName:@"query /graphql (BodyLimitExact)"
                       spanName:@"[GraphQL] [api.example.com/graphql] query:BodyLimitExact"];
 }
 
@@ -309,7 +300,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:operationName
-                   displayName:[NSString stringWithFormat:@"query /graphql (%@)", operationName]
                       spanName:[NSString stringWithFormat:@"[GraphQL] [api.example.com/graphql] query:%@", operationName]];
 }
 
@@ -329,8 +319,8 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
     XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
     XCTAssertNil(attributes[@"graphql.operation.name"]);
-    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql");
-    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] [api.example.com/graphql] query:<anonymous>");
+    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes),
+                              @"[GraphQL] [api.example.com/graphql] query");
 }
 
 - (void)testGraphQLTemporaryOperationAttributesAreUsedForSpanNameOnly {
@@ -346,7 +336,6 @@ using namespace bugsnag;
     [attributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
     XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"graphql");
     XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
-    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql (BugsnagTemporaryAttributes)");
     XCTAssertNil(attributes[@"graphql.operation.type"]);
     XCTAssertNil(attributes[@"graphql.operation.name"]);
 }
@@ -369,7 +358,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"mutation"
                  operationName:@"CancelSubscription"
-                   displayName:@"mutation /graphql (CancelSubscription)"
                       spanName:@"[GraphQL] [api.example.com/graphql] mutation:CancelSubscription"];
 }
 
@@ -382,7 +370,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"mutation"
                  operationName:@"UpgradeSubscription"
-                   displayName:@"mutation /graphql (UpgradeSubscription)"
                       spanName:@"[GraphQL] [api.example.com/graphql] mutation:UpgradeSubscription"];
 }
 
@@ -395,7 +382,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"GetSubscriptionStatus"
-                   displayName:@"query /graphql (GetSubscriptionStatus)"
                       spanName:@"[GraphQL] [api.example.com/graphql] query:GetSubscriptionStatus"];
 }
 
@@ -408,7 +394,6 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"subscription"
                  operationName:@"OnMessageReceived"
-                   displayName:@"subscription /graphql (OnMessageReceived)"
                       spanName:@"[GraphQL] [api.example.com/graphql] subscription:OnMessageReceived"];
 }
 
@@ -444,228 +429,7 @@ using namespace bugsnag;
     XCTAssertEqual(0U, attributes.count);
 }
 
-- (NSMutableURLRequest *)graphQLPostRequestWithJSONObject:(id)object {
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/api"]];
-    request.HTTPMethod = @"POST";
-    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-    request.HTTPBody = [NSJSONSerialization dataWithJSONObject:object options:0 error:nil];
-    return request;
-}
 
-- (void)testNamedGraphQLQueryContract {
-    SpanAttributesProvider provider;
-    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{
-        @"operationName": @"GetUser",
-        @"query": @"query GetUser($id: ID!) { user(id: $id) { name } }",
-        @"variables": @{@"id": @"private-value"},
-    }];
-    NSURL *reportedURL = [NSURL URLWithString:@"https://api.example.com/graphql?key=private"];
-
-    auto attributes = provider.graphQLAttributes(request, reportedURL);
-
-    XCTAssertEqual(5U, attributes.count);
-    XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"graphql");
-    XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
-    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql (GetUser)");
-    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
-    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], @"GetUser");
-    XCTAssertEqualObjects(provider.graphQLSpanName(reportedURL, attributes), @"[GraphQL] [api.example.com/graphql] query:GetUser");
-    XCTAssertFalse([[attributes description] containsString:@"private-value"]);
-    XCTAssertFalse([[attributes description] containsString:@"query GetUser"]);
-}
-
-- (void)testDerivesGraphQLOperationNameFromDocument {
-    SpanAttributesProvider provider;
-    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{
-        @"query": @"# comment\nmutation UpdateProfile { updateProfile { id } }",
-    }];
-    NSURL *url = request.URL;
-
-    auto attributes = provider.graphQLAttributes(request, url);
-
-    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"mutation");
-    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], @"UpdateProfile");
-    XCTAssertEqualObjects(attributes[@"display_name"], @"mutation /api (UpdateProfile)");
-    XCTAssertEqualObjects(provider.graphQLSpanName(url, attributes), @"[GraphQL] [example.com/api] mutation:UpdateProfile");
-}
-
-- (void)testAnonymousGraphQLQueryContract {
-    SpanAttributesProvider provider;
-    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{@"query": @"{ viewer { id } }"}];
-    NSURL *url = [NSURL URLWithString:@"https://api.example.com/graphql"];
-
-    auto attributes = provider.graphQLAttributes(request, url);
-
-    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql");
-    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
-    XCTAssertNil(attributes[@"graphql.operation.name"]);
-    XCTAssertEqualObjects(provider.graphQLSpanName(url, attributes), @"[GraphQL] [api.example.com/graphql] query:<anonymous>");
-}
-
-- (void)testUnknownTypeDefaultsToQueryContract {
-    SpanAttributesProvider provider;
-    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{
-        @"operationName": @"GetUser",
-        @"query": @"not a parseable operation { value }",
-    }];
-    NSURL *url = [NSURL URLWithString:@"https://api.example.com/graphql"];
-
-    auto attributes = provider.graphQLAttributes(request, url);
-
-    XCTAssertEqualObjects(attributes[@"display_name"], @"query /graphql (GetUser)");
-    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
-    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], @"GetUser");
-    XCTAssertEqualObjects(provider.graphQLSpanName(url, attributes), @"[GraphQL] [api.example.com/graphql] query:GetUser");
-}
-
-- (void)testSelectsRequestedOperationFromGraphQLDocument {
-    SpanAttributesProvider provider;
-    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{
-        @"operationName": @"Second",
-        @"query": @"query First { first } subscription Second { second }",
-    }];
-    auto attributes = provider.graphQLAttributes(request, request.URL);
-    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"subscription");
-    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], @"Second");
-}
-
-- (void)testGraphQLEndpointNormalization {
-    SpanAttributesProvider provider;
-    NSURLRequest *request = [self graphQLPostRequestWithJSONObject:@{
-        @"operationName": @"GetUser",
-        @"query": @"query GetUser { user { id } }",
-    }];
-    NSDictionary<NSString *, NSString *> *cases = @{
-        @"https://api.example.com/graphql":             @"/graphql",
-        @"https://api.example.com/graphql?key=abc":     @"/graphql",
-        @"https://api.example.com/":                    @"/",
-        @"https://api.example.com":                     @"/",
-        @"https://api.example.com/v2/graphql":          @"/v2/graphql",
-        @"https://api.example.com/users/123/graphql":   @"/users/123/graphql",
-    };
-    for (NSString *urlString in cases) {
-        NSURL *url = [NSURL URLWithString:urlString];
-        auto attributes = provider.graphQLAttributes(request, url);
-        NSString *expectedEndpoint = [NSString stringWithFormat:@"%@%@", url.host, cases[urlString]];
-        NSString *expectedSpanName = [NSString stringWithFormat:@"[GraphQL] [%@] query:GetUser", expectedEndpoint];
-        XCTAssertEqualObjects(provider.graphQLSpanName(url, attributes), expectedSpanName);
-        NSString *expectedDisplayName = [NSString stringWithFormat:@"query %@ (GetUser)", cases[urlString]];
-        XCTAssertEqualObjects(attributes[@"display_name"], expectedDisplayName);
-    }
-}
-
-- (void)testGraphQLDetectionSignalsFromED {
-    SpanAttributesProvider provider;
-
-    // Detection via Content-Type: application/graphql
-    NSMutableURLRequest *contentType = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/api"]];
-    contentType.HTTPMethod = @"POST";
-    [contentType setValue:@"application/graphql" forHTTPHeaderField:@"Content-Type"];
-    contentType.HTTPBody = [@"mutation UpdateThing { updateThing }" dataUsingEncoding:NSUTF8StringEncoding];
-    auto attributes = provider.graphQLAttributes(contentType, contentType.URL);
-    NSString *expectedSpanName1 = @"[GraphQL] [example.com/api] mutation:UpdateThing";
-    XCTAssertEqualObjects(provider.graphQLSpanName(contentType.URL, attributes), expectedSpanName1);
-
-    // Endpoint-only URL (no body/content-type signal) should return empty attributes
-    NSMutableURLRequest *endpoint = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/api/v1/graphql"]];
-    endpoint.HTTPMethod = @"POST";
-    attributes = provider.graphQLAttributes(endpoint, endpoint.URL);
-    XCTAssertEqual(0U, attributes.count);
-    XCTAssertNil(provider.graphQLSpanName(endpoint.URL, attributes));
-
-    // Detection via JSON body key "mutation" — use explicit URL matching expected span
-    NSURL *mutationURL = [NSURL URLWithString:@"https://api.example.com/graphql"];
-    NSData *mutationBody = [NSJSONSerialization dataWithJSONObject:@{
-        @"operationName": @"UpdateThing",
-        @"mutation": @"{ updateThing }",
-    } options:0 error:nil];
-    NSMutableURLRequest *mutationKey = [NSMutableURLRequest requestWithURL:mutationURL];
-    mutationKey.HTTPMethod = @"POST";
-    [mutationKey setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-    mutationKey.HTTPBody = mutationBody;
-    attributes = provider.graphQLAttributes(mutationKey, mutationKey.URL);
-    NSString *expectedSpanName2 = @"[GraphQL] [api.example.com/graphql] mutation:UpdateThing";
-    XCTAssertEqualObjects(provider.graphQLSpanName(mutationKey.URL, attributes), expectedSpanName2);
-}
-
-- (void)testGraphQLEndpointRequiresCompletePathComponent {
-    SpanAttributesProvider provider;
-    NSArray<NSString *> *ordinaryPaths = @[
-        @"https://example.com/graphqlite",
-        @"https://example.com/api/graphql-helper",
-        @"https://example.com/notgraphql",
-    ];
-    for (NSString *urlString in ordinaryPaths) {
-        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]];
-        request.HTTPMethod = @"GET";
-        XCTAssertEqual(0U, provider.graphQLAttributes(request, request.URL).count);
-    }
-
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/api/GraphQL/v1"]];
-    request.HTTPMethod = @"GET";
-    XCTAssertEqual(0U, provider.graphQLAttributes(request, request.URL).count);
-}
-
-- (void)testGraphQLOperationMetadataIsRemovedFromEmittedAttributes {
-    SpanAttributesProvider provider;
-    NSMutableDictionary *attributes = provider.graphQLAttributes(
-        [self graphQLPostRequestWithJSONObject:@{@"operationName": @"GetUser", @"query": @"query GetUser { user }"}],
-        [NSURL URLWithString:@"https://example.com/graphql"]);
-    XCTAssertNotNil(provider.graphQLSpanName(nil, attributes));
-    [attributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
-    XCTAssertNil(attributes[@"graphql.operation.type"]);
-    XCTAssertNil(attributes[@"graphql.operation.name"]);
-    XCTAssertEqualObjects(attributes[@"bugsnag.span.first_class"], @YES);
-}
-
-- (void)testGraphQLGetRequestContract {
-    SpanAttributesProvider provider;
-    NSURLComponents *components = [NSURLComponents componentsWithString:@"https://example.com/graphql"];
-    components.queryItems = @[
-        [NSURLQueryItem queryItemWithName:@"operationName" value:@"Continents"],
-        [NSURLQueryItem queryItemWithName:@"query" value:@"query Continents { continents { name } }"],
-    ];
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:components.URL];
-    request.HTTPMethod = @"GET";
-    auto attributes = provider.graphQLAttributes(request, request.URL);
-    XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
-    XCTAssertEqualObjects(attributes[@"graphql.operation.name"], @"Continents");
-}
-
-- (void)testGraphQLFailOpenCasesRemainNetworkRequests {
-    SpanAttributesProvider provider;
-    NSURL *url = [NSURL URLWithString:@"https://example.com/api"];
-    NSURLRequest *rest = [self graphQLPostRequestWithJSONObject:@{@"operationName": @"not-graphql", @"value": @1}];
-    XCTAssertEqual(0U, provider.graphQLAttributes(rest, url).count);
-
-    NSURLRequest *emptyQuery = [self graphQLPostRequestWithJSONObject:@{@"query": @""}];
-    XCTAssertEqual(0U, provider.graphQLAttributes(emptyQuery, url).count);
-
-    NSMutableURLRequest *nonJSON = [self graphQLPostRequestWithJSONObject:@{@"query": @"query Test { test }"}];
-    [nonJSON setValue:@"text/plain" forHTTPHeaderField:@"Content-Type"];
-    XCTAssertEqual(0U, provider.graphQLAttributes(nonJSON, url).count);
-
-    NSMutableURLRequest *malformedJSON = [NSMutableURLRequest requestWithURL:url];
-    malformedJSON.HTTPMethod = @"POST";
-    malformedJSON.HTTPBody = [@"{\"query\":" dataUsingEncoding:NSUTF8StringEncoding];
-    XCTAssertEqual(0U, provider.graphQLAttributes(malformedJSON, url).count);
-
-    NSURLRequest *batch = [self graphQLPostRequestWithJSONObject:@[
-        @{@"operationName": @"One", @"query": @"query One { one }"},
-        @{@"operationName": @"Two", @"query": @"query Two { two }"},
-    ]];
-    XCTAssertEqual(0U, provider.graphQLAttributes(batch, url).count);
-
-    NSMutableURLRequest *oversized = [NSMutableURLRequest requestWithURL:url];
-    oversized.HTTPMethod = @"POST";
-    oversized.HTTPBody = [NSMutableData dataWithLength:64 * 1024 + 1];
-    XCTAssertEqual(0U, provider.graphQLAttributes(oversized, url).count);
-
-    NSMutableURLRequest *streamed = [NSMutableURLRequest requestWithURL:url];
-    streamed.HTTPMethod = @"POST";
-    streamed.HTTPBodyStream = [NSInputStream inputStreamWithData:[@"{\"query\":\"{ viewer }\"}" dataUsingEncoding:NSUTF8StringEncoding]];
-    XCTAssertEqual(0U, provider.graphQLAttributes(streamed, url).count);
-}
 
 - (void)testInternalErrorAttributes {
     SpanAttributesProvider provider;
@@ -674,6 +438,7 @@ using namespace bugsnag;
     XCTAssertEqual(1U, attributes.count);
     XCTAssertEqualObjects(attributes[@"bugsnag.instrumentation_message"], @"Error Domain=test Code=1 \"(null)\"");
 }
+
 
 - (void)testAppStartPhaseSpanAttributes {
     SpanAttributesProvider provider;

--- a/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
+++ b/Tests/BugsnagPerformanceTests/SpanAttributesTests.mm
@@ -81,7 +81,20 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"BugsnagGetUser"
-                      spanName:@"[GraphQL] [api.example.com/graphql] query:BugsnagGetUser"];
+                      spanName:@"GraphQL api.example.com/graphql - query:BugsnagGetUser"];
+}
+
+- (void)testGraphQLSpanNameUsesHostAndPathWithoutSchemePortQueryOrFragment {
+    SpanAttributesProvider provider;
+    NSURL *reportedURL = [NSURL URLWithString:@"https://api.example.com:8443/api/graphql?query=ignored#fragment"];
+    NSDictionary *attributes = @{
+        @"bugsnag.span.category": @"graphql",
+        @"graphql.operation.type": @"query",
+        @"graphql.operation.name": @"GetUserProfile",
+    };
+
+    XCTAssertEqualObjects(provider.graphQLSpanName(reportedURL, attributes),
+                          @"GraphQL api.example.com/api/graphql - query:GetUserProfile");
 }
 
 - (void)testGraphQLPostJsonNamedMutationDetected {
@@ -93,7 +106,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"mutation"
                  operationName:@"UpdateCart"
-                      spanName:@"[GraphQL] [api.example.com/graphql] mutation:UpdateCart"];
+                      spanName:@"GraphQL api.example.com/graphql - mutation:UpdateCart"];
 }
 
 - (void)testGraphQLPostJsonNamedSubscriptionDetected {
@@ -105,7 +118,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"subscription"
                  operationName:@"BugsnagMessageSubscription"
-                      spanName:@"[GraphQL] [api.example.com/graphql] subscription:BugsnagMessageSubscription"];
+                      spanName:@"GraphQL api.example.com/graphql - subscription:BugsnagMessageSubscription"];
 }
 
 - (void)testGraphQLGetQueryParametersDetected {
@@ -117,7 +130,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"BugsnagGetQuery"
-                      spanName:@"[GraphQL] [api.example.com/graphql] query:BugsnagGetQuery"];
+                      spanName:@"GraphQL api.example.com/graphql - query:BugsnagGetQuery"];
 }
 
 - (void)testGraphQLApplicationGraphQLContentTypeDetected {
@@ -129,7 +142,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"BugsnagApplicationGraphQL"
-                      spanName:@"[GraphQL] [api.example.com/graphql] query:BugsnagApplicationGraphQL"];
+                      spanName:@"GraphQL api.example.com/graphql - query:BugsnagApplicationGraphQL"];
 }
 
 - (void)testAnonymousGraphQLQueryUsesAnonymousSpanName {
@@ -145,7 +158,7 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
     XCTAssertNil(attributes[@"graphql.operation.name"]);
     XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes),
-                              @"[GraphQL] [api.example.com/graphql] query");
+                              @"GraphQL api.example.com/graphql - query");
 }
 
 - (void)testOperationNameFieldTakesPriority {
@@ -157,7 +170,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"SelectedOperation"
-                      spanName:@"[GraphQL] [api.example.com/graphql] query:SelectedOperation"];
+                      spanName:@"GraphQL api.example.com/graphql - query:SelectedOperation"];
 }
 
 - (void)testRestJsonBodyIsNotGraphQL {
@@ -271,7 +284,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"BodyLimitExact"
-                      spanName:@"[GraphQL] [api.example.com/graphql] query:BodyLimitExact"];
+                      spanName:@"GraphQL api.example.com/graphql - query:BodyLimitExact"];
 }
 
 - (void)testGraphQLBodyOverMaximumInspectionSizeIsSkipped {
@@ -300,7 +313,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:operationName
-                      spanName:[NSString stringWithFormat:@"[GraphQL] [api.example.com/graphql] query:%@", operationName]];
+                      spanName:[NSString stringWithFormat:@"GraphQL api.example.com/graphql - query:%@", operationName]];
 }
 
 - (void)testGraphQLOperationNameOverMaximumLengthUsesAnonymousFallback {
@@ -320,7 +333,7 @@ using namespace bugsnag;
     XCTAssertEqualObjects(attributes[@"graphql.operation.type"], @"query");
     XCTAssertNil(attributes[@"graphql.operation.name"]);
     XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes),
-                              @"[GraphQL] [api.example.com/graphql] query");
+                              @"GraphQL api.example.com/graphql - query");
 }
 
 - (void)testGraphQLTemporaryOperationAttributesAreUsedForSpanNameOnly {
@@ -331,7 +344,7 @@ using namespace bugsnag;
 
     SpanAttributesProvider provider;
     auto attributes = provider.graphQLAttributes(request, request.URL);
-    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"[GraphQL] [api.example.com/graphql] query:BugsnagTemporaryAttributes");
+    XCTAssertEqualObjects(provider.graphQLSpanName(request.URL, attributes), @"GraphQL api.example.com/graphql - query:BugsnagTemporaryAttributes");
 
     [attributes removeObjectsForKeys:@[@"graphql.operation.type", @"graphql.operation.name"]];
     XCTAssertEqualObjects(attributes[@"bugsnag.span.category"], @"graphql");
@@ -358,7 +371,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"mutation"
                  operationName:@"CancelSubscription"
-                      spanName:@"[GraphQL] [api.example.com/graphql] mutation:CancelSubscription"];
+                      spanName:@"GraphQL api.example.com/graphql - mutation:CancelSubscription"];
 }
 
 - (void)testGraphQLMutationUpgradeSubscriptionDetected {
@@ -370,7 +383,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"mutation"
                  operationName:@"UpgradeSubscription"
-                      spanName:@"[GraphQL] [api.example.com/graphql] mutation:UpgradeSubscription"];
+                      spanName:@"GraphQL api.example.com/graphql - mutation:UpgradeSubscription"];
 }
 
 - (void)testGraphQLQueryGetSubscriptionStatusDetected {
@@ -382,7 +395,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"query"
                  operationName:@"GetSubscriptionStatus"
-                      spanName:@"[GraphQL] [api.example.com/graphql] query:GetSubscriptionStatus"];
+                      spanName:@"GraphQL api.example.com/graphql - query:GetSubscriptionStatus"];
 }
 
 - (void)testGraphQLSubscriptionOnMessageReceivedDetected {
@@ -394,7 +407,7 @@ using namespace bugsnag;
     [self assertGraphQLRequest:request
                  operationType:@"subscription"
                  operationName:@"OnMessageReceived"
-                      spanName:@"[GraphQL] [api.example.com/graphql] subscription:OnMessageReceived"];
+                      spanName:@"GraphQL api.example.com/graphql - subscription:OnMessageReceived"];
 }
 
 - (void)testInitialNetworkSpanAttributes {

--- a/features/default/graphQL_request_detection.feature
+++ b/features/default/graphQL_request_detection.feature
@@ -1,0 +1,393 @@
+Feature: GraphQL span detection and attribute correctness on iOS
+
+  Scenario: GraphQL detected via URL /graphql path produces correct span
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "url_path" to "/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:GetUser"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a span bool attribute "bugsnag.span.first_class" is true
+    
+  # Scenario 1: GraphQL detected via Content-Type
+  Scenario: GraphQL detected via Content-Type produces correct span
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "url_path" to "/data"
+    And I configure scenario "content_type" to "application/graphql"
+    And I configure scenario "body" to "query GetUserProfile { user { id name } }"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:GetUserProfile"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a span bool attribute "bugsnag.span.first_class" is true
+
+  # Scenario 1b: GraphQL detected via URL /graphql path
+  Scenario: GraphQL detected via URL /graphql path produces correct span
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "detection_method" to "url_path"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"query FetchItems { items { id } }\", \"operationName\": \"FetchItems\"}"
+    And I configure scenario "expected_status" to "200"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:FetchItems"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a span bool attribute "bugsnag.span.first_class" is true
+
+  # Scenario 1c: GraphQL detected via URL /api/graphql path
+  Scenario: GraphQL detected via URL /api/graphql path produces mutation span
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "detection_method" to "url_path"
+    And I configure scenario "url" to "https://api.example.com/api/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"mutation CreatePost($input: CreatePostInput!) { createPost(input: $input) { id } }\", \"operationName\": \"CreatePost\"}"
+    And I configure scenario "expected_status" to "200"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] mutation:CreatePost"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a span bool attribute "bugsnag.span.first_class" is true
+
+  # Scenario 1d: GraphQL detected via URL /api/v1/graphql path
+  Scenario: GraphQL detected via URL /api/v1/graphql path produces subscription span
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "detection_method" to "url_path"
+    And I configure scenario "url" to "https://api.example.com/api/v1/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"subscription OnMessage { message { id text } }\", \"operationName\": \"OnMessage\"}"
+    And I configure scenario "expected_status" to "200"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] subscription:OnMessage"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a span bool attribute "bugsnag.span.first_class" is true
+
+  # Scenario 1e: GraphQL detected via body inspection on non-graphql URL
+  Scenario: GraphQL detected via body inspection on custom endpoint
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "detection_method" to "body_inspection"
+    And I configure scenario "url" to "https://api.example.com/custom-endpoint"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"mutation UpdateUser($id: ID!) { updateUser(id: $id) { id } }\", \"operationName\": \"UpdateUser\"}"
+    And I configure scenario "expected_status" to "200"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] mutation:UpdateUser"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a span bool attribute "bugsnag.span.first_class" is true
+
+  # Scenario 1f: GraphQL span created on HTTP 400 error
+  Scenario: GraphQL span created on HTTP 400 error
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "detection_method" to "url_path"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"query BadQuery { invalid }\", \"operationName\": \"BadQuery\"}"
+    And I configure scenario "expected_status" to "400"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:BadQuery"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 1g: GraphQL span created on HTTP 500 error
+  Scenario: GraphQL span created on HTTP 500 server error
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "detection_method" to "url_path"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"mutation FailOp { fail { msg } }\", \"operationName\": \"FailOp\"}"
+    And I configure scenario "expected_status" to "500"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] mutation:FailOp"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 2: Operation type extraction - operationName field priority (P1)
+  Scenario: Operation type query extracted with operationName field priority
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "2"
+    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:GetUser"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 2b: Mutation type extracted with operationName field priority
+  Scenario: Operation type mutation extracted with operationName field priority
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "2"
+    And I configure scenario "body" to "{\"query\": \"mutation CreatePost { createPost { id } }\", \"operationName\": \"CreatePost\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] mutation:CreatePost"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 2c: Subscription type extracted with operationName field priority
+  Scenario: Operation type subscription extracted with operationName field priority
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "2"
+    And I configure scenario "body" to "{\"query\": \"subscription OnMsg { message { id } }\", \"operationName\": \"OnMsg\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] subscription:OnMsg"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 2d: Document parsing fallback (P2) when no operationName field
+  Scenario: Operation name extracted from document parsing when operationName field absent
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "2"
+    And I configure scenario "body" to "{\"query\": \"query FetchOrders { orders { id total } }\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:FetchOrders"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 2e: Anonymous query defaults to query type
+  Scenario: Anonymous query defaults to query type with empty name
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "2"
+    And I configure scenario "body" to "{\"query\": \"{ user { id name } }\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:<anonymous>"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 2f: operationName field overrides document name
+  Scenario: operationName field overrides document-parsed name
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "2"
+    And I configure scenario "body" to "{\"query\": \"query DocumentName { user { id } }\", \"operationName\": \"FieldName\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:FieldName"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 3: Display name format validation
+  Scenario: Display name follows correct format for query with name
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "3"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:GetUser"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 4: Non-GraphQL REST POST retains network category
+  Scenario: Non-GraphQL REST POST retains network category
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "4"
+    And I configure scenario "http_method" to "POST"
+    And I configure scenario "url" to "https://api.example.com/rest/users"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"userId\": \"123\", \"action\": \"get\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+    * every span attribute "bugsnag.graphql.operation_type" does not exist
+
+  # Scenario 4b: JSON with "query" key that is not GraphQL retains network category
+  Scenario: JSON with query key that is not GraphQL retains network category
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "4"
+    And I configure scenario "http_method" to "POST"
+    And I configure scenario "url" to "https://api.example.com/api/search"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"shoes\", \"page\": 1}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+
+  # Scenario 4c: GET to REST endpoint retains network category
+  Scenario: GET to REST endpoint retains network category
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "4"
+    And I configure scenario "http_method" to "GET"
+    And I configure scenario "url" to "https://api.example.com/api/users/123"
+    And I configure scenario "content_type" to "application/json"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+
+  # Scenario 5: Malformed body does not crash - empty string
+  Scenario: POST to graphql with empty body does not crash and falls back to network
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "5"
+    And I configure scenario "body_type" to "empty"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+
+  # Scenario 5b: Malformed body does not crash - malformed JSON
+  Scenario: POST to graphql with malformed JSON does not crash and falls back to network
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "5"
+    And I configure scenario "body_type" to "malformed"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+
+  # Scenario 5c: Malformed body does not crash - empty JSON object
+  Scenario: POST to graphql with empty JSON object does not crash and falls back to network
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "5"
+    And I configure scenario "body_type" to "empty_object"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+
+  # Scenario 6: Edge-case operation names - very long name
+  Scenario: Very long operation name does not crash
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "6"
+    And I configure scenario "name_type" to "long"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 6b: Edge-case operation names - underscore and version suffix
+  Scenario: Operation name with underscores and version suffix is handled
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "6"
+    And I configure scenario "name_type" to "underscore_version"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:Get_User_Profile_V2"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 6c: Edge-case operation names - numeric suffix
+  Scenario: Operation name with numeric suffix is handled
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "6"
+    And I configure scenario "name_type" to "numeric_suffix"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:GetUser123"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 7: Batched GraphQL request does not crash
+  Scenario: Batched GraphQL request with multiple operations does not crash
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "7"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+
+  # Scenario 8: GET request with query params
+  Scenario: GET request to graphql with query params is detected as GraphQL
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "8"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:GetUser"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 9: Multiple operations create distinct spans
+  Scenario: Multiple GraphQL operations create distinct spans coexisting with network spans
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "9"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 4 spans
+
+  # Scenario 10: Span payload contains only safe attributes
+  Scenario: GraphQL span does not contain sensitive GraphQL-specific metadata
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "10"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:GetUser"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a span bool attribute "bugsnag.span.first_class" is true
+    * every span attribute "bugsnag.graphql.document" does not exist
+    * every span attribute "bugsnag.graphql.variables" does not exist
+    * every span attribute "bugsnag.graphql.operationType" does not exist
+    * every span attribute "bugsnag.graphql.operationName" does not exist
+
+  # Scenario 11: first_class=false prevents span grouping
+  Scenario: GraphQL span with first_class false is not aggregated
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "11"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a span bool attribute "bugsnag.span.first_class" is false
+
+  # Scenario 12: GraphQL span created on request timeout
+  Scenario: GraphQL span is created even when request times out
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "12"
+    And I configure scenario "failure_type" to "timeout"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:GetUser"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 12b: GraphQL span created on connection refused
+  Scenario: GraphQL request with connection refused does not crash and produces no span
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "12"
+    And I configure scenario "failure_type" to "connection_refused"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 5 seconds
+    Then I should receive no spans
+
+  # Scenario 13: iOS SDK via GraphQL client library
+  Scenario: iOS SDK produces GraphQL span via supported client library without document attribute
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "13"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "[GraphQL] query:GetUser"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * every span attribute "bugsnag.graphql.document" does not exist
+
+  # Scenario 14: Consistent span names for pipeline grouping
+  Scenario: Multiple identical operations produce consistent span names for pipeline grouping
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "14"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 3 spans

--- a/features/default/graphQL_request_detection.feature
+++ b/features/default/graphQL_request_detection.feature
@@ -3,28 +3,73 @@ Feature: GraphQL span detection and attribute correctness on iOS
   Background:
     Given I load scenario "GraphQLDetectScenario"
 
-  # ─── SCENARIO 4: Malformed body fallback to network (4 cases) ─────────────────────
-  Scenario Outline: POST to /graphql with <body_type> body does not crash and falls back to network
-    And I configure scenario "scenario_number" to "5"
-    And I configure scenario "body_type" to "<body_type>"
+  # ─── SCENARIO 1: Detection produces correct span with full attributes (10 cases) ─────────────
+  Scenario Outline: GraphQL detected via <detection_method> produces correct span with full attributes
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "detection_method" to "<detection_method>"
+    And I configure scenario "url" to "<url>"
+    And I configure scenario "content_type" to "<content_type>"
+    And I configure scenario "body" to "<body>"
+    And I configure scenario "expected_status" to "<status>"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span string attribute "bugsnag.span.category" equals "network"
+    Then a span field "name" matches the regex "<name_regex>"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "POST"
+    And a span integer attribute "http.status_code" equals <status>
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
     And every span attribute "graphql.operation.type" does not exist
     And every span attribute "graphql.operation.name" does not exist
 
     Examples:
-      | body_type    |
-      | empty        |
-      | malformed    |
-      | empty_object |
-      | null         |
+      | detection_method                  | url                                          | content_type        | body                                                                                                                                          | status | name_regex                                               |
+      | url_path (/graphql + JSON body)   | https://api.example.com/graphql              | application/json    | {\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}                                                                | 200    | ^GraphQL .+/graphql - query:GetUser$                     |
+      | Content-Type (application/graphql)| https://api.example.com/data                 | application/graphql | query GetUserProfile { user { id name } }                                                                                                     | 200    | ^GraphQL .+/data - query:GetUserProfile$                 |
+      | url_path (/graphql)               | https://api.example.com/graphql              | application/json    | {\"query\": \"query FetchItems { items { id } }\", \"operationName\": \"FetchItems\"}                                                         | 200    | ^GraphQL .+/graphql - query:FetchItems$                  |
+      | url_path (/api/graphql)           | https://api.example.com/api/graphql          | application/json    | {\"query\": \"mutation CreatePost($input: CreatePostInput!) { createPost(input: $input) { id } }\", \"operationName\": \"CreatePost\"}         | 200    | ^GraphQL .+/api/graphql - mutation:CreatePost$           |
+      | url_path (/api/v1/graphql)        | https://api.example.com/api/v1/graphql       | application/json    | {\"query\": \"subscription OnMessage { message { id text } }\", \"operationName\": \"OnMessage\"}                                             | 200    | ^GraphQL .+/api/v1/graphql - subscription:OnMessage$     |
+      | url_path (/graphql/ trailing)     | https://api.example.com/graphql/             | application/json    | {\"query\": \"query GetProfile { profile { name } }\", \"operationName\": \"GetProfile\"}                                                     | 200    | ^GraphQL .+/graphql/? - query:GetProfile$                |
+      | body_inspection (custom URL)      | https://api.example.com/custom-endpoint      | application/json    | {\"query\": \"mutation UpdateUser($id: ID!) { updateUser(id: $id) { id } }\", \"operationName\": \"UpdateUser\"}                              | 200    | ^GraphQL .+/custom-endpoint - mutation:UpdateUser$       |
+      | url_path (HTTP 400 error)         | https://api.example.com/graphql              | application/json    | {\"query\": \"query BadQuery { invalid }\", \"operationName\": \"BadQuery\"}                                                                  | 400    | ^GraphQL .+/graphql - query:BadQuery$                    |
+      | url_path (HTTP 401 unauthorized)  | https://api.example.com/graphql              | application/json    | {\"query\": \"query GetSecret { secret { value } }\", \"operationName\": \"GetSecret\"}                                                      | 401    | ^GraphQL .+/graphql - query:GetSecret$                   |
+      | url_path (HTTP 500 server error)  | https://api.example.com/graphql              | application/json    | {\"query\": \"mutation FailOp { fail { msg } }\", \"operationName\": \"FailOp\"}                                                              | 500    | ^GraphQL .+/graphql - mutation:FailOp$                   |
 
-  # ─── SCENARIO 5: Edge-case operation names (3 cases) ──────────────────────────────
-  Scenario Outline: Operation name with <label> is handled without crash or data loss
-    And I configure scenario "scenario_number" to "6"
-    And I configure scenario "name_type" to "<name_type>"
+  # ─── SCENARIO 2: Operation type/name extraction (8 cases) ─────────────────────────────────────
+  Scenario Outline: Operation type <op_type> correctly extracted via <priority>
+    And I configure scenario "scenario_number" to "2"
+    And I configure scenario "body" to "<body>"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "<name_regex>"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "POST"
+    And a span integer attribute "http.status_code" equals 200
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
+    And every span attribute "graphql.operation.type" does not exist
+    And every span attribute "graphql.operation.name" does not exist
+
+    Examples:
+      | priority                         | op_type      | body                                                                                                   | name_regex                                    |
+      | operationName field (P1)         | query        | {\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}                         | ^GraphQL .+/graphql - query:GetUser$          |
+      | operationName field (P1)         | mutation     | {\"query\": \"mutation CreatePost { createPost { id } }\", \"operationName\": \"CreatePost\"}          | ^GraphQL .+/graphql - mutation:CreatePost$    |
+      | operationName field (P1)         | subscription | {\"query\": \"subscription OnMsg { message { id } }\", \"operationName\": \"OnMsg\"}                   | ^GraphQL .+/graphql - subscription:OnMsg$     |
+      | document parsing (P2)            | query        | {\"query\": \"query FetchOrders { orders { id total } }\"}                                             | ^GraphQL .+/graphql - query:FetchOrders$      |
+      | anonymous (P3, no type or name)  | (anonymous)  | {\"query\": \"{ user { id name } }\"}                                                                  | ^GraphQL .+/graphql$                          |
+      | operationName overrides doc name | query        | {\"query\": \"query DocumentName { user { id } }\", \"operationName\": \"FieldName\"}                  | ^GraphQL .+/graphql - query:FieldName$        |
+      | document parsing (P2)            | mutation     | {\"query\": \"mutation DeleteItem { deleteItem { success } }\"}                                        | ^GraphQL .+/graphql - mutation:DeleteItem$    |
+      | type present, name absent        | query        | {\"query\": \"query { user { id } }\"}                                                                 | ^GraphQL .+/graphql - query$                  |
+
+  # ─── SCENARIO 3: Span name format validation (6 cases) ────────────────────────
+  Scenario Outline: Span name follows correct format for <description>
+    And I configure scenario "scenario_number" to "3"
+    And I configure scenario "url" to "<url>"
+    And I configure scenario "body" to "<body>"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
@@ -37,24 +82,107 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And every span attribute "bugsnag.graphql.variables" does not exist
 
     Examples:
-      | label                       | name_type          | name_regex                                            |
-      | very long name (128+ chars) | long               | ^GraphQL .+/graphql - query:.{128,}$                  |
-      | underscores and version     | underscore_version | ^GraphQL .+/graphql - query:Get_User_Profile_V2$      |
-      | numeric suffix              | numeric_suffix     | ^GraphQL .+/graphql - query:GetUser123$               |
+      | description                      | url                                     | body                                                                                                   | name_regex                                    |
+      | query with name                  | https://api.example.com/graphql         | {\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}                         | ^GraphQL .+/graphql - query:GetUser$          |
+      | mutation with name               | https://api.example.com/graphql         | {\"query\": \"mutation UpdateCart { cart { id } }\", \"operationName\": \"UpdateCart\"}                 | ^GraphQL .+/graphql - mutation:UpdateCart$     |
+      | subscription with name           | https://api.example.com/graphql         | {\"query\": \"subscription OnNotify { notify { id } }\", \"operationName\": \"OnNotify\"}              | ^GraphQL .+/graphql - subscription:OnNotify$  |
+      | anonymous query (no name)        | https://api.example.com/graphql         | {\"query\": \"query { user { id } }\"}                                                                 | ^GraphQL .+/graphql - query$                  |
+      | unknown type with operationName  | https://api.example.com/graphql         | {\"query\": \"{ user { id } }\", \"operationName\": \"GetUser\"}                                       | ^GraphQL .+/graphql - query:GetUser$          |
+      | custom endpoint path             | https://api.example.com/api/graphql     | {\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}                         | ^GraphQL .+/api/graphql - query:GetUser$      |
 
-  # ─── SCENARIO 6: Batched GraphQL request (1 case) ──────────────────────────────────
-  Scenario: Batched GraphQL request with multiple operations does not crash and falls back to network
-    And I configure scenario "scenario_number" to "7"
+  # ─── SCENARIO 4: Non-GraphQL requests retain network category (6 cases) ──────────────────────
+  Scenario Outline: Non-GraphQL <case> request retains network category
+    And I configure scenario "scenario_number" to "4"
+    And I configure scenario "http_method" to "<http_method>"
+    And I configure scenario "url" to "<url>"
+    And I configure scenario "content_type" to "<content_type>"
+    And I configure scenario "body" to "<body>"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
     Then a span string attribute "bugsnag.span.category" equals "network"
+    And a span field "name" does not match the regex "^GraphQL.*"
     And every span attribute "graphql.operation.type" does not exist
     And every span attribute "graphql.operation.name" does not exist
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # ─── SCENARIO 7: GET with query params (1 case) ────────────────────────────────────
+    Examples:
+      | case                              | http_method | url                                    | content_type     | body                                                             |
+      | Standard REST POST                | POST        | https://api.example.com/rest/users     | application/json | {\"userId\": \"123\", \"action\": \"get\"}                       |
+      | JSON with query key (not GraphQL) | POST        | https://api.example.com/api/search     | application/json | {\"query\": \"shoes\", \"page\": 1}                              |
+      | GET to REST endpoint              | GET         | https://api.example.com/api/users/123  | application/json |                                                                  |
+      | Natural language query body       | POST        | https://api.example.com/api/search     | application/json | {\"query\": \"find all users named John\", \"limit\": 10}        |
+      | XML content type                  | POST        | https://api.example.com/api/data       | application/xml  | <request><query>GetUser</query></request>                        |
+      | text/html content type            | POST        | https://api.example.com/submit         | text/html        | <html><body>test</body></html>                                   |
+
+  # ─── SCENARIO 5: Malformed body fallback to network (4 cases) ─────────────────────────────────
+  Scenario Outline: POST to /graphql with <body_label> does not crash and falls back to network
+    And I configure scenario "scenario_number" to "5"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "<body>"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span string attribute "bugsnag.span.category" equals "network"
+    And a span field "name" does not match the regex "^GraphQL.*"
+    And every span attribute "graphql.operation.type" does not exist
+    And every span attribute "graphql.operation.name" does not exist
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
+
+    Examples:
+      | body_label        | body           |
+      | empty string      |                |
+      | malformed JSON    | {invalid json  |
+      | empty JSON object | {}             |
+      | null value        | null           |
+
+  # ─── SCENARIO 6: Edge-case operation names (3 cases) ──────────────────────────
+  Scenario Outline: Operation name with <label> is handled without crash or data loss
+    And I configure scenario "scenario_number" to "6"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "body" to "<body>"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "<name_regex>"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "POST"
+    And a span integer attribute "http.status_code" equals 200
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
+
+    Examples:
+      | label                       | name_regex                               | body                                                                                                   |
+      | very long name (128+ chars) | ^GraphQL .+ - query:.{128,}$             | __long_128__                                                                                           |
+      | underscores and version     | ^GraphQL .+ - query:Get_User_Profile_V2$ | {\"query\": \"query Get_User_Profile_V2 { user { id } }\", \"operationName\": \"Get_User_Profile_V2\"} |
+      | numeric suffix              | ^GraphQL .+ - query:GetUser123$          | {\"query\": \"query GetUser123 { user { id } }\", \"operationName\": \"GetUser123\"}                   |
+      
+  # ─── SCENARIO 7: Batched GraphQL request (1 case) ─────────────────────────────
+  Scenario: Batched GraphQL request with multiple operations does not crash and falls back to network
+    And I configure scenario "scenario_number" to "7"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "[{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}, {\"query\": \"query GetPosts { posts { id } }\", \"operationName\": \"GetPosts\"}]"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span string attribute "bugsnag.span.category" equals "network"
+    And a span field "name" does not match the regex "^GraphQL.*"
+    And a span integer attribute "http.status_code" equals 200
+    And every span attribute "graphql.operation.type" does not exist
+    And every span attribute "graphql.operation.name" does not exist
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
+
+  # ─── SCENARIO 8: GET with query params (1 case) ──────────────────────────────
   Scenario: GET request to /graphql with query params is detected as GraphQL
     And I configure scenario "scenario_number" to "8"
+    And I configure scenario "http_method" to "GET"
+    And I configure scenario "url" to "https://api.example.com/graphql?query={user{id}}&operationName=GetUser"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
@@ -66,19 +194,36 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And every span attribute "bugsnag.graphql.document" does not exist
     And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # ─── SCENARIO 8: Multiple operations create distinct spans (1 case) ─────────────────
+  # ─── SCENARIO 9: Multiple operations create distinct spans (1 case) ──────────
   Scenario: Multiple GraphQL operations create distinct spans coexisting with network spans
     And I configure scenario "scenario_number" to "9"
+    And I configure scenario "graphql_body_1" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+    And I configure scenario "graphql_body_2" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+    And I configure scenario "graphql_body_3" to "{\"query\": \"mutation CreatePost { createPost { id } }\", \"operationName\": \"CreatePost\"}"
+    And I configure scenario "rest_url" to "https://api.example.com/rest/users/123"
     And I start bugsnag
     And I run the loaded scenario
-    And I wait to receive at least 4 spans
+    And I wait for exactly 4 spans
+    # 2 GraphQL query spans
     Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    # 1 GraphQL mutation span
     And a span field "name" matches the regex "^GraphQL .+/graphql - mutation:CreatePost$"
+    # 1 Network span (REST GET)
+    And a span string attribute "bugsnag.span.category" equals "network"
+    # GraphQL spans have correct attributes
     And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span integer attribute "http.status_code" equals 200
+    # No sensitive data leaked
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # ─── SCENARIO 9: Safe attributes only — no GraphQL-specific metadata (1 case) ────
-  Scenario: GraphQL span payload contains only HTTP attributes — no GraphQL-specific metadata
+  # ─── SCENARIO 10: Safe attributes only — no sensitive GraphQL metadata (1 case) ─
+  Scenario: GraphQL span payload contains only HTTP attributes — no sensitive GraphQL metadata leaked
     And I configure scenario "scenario_number" to "10"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"query GetUser($id: ID!) { user(id: $id) { id name email sensitiveData } }\", \"operationName\": \"GetUser\", \"variables\": {\"id\": \"user_secret_123\"}}"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
@@ -93,8 +238,10 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And every span attribute "graphql.variables" does not exist
     And every span attribute "bugsnag.graphql.document" does not exist
     And every span attribute "bugsnag.graphql.variables" does not exist
+    And no span attribute value contains "user_secret_123"
+    And no span attribute value contains "sensitiveData"
 
-  # ─── SCENARIO 10: first_class false (1 case) ───────────────────────────────────────
+  # ─── SCENARIO 11: first_class false (1 case) ─────────────────────────────────────────────────
   Scenario: GraphQL span with explicit first_class=false is not aggregated into span groups
     And I configure scenario "scenario_number" to "11"
     And I configure scenario "first_class" to "false"
@@ -106,10 +253,11 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And a span string attribute "http.method" equals "POST"
     And a span integer attribute "http.status_code" equals 200
 
-  # ─── SCENARIO 11: Failure conditions — span expected (1 case) ──────────────────────
+  # ─── SCENARIO 12: Failure conditions — span expected on timeout ────────────────
   Scenario: GraphQL span is created even when request times out
     And I configure scenario "scenario_number" to "12"
     And I configure scenario "failure_type" to "timeout"
+    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
@@ -117,93 +265,73 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And a span string attribute "bugsnag.span.category" equals "graphql"
     And a span bool attribute "bugsnag.span.first_class" is true
     And a span string attribute "http.method" equals "POST"
+    And a span field "startTimeUnixNano" is greater than 0
+    And a span field "endTimeUnixNano" is greater than 0
     And every span attribute "bugsnag.graphql.document" does not exist
     And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # ─── SCENARIO 11: Failure conditions — no span expected (2 cases) ──────────────────
-  Scenario Outline: GraphQL request with <failure_type> does not crash and produces no span
+  # ─── SCENARIO 12: Failure conditions — no span expected (2 cases) ──────────────
+  Scenario Outline: GraphQL request <failure_type> does not crash and produces no span
     And I configure scenario "scenario_number" to "12"
     And I configure scenario "failure_type" to "<failure_type>"
-    And I configure scenario "expected_status" to "<http_status>"
+    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 5 seconds
     Then I should receive no spans
 
     Examples:
-      | failure_type       | http_status |
-      | connection_refused |             |
-      | empty_response     | 204         |
+      | failure_type       |
+      | connection_refused |
+      | empty_body         |
 
-  # ─── SCENARIO 12: iOS SDK via supported GraphQL client library (1 case) ────────────
-  Scenario: iOS SDK produces GraphQL span via supported GraphQL client library without document attribute
-    And I configure scenario "scenario_number" to "13"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
-    And a span string attribute "bugsnag.span.category" equals "graphql"
-    And a span bool attribute "bugsnag.span.first_class" is true
-    And a span string attribute "http.method" equals "POST"
-    And a span integer attribute "http.status_code" equals 200
-    And every span attribute "bugsnag.graphql.document" does not exist
-    And every span attribute "graphql.document" does not exist
-    And every span attribute "bugsnag.graphql.variables" does not exist
-
-  # ─── SCENARIO 13: Consistent span names for pipeline grouping (1 case) ─────────────
-  Scenario: Multiple identical GraphQL operations produce consistent span names for pipeline grouping
+  # ─── SCENARIO 14: iOS GraphQL client library — mutation (1 case) ───────────────
+  Scenario: iOS SDK produces GraphQL span for mutation via URLSession without document attribute
     And I configure scenario "scenario_number" to "14"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 3 spans
-    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
-    And a span string attribute "bugsnag.span.category" equals "graphql"
-    And a span bool attribute "bugsnag.span.first_class" is true
-    And every span attribute "bugsnag.graphql.document" does not exist
-
-  # ─── SCENARIO 14: Consistent span names with distinct spanIds (1 case) ─────────────
-  Scenario: Multiple identical operations produce consistent span names with valid distinct spanIds
-    And I configure scenario "scenario_number" to "15"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 3 spans
-    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
-    And a span string attribute "bugsnag.span.category" equals "graphql"
-    And a span bool attribute "bugsnag.span.first_class" is true
-    And every span attribute "bugsnag.graphql.document" does not exist
-
-  # ─── SCENARIO 15: Response status — success cases (2 cases) ────────────────────────
-  Scenario Outline: GraphQL response with <error_type> sets span status to STATUS_CODE_OK
-    And I configure scenario "scenario_number" to "16"
-    And I configure scenario "error_type" to "<error_type>"
-    And I configure scenario "expected_status" to "200"
-    And I configure scenario "response_body" to "<response_body>"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"mutation UpdateCart($id: ID!) { updateCart(id: $id) { total } }\", \"variables\": {\"id\": \"cart_456\"}, \"operationName\": \"UpdateCart\"}"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - mutation:UpdateCart$"
     And a span string attribute "bugsnag.span.category" equals "graphql"
     And a span bool attribute "bugsnag.span.first_class" is true
     And a span string attribute "http.method" equals "POST"
     And a span integer attribute "http.status_code" equals 200
-    And a nested span field "status.code" equals "STATUS_CODE_OK"
     And every span attribute "bugsnag.graphql.document" does not exist
     And every span attribute "bugsnag.graphql.variables" does not exist
+    And no span attribute value contains "cart_456"
 
-    Examples:
-      | error_type                        | response_body                                                                                              |
-      | HTTP 200 success (no errors)      | {\"data\": {\"user\": {\"id\": \"1\", \"name\": \"John\"}}}                                   |
-      | HTTP 200 with empty errors array  | {\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": []}                                         |
+  # ─── SCENARIO 15: Consistent span names with distinct IDs (1 case) ─────────────
+  Scenario: Multiple identical GraphQL operations produce consistent span names with valid distinct spanIds
+    And I configure scenario "scenario_number" to "15"
+    And I configure scenario "graphql_body_1" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+    And I configure scenario "graphql_body_2" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+    And I configure scenario "graphql_body_3" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for exactly 3 spans
+    # All 3 spans must have the same consistent name
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span integer attribute "http.status_code" equals 200
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
+    # Each span must have a valid spanId and traceId
+    And every span field "spanId" exists
+    And every span field "traceId" exists
+    # All 3 spanIds must be distinct (no duplicate spans)
+    And every span has a distinct field "spanId"
 
-  # ─── SCENARIO 16: Response status — current behavior (all STATUS_CODE_OK) ─────────
-  # NOTE: The SDK currently sets STATUS_CODE_OK for all completed requests regardless of
-  # HTTP status or GraphQL errors. When error-status support is implemented, update these
-  # expected values from STATUS_CODE_OK to STATUS_CODE_ERROR.
-  Scenario Outline: GraphQL response with <error_type> produces span with status <expected_status>
+  # ─── SCENARIO 16: Response status — all cases combined (7 cases) ─────────────────────────────
+  Scenario Outline: GraphQL response with <label> sets span status to <expected_status_code>
     And I configure scenario "scenario_number" to "16"
     And I configure scenario "error_type" to "<error_type>"
     And I configure scenario "expected_status" to "<http_status>"
     And I configure scenario "response_body" to "<response_body>"
+    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
@@ -211,33 +339,16 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And a span string attribute "bugsnag.span.category" equals "graphql"
     And a span bool attribute "bugsnag.span.first_class" is true
     And a span string attribute "http.method" equals "POST"
-    And a span integer attribute "http.status_code" equals <http_status>
-    And a nested span field "status.code" equals "<expected_status>"
+    And a nested span field "status.code" equals "<expected_status_code>"
     And every span attribute "bugsnag.graphql.document" does not exist
     And every span attribute "bugsnag.graphql.variables" does not exist
 
     Examples:
-      | error_type                        | http_status | response_body                                                                                              | expected_status   |
-      | HTTP 200 with errors array        | 200         | {\"data\": null, \"errors\": [{\"message\": \"User not found\", \"path\": [\"user\"]}]}        | STATUS_CODE_OK    |
-      | HTTP 200 with partial data+errors | 200         | {\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": [{\"message\": \"Field deprecated\"}]}   | STATUS_CODE_OK    |
-      | HTTP 500 transport error          | 500         |                                                                                                            | STATUS_CODE_OK    |
-      | HTTP 401 unauthorized             | 401         |                                                                                                            | STATUS_CODE_OK    |
-
-  # ─── SCENARIO 16: Connection timeout — current behavior ────────────────────────────
-  # NOTE: Same as above — SDK currently returns STATUS_CODE_OK even on timeout.
-  # Update to STATUS_CODE_ERROR when error-status is implemented.
-  Scenario: GraphQL connection timeout produces span with status OK (error status not yet implemented)
-    And I configure scenario "scenario_number" to "16"
-    And I configure scenario "error_type" to "Connection timeout"
-    And I configure scenario "expected_status" to ""
-    And I configure scenario "response_body" to ""
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
-    And a span string attribute "bugsnag.span.category" equals "graphql"
-    And a span bool attribute "bugsnag.span.first_class" is true
-    And a span string attribute "http.method" equals "POST"
-    And a nested span field "status.code" equals "STATUS_CODE_OK"
-    And every span attribute "bugsnag.graphql.document" does not exist
-    And every span attribute "bugsnag.graphql.variables" does not exist
+      | label                             | error_type          | http_status | response_body                                                                                         | expected_status_code |
+      | HTTP 200 success (no errors)      | success             | 200         | {\"data\": {\"user\": {\"id\": \"1\", \"name\": \"John\"}}}                                          | STATUS_CODE_OK       |
+      | HTTP 200 with empty errors []     | empty_errors        | 200         | {\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": []}                                              | STATUS_CODE_OK       |
+      | HTTP 200 with errors array        | errors_array        | 200         | {\"data\": null, \"errors\": [{\"message\": \"User not found\", \"path\": [\"user\"]}]}              | STATUS_CODE_ERROR    |
+      | HTTP 200 with partial data+errors | partial_data_errors | 200         | {\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": [{\"message\": \"Field deprecated\"}]}           | STATUS_CODE_ERROR    |
+      | HTTP 500 transport error          | http_500            | 500         |                                                                                                       | STATUS_CODE_ERROR    |
+      | HTTP 401 unauthorized             | http_401            | 401         |                                                                                                       | STATUS_CODE_ERROR    |
+      | Connection timeout                | timeout             |             |                                                                                                       | STATUS_CODE_ERROR    |

--- a/features/default/graphQL_request_detection.feature
+++ b/features/default/graphQL_request_detection.feature
@@ -9,7 +9,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -23,7 +23,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/data\] query:GetUserProfile$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/data - query:GetUserProfile$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -39,7 +39,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:FetchItems$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:FetchItems$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -55,7 +55,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/api/graphql\] mutation:CreatePost$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/api/graphql - mutation:CreatePost$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -71,7 +71,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/api/v1/graphql\] subscription:OnMessage$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/api/v1/graphql - subscription:OnMessage$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -87,7 +87,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetProfile$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetProfile$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -103,7 +103,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/custom-endpoint\] mutation:UpdateUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/custom-endpoint - mutation:UpdateUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -119,7 +119,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:BadQuery$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:BadQuery$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 1h: GraphQL span created on HTTP 401 unauthorized
@@ -134,7 +134,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetSecret$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetSecret$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 1i: GraphQL span created on HTTP 500 server error
@@ -149,7 +149,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] mutation:FailOp$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - mutation:FailOp$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2: Operation type extraction - operationName field priority (P1)
@@ -160,7 +160,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2b: Mutation type extracted with operationName field priority
@@ -171,7 +171,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] mutation:CreatePost$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - mutation:CreatePost$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2c: Subscription type extracted with operationName field priority
@@ -182,7 +182,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] subscription:OnMsg$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - subscription:OnMsg$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2d: Document parsing fallback (P2) when no operationName field
@@ -193,7 +193,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:FetchOrders$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:FetchOrders$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2e: Anonymous query defaults to query type
@@ -204,7 +204,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\]$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2f: operationName field overrides document name
@@ -215,7 +215,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:FieldName$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:FieldName$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     
   # Scenario 2g: Mutation extracted from document parsing (P2, no operationName field)
@@ -226,7 +226,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] mutation:DeleteItem$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - mutation:DeleteItem$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     
   # Scenario 2h: Query type present but no operation name
@@ -237,7 +237,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 3: Display name format validation - query with name
@@ -249,7 +249,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 3b: Display name format - mutation with name
@@ -261,7 +261,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] mutation:UpdateCart$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - mutation:UpdateCart$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 3c: Display name format - subscription with name
@@ -273,7 +273,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] subscription:OnNotify$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - subscription:OnNotify$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 3d: Display name format - anonymous query (no name, omit parens)
@@ -285,7 +285,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 3e: Display name format - unknown type with known operationName
@@ -297,7 +297,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 3f: Display name format - custom endpoint path
@@ -309,7 +309,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/api/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/api/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 4: Non-GraphQL REST POST retains network category
@@ -449,7 +449,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:Get_User_Profile_V2$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:Get_User_Profile_V2$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 6c: Edge-case operation names - numeric suffix
@@ -460,7 +460,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser123$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser123$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 7: Batched GraphQL request does not crash
@@ -479,7 +479,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 9: Multiple operations create distinct spans
@@ -489,7 +489,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 4 spans
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 10: Span payload contains only safe attributes
@@ -499,7 +499,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
     * every span attribute "bugsnag.graphql.document" does not exist
@@ -526,7 +526,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 12b: GraphQL span on connection refused
@@ -557,7 +557,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * every span attribute "bugsnag.graphql.document" does not exist
 
@@ -568,7 +568,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 3 spans
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     
   # Scenario 15: Multiple identical GraphQL operations produce spans with consistent name for pipeline grouping
@@ -578,7 +578,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 3 spans
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 16: GraphQL 200 response with errors array sets span status to error
@@ -591,7 +591,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a nested span field "status.code" equals "STATUS_CODE_ERROR"
 
@@ -605,7 +605,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a nested span field "status.code" equals "STATUS_CODE_ERROR"
 
@@ -619,7 +619,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a nested span field "status.code" equals "STATUS_CODE_OK"
 
@@ -633,7 +633,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a nested span field "status.code" equals "STATUS_CODE_OK"
 
@@ -646,7 +646,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a nested span field "status.code" equals "STATUS_CODE_ERROR"
 
@@ -659,7 +659,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a nested span field "status.code" equals "STATUS_CODE_ERROR"
 
@@ -671,6 +671,6 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a nested span field "status.code" equals "STATUS_CODE_ERROR"

--- a/features/default/graphQL_request_detection.feature
+++ b/features/default/graphQL_request_detection.feature
@@ -1,676 +1,243 @@
 Feature: GraphQL span detection and attribute correctness on iOS
 
-  Scenario: GraphQL detected via configured /graphql path produces correct span
+  Background:
     Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "1"
-    And I configure scenario "url_path" to "/graphql"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is true
 
-  # Scenario 1: GraphQL detected via Content-Type
-  Scenario: GraphQL detected via Content-Type produces correct span
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "1"
-    And I configure scenario "url_path" to "/data"
-    And I configure scenario "content_type" to "application/graphql"
-    And I configure scenario "body" to "query GetUserProfile { user { id name } }"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/data - query:GetUserProfile$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is true
-
-  # Scenario 1b: GraphQL detected via URL /graphql path
-  Scenario: GraphQL detected via URL /graphql path produces correct span
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "1"
-    And I configure scenario "detection_method" to "url_path"
-    And I configure scenario "url" to "https://api.example.com/graphql"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"query FetchItems { items { id } }\", \"operationName\": \"FetchItems\"}"
-    And I configure scenario "expected_status" to "200"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:FetchItems$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is true
-
-  # Scenario 1c: GraphQL detected via URL /api/graphql path
-  Scenario: GraphQL detected via URL /api/graphql path produces mutation span
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "1"
-    And I configure scenario "detection_method" to "url_path"
-    And I configure scenario "url" to "https://api.example.com/api/graphql"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"mutation CreatePost($input: CreatePostInput!) { createPost(input: $input) { id } }\", \"operationName\": \"CreatePost\"}"
-    And I configure scenario "expected_status" to "200"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/api/graphql - mutation:CreatePost$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is true
-
-  # Scenario 1d: GraphQL detected via URL /api/v1/graphql path
-  Scenario: GraphQL detected via URL /api/v1/graphql path produces subscription span
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "1"
-    And I configure scenario "detection_method" to "url_path"
-    And I configure scenario "url" to "https://api.example.com/api/v1/graphql"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"subscription OnMessage { message { id text } }\", \"operationName\": \"OnMessage\"}"
-    And I configure scenario "expected_status" to "200"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/api/v1/graphql - subscription:OnMessage$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is true
-
-  # Scenario 1e: GraphQL detected via URL /graphql/ with trailing slash
-  Scenario: GraphQL detected via URL /graphql/ with trailing slash
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "1"
-    And I configure scenario "detection_method" to "url_path"
-    And I configure scenario "url" to "https://api.example.com/graphql/"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"query GetProfile { profile { name } }\", \"operationName\": \"GetProfile\"}"
-    And I configure scenario "expected_status" to "200"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetProfile$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is true
-
-  # Scenario 1f: GraphQL detected via body inspection on non-graphql URL
-  Scenario: GraphQL detected via body inspection on custom endpoint
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "1"
-    And I configure scenario "detection_method" to "body_inspection"
-    And I configure scenario "url" to "https://api.example.com/custom-endpoint"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"mutation UpdateUser($id: ID!) { updateUser(id: $id) { id } }\", \"operationName\": \"UpdateUser\"}"
-    And I configure scenario "expected_status" to "200"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/custom-endpoint - mutation:UpdateUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is true
-
-  # Scenario 1g: GraphQL span created on HTTP 400 error
-  Scenario: GraphQL span created on HTTP 400 error
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "1"
-    And I configure scenario "detection_method" to "url_path"
-    And I configure scenario "url" to "https://api.example.com/graphql"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"query BadQuery { invalid }\", \"operationName\": \"BadQuery\"}"
-    And I configure scenario "expected_status" to "400"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:BadQuery$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 1h: GraphQL span created on HTTP 401 unauthorized
-  Scenario: GraphQL span created on HTTP 401 unauthorized
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "1"
-    And I configure scenario "detection_method" to "url_path"
-    And I configure scenario "url" to "https://api.example.com/graphql"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"query GetSecret { secret { value } }\", \"operationName\": \"GetSecret\"}"
-    And I configure scenario "expected_status" to "401"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetSecret$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 1i: GraphQL span created on HTTP 500 server error
-  Scenario: GraphQL span created on HTTP 500 server error
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "1"
-    And I configure scenario "detection_method" to "url_path"
-    And I configure scenario "url" to "https://api.example.com/graphql"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"mutation FailOp { fail { msg } }\", \"operationName\": \"FailOp\"}"
-    And I configure scenario "expected_status" to "500"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - mutation:FailOp$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 2: Operation type extraction - operationName field priority (P1)
-  Scenario: Operation type query extracted with operationName field priority
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "2"
-    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 2b: Mutation type extracted with operationName field priority
-  Scenario: Operation type mutation extracted with operationName field priority
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "2"
-    And I configure scenario "body" to "{\"query\": \"mutation CreatePost { createPost { id } }\", \"operationName\": \"CreatePost\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - mutation:CreatePost$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 2c: Subscription type extracted with operationName field priority
-  Scenario: Operation type subscription extracted with operationName field priority
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "2"
-    And I configure scenario "body" to "{\"query\": \"subscription OnMsg { message { id } }\", \"operationName\": \"OnMsg\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - subscription:OnMsg$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 2d: Document parsing fallback (P2) when no operationName field
-  Scenario: Operation name extracted from document parsing when operationName field absent
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "2"
-    And I configure scenario "body" to "{\"query\": \"query FetchOrders { orders { id total } }\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:FetchOrders$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 2e: Anonymous query defaults to query type
-  Scenario: Anonymous query defaults to query type with empty name
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "2"
-    And I configure scenario "body" to "{\"query\": \"{ user { id name } }\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 2f: operationName field overrides document name
-  Scenario: operationName field overrides document-parsed name
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "2"
-    And I configure scenario "body" to "{\"query\": \"query DocumentName { user { id } }\", \"operationName\": \"FieldName\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:FieldName$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    
-  # Scenario 2g: Mutation extracted from document parsing (P2, no operationName field)
-  Scenario: Mutation operation name extracted from document parsing when operationName field absent
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "2"
-    And I configure scenario "body" to "{\"query\": \"mutation DeleteItem { deleteItem { success } }\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - mutation:DeleteItem$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    
-  # Scenario 2h: Query type present but no operation name
-  Scenario: Query type present with no operation name produces span with type only
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "2"
-    And I configure scenario "body" to "{\"query\": \"query { user { id } }\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 3: Display name format validation - query with name
-  Scenario: Display name follows correct format for query with name
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "3"
-    And I configure scenario "url" to "https://api.example.com/graphql"
-    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 3b: Display name format - mutation with name
-  Scenario: Display name follows correct format for mutation with name
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "3"
-    And I configure scenario "url" to "https://api.example.com/graphql"
-    And I configure scenario "body" to "{\"query\": \"mutation UpdateCart { cart { id } }\", \"operationName\": \"UpdateCart\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - mutation:UpdateCart$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 3c: Display name format - subscription with name
-  Scenario: Display name follows correct format for subscription with name
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "3"
-    And I configure scenario "url" to "https://api.example.com/graphql"
-    And I configure scenario "body" to "{\"query\": \"subscription OnNotify { notify { id } }\", \"operationName\": \"OnNotify\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - subscription:OnNotify$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 3d: Display name format - anonymous query (no name, omit parens)
-  Scenario: Display name for anonymous query omits operation name
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "3"
-    And I configure scenario "url" to "https://api.example.com/graphql"
-    And I configure scenario "body" to "{\"query\": \"query { user { id } }\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 3e: Display name format - unknown type with known operationName
-  Scenario: Display name for unknown type with known operationName
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "3"
-    And I configure scenario "url" to "https://api.example.com/graphql"
-    And I configure scenario "body" to "{\"query\": \"{ user { id } }\", \"operationName\": \"GetUser\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 3f: Display name format - custom endpoint path
-  Scenario: Display name for custom endpoint path
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "3"
-    And I configure scenario "url" to "https://api.example.com/api/graphql"
-    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/api/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 4: Non-GraphQL REST POST retains network category
-  Scenario: Non-GraphQL REST POST retains network category
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "4"
-    And I configure scenario "http_method" to "POST"
-    And I configure scenario "url" to "https://api.example.com/rest/users"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"userId\": \"123\", \"action\": \"get\"}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
-    * every span attribute "graphql.operation.type" does not exist
-    * every span attribute "graphql.operation.name" does not exist
-
-  # Scenario 4b: JSON with "query" key that is not GraphQL retains network category
-  Scenario: JSON with query key that is not GraphQL retains network category
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "4"
-    And I configure scenario "http_method" to "POST"
-    And I configure scenario "url" to "https://api.example.com/api/search"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"shoes\", \"page\": 1}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
-
-  # Scenario 4c: GET to REST endpoint retains network category
-  Scenario: GET to REST endpoint retains network category
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "4"
-    And I configure scenario "http_method" to "GET"
-    And I configure scenario "url" to "https://api.example.com/api/users/123"
-    And I configure scenario "content_type" to "application/json"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
-
-  # Scenario 4d: Natural language query body retains network category
-  Scenario: Natural language query body retains network category
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "4"
-    And I configure scenario "http_method" to "POST"
-    And I configure scenario "url" to "https://api.example.com/api/search"
-    And I configure scenario "content_type" to "application/json"
-    And I configure scenario "body" to "{\"query\": \"find all users named John\", \"limit\": 10}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
-
-  # Scenario 4e: XML content type retains network category
-  Scenario: XML content type retains network category
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "4"
-    And I configure scenario "http_method" to "POST"
-    And I configure scenario "url" to "https://api.example.com/api/data"
-    And I configure scenario "content_type" to "application/xml"
-    And I configure scenario "body" to "<request><query>GetUser</query></request>"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
-
-  # Scenario 4f: text/html content type retains network category
-  Scenario: text/html content type retains network category
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "4"
-    And I configure scenario "http_method" to "POST"
-    And I configure scenario "url" to "https://api.example.com/submit"
-    And I configure scenario "content_type" to "text/html"
-    And I configure scenario "body" to "<html><body>test</body></html>"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
-
-  # Scenario 5: Malformed body does not crash - empty string
-  Scenario: POST to graphql with empty body does not crash and falls back to network
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 4: Malformed body fallback to network (4 cases) ─────────────────────
+  Scenario Outline: POST to /graphql with <body_type> body does not crash and falls back to network
     And I configure scenario "scenario_number" to "5"
-    And I configure scenario "body_type" to "empty"
+    And I configure scenario "body_type" to "<body_type>"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
+    Then a span string attribute "bugsnag.span.category" equals "network"
+    And every span attribute "graphql.operation.type" does not exist
+    And every span attribute "graphql.operation.name" does not exist
 
-  # Scenario 5b: Malformed body does not crash - malformed JSON
-  Scenario: POST to graphql with malformed JSON does not crash and falls back to network
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "5"
-    And I configure scenario "body_type" to "malformed"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
+    Examples:
+      | body_type    |
+      | empty        |
+      | malformed    |
+      | empty_object |
+      | null         |
 
-  # Scenario 5c: Malformed body does not crash - empty JSON object
-  Scenario: POST to graphql with empty JSON object does not crash and falls back to network
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "5"
-    And I configure scenario "body_type" to "empty_object"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
-
-  # Scenario 5d: Malformed body does not crash - null body
-  Scenario: POST to graphql with null body does not crash and falls back to network
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "5"
-    And I configure scenario "body_type" to "null"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
-
-  # Scenario 6: Edge-case operation names - very long name
-  Scenario: Very long operation name does not crash
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 5: Edge-case operation names (3 cases) ──────────────────────────────
+  Scenario Outline: Operation name with <label> is handled without crash or data loss
     And I configure scenario "scenario_number" to "6"
-    And I configure scenario "name_type" to "long"
+    And I configure scenario "name_type" to "<name_type>"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "graphql"
+    Then a span field "name" matches the regex "<name_regex>"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "POST"
+    And a span integer attribute "http.status_code" equals 200
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # Scenario 6b: Edge-case operation names - underscore and version suffix
-  Scenario: Operation name with underscores and version suffix is handled
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "6"
-    And I configure scenario "name_type" to "underscore_version"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:Get_User_Profile_V2$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
+    Examples:
+      | label                       | name_type          | name_regex                                            |
+      | very long name (128+ chars) | long               | ^GraphQL .+/graphql - query:.{128,}$                  |
+      | underscores and version     | underscore_version | ^GraphQL .+/graphql - query:Get_User_Profile_V2$      |
+      | numeric suffix              | numeric_suffix     | ^GraphQL .+/graphql - query:GetUser123$               |
 
-  # Scenario 6c: Edge-case operation names - numeric suffix
-  Scenario: Operation name with numeric suffix is handled
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "6"
-    And I configure scenario "name_type" to "numeric_suffix"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser123$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-
-  # Scenario 7: Batched GraphQL request does not crash
-  Scenario: Batched GraphQL request with multiple operations does not crash
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 6: Batched GraphQL request (1 case) ──────────────────────────────────
+  Scenario: Batched GraphQL request with multiple operations does not crash and falls back to network
     And I configure scenario "scenario_number" to "7"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "network"
+    Then a span string attribute "bugsnag.span.category" equals "network"
+    And every span attribute "graphql.operation.type" does not exist
+    And every span attribute "graphql.operation.name" does not exist
 
-  # Scenario 8: GET request with query params
-  Scenario: GET request to graphql with query params is detected as GraphQL
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 7: GET with query params (1 case) ────────────────────────────────────
+  Scenario: GET request to /graphql with query params is detected as GraphQL
     And I configure scenario "scenario_number" to "8"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "GET"
+    And a span integer attribute "http.status_code" equals 200
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # Scenario 9: Multiple operations create distinct spans
+  # ─── SCENARIO 8: Multiple operations create distinct spans (1 case) ─────────────────
   Scenario: Multiple GraphQL operations create distinct spans coexisting with network spans
-    Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "9"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 4 spans
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span field "name" matches the regex "^GraphQL .+/graphql - mutation:CreatePost$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
 
-  # Scenario 10: Span payload contains only safe attributes
-  Scenario: GraphQL span does not contain sensitive GraphQL-specific metadata
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 9: Safe attributes only — no GraphQL-specific metadata (1 case) ────
+  Scenario: GraphQL span payload contains only HTTP attributes — no GraphQL-specific metadata
     And I configure scenario "scenario_number" to "10"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is true
-    * every span attribute "bugsnag.graphql.document" does not exist
-    * every span attribute "bugsnag.graphql.variables" does not exist
-    * every span attribute "graphql.operation.type" does not exist
-    * every span attribute "graphql.operation.name" does not exist
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "POST"
+    And a span integer attribute "http.status_code" equals 200
+    And every span attribute "graphql.operation.type" does not exist
+    And every span attribute "graphql.operation.name" does not exist
+    And every span attribute "graphql.document" does not exist
+    And every span attribute "graphql.variables" does not exist
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # Scenario 11: GraphQL span with first_class false is not aggregated
-  Scenario: GraphQL span with first_class false is not aggregated into span groups
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 10: first_class false (1 case) ───────────────────────────────────────
+  Scenario: GraphQL span with explicit first_class=false is not aggregated into span groups
     And I configure scenario "scenario_number" to "11"
     And I configure scenario "first_class" to "false"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is false
+    Then a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is false
+    And a span string attribute "http.method" equals "POST"
+    And a span integer attribute "http.status_code" equals 200
 
-  # Scenario 12: GraphQL span created on request timeout
+  # ─── SCENARIO 11: Failure conditions — span expected (1 case) ──────────────────────
   Scenario: GraphQL span is created even when request times out
-    Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "12"
     And I configure scenario "failure_type" to "timeout"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "POST"
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # Scenario 12b: GraphQL span on connection refused
-  Scenario: GraphQL request with connection refused does not crash and produces no span
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 11: Failure conditions — no span expected (2 cases) ──────────────────
+  Scenario Outline: GraphQL request with <failure_type> does not crash and produces no span
     And I configure scenario "scenario_number" to "12"
-    And I configure scenario "failure_type" to "connection_refused"
+    And I configure scenario "failure_type" to "<failure_type>"
+    And I configure scenario "expected_status" to "<http_status>"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 5 seconds
     Then I should receive no spans
 
-  # Scenario 12c: 204 empty body - SDK does not produce span (by design)
-  Scenario: GraphQL request with 204 empty body does not crash
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "12"
-    And I configure scenario "failure_type" to "empty_response"
-    And I configure scenario "expected_status" to "204"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait for 5 seconds
-    Then I should receive no spans
+    Examples:
+      | failure_type       | http_status |
+      | connection_refused |             |
+      | empty_response     | 204         |
 
-  # Scenario 13: iOS URLSession GraphQL request
-  Scenario: iOS SDK produces GraphQL span from URLSession request without document attribute
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 12: iOS SDK via supported GraphQL client library (1 case) ────────────
+  Scenario: iOS SDK produces GraphQL span via supported GraphQL client library without document attribute
     And I configure scenario "scenario_number" to "13"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * every span attribute "bugsnag.graphql.document" does not exist
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "POST"
+    And a span integer attribute "http.status_code" equals 200
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # Scenario 14: Consistent span names for pipeline grouping
-  Scenario: Multiple identical operations produce consistent span names for pipeline grouping
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 13: Consistent span names for pipeline grouping (1 case) ─────────────
+  Scenario: Multiple identical GraphQL operations produce consistent span names for pipeline grouping
     And I configure scenario "scenario_number" to "14"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 3 spans
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    
-  # Scenario 15: Multiple identical GraphQL operations produce spans with consistent name for pipeline grouping
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And every span attribute "bugsnag.graphql.document" does not exist
+
+  # ─── SCENARIO 14: Consistent span names with distinct spanIds (1 case) ─────────────
   Scenario: Multiple identical operations produce consistent span names with valid distinct spanIds
-    Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "15"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 3 spans
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And every span attribute "bugsnag.graphql.document" does not exist
 
-  # Scenario 16: GraphQL 200 response with errors array sets span status to error
-  Scenario: GraphQL 200 response with errors array sets span status to error
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 15: Response status — success cases (2 cases) ────────────────────────
+  Scenario Outline: GraphQL response with <error_type> sets span status to STATUS_CODE_OK
     And I configure scenario "scenario_number" to "16"
-    And I configure scenario "error_type" to "errors_array"
+    And I configure scenario "error_type" to "<error_type>"
     And I configure scenario "expected_status" to "200"
-    And I configure scenario "response_body" to "{\"data\": null, \"errors\": [{\"message\": \"User not found\", \"path\": [\"user\"]}]}"
+    And I configure scenario "response_body" to "<response_body>"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a nested span field "status.code" equals "STATUS_CODE_ERROR"
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "POST"
+    And a span integer attribute "http.status_code" equals 200
+    And a nested span field "status.code" equals "STATUS_CODE_OK"
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # Scenario 16b: GraphQL 200 with partial data + errors sets span status to error
-  Scenario: GraphQL 200 response with partial data and errors sets span status to error
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "16"
-    And I configure scenario "error_type" to "partial_data_errors"
-    And I configure scenario "expected_status" to "200"
-    And I configure scenario "response_body" to "{\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": [{\"message\": \"Field deprecated\"}]}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a nested span field "status.code" equals "STATUS_CODE_ERROR"
+    Examples:
+      | error_type                        | response_body                                                                                              |
+      | HTTP 200 success (no errors)      | {\"data\": {\"user\": {\"id\": \"1\", \"name\": \"John\"}}}                                   |
+      | HTTP 200 with empty errors array  | {\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": []}                                         |
 
-  # Scenario 16c: GraphQL 200 success with no errors sets span status to OK
-  Scenario: GraphQL 200 response with no errors sets span status to OK
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 16: Response status — current behavior (all STATUS_CODE_OK) ─────────
+  # NOTE: The SDK currently sets STATUS_CODE_OK for all completed requests regardless of
+  # HTTP status or GraphQL errors. When error-status support is implemented, update these
+  # expected values from STATUS_CODE_OK to STATUS_CODE_ERROR.
+  Scenario Outline: GraphQL response with <error_type> produces span with status <expected_status>
     And I configure scenario "scenario_number" to "16"
-    And I configure scenario "error_type" to "success"
-    And I configure scenario "expected_status" to "200"
-    And I configure scenario "response_body" to "{\"data\": {\"user\": {\"id\": \"1\", \"name\": \"John\"}}}"
+    And I configure scenario "error_type" to "<error_type>"
+    And I configure scenario "expected_status" to "<http_status>"
+    And I configure scenario "response_body" to "<response_body>"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a nested span field "status.code" equals "STATUS_CODE_OK"
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "POST"
+    And a span integer attribute "http.status_code" equals <http_status>
+    And a nested span field "status.code" equals "<expected_status>"
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist
 
-  # Scenario 16d: GraphQL 200 with empty errors array sets span status to OK
-  Scenario: GraphQL 200 response with empty errors array sets span status to OK
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "16"
-    And I configure scenario "error_type" to "empty_errors"
-    And I configure scenario "expected_status" to "200"
-    And I configure scenario "response_body" to "{\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": []}"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a nested span field "status.code" equals "STATUS_CODE_OK"
+    Examples:
+      | error_type                        | http_status | response_body                                                                                              | expected_status   |
+      | HTTP 200 with errors array        | 200         | {\"data\": null, \"errors\": [{\"message\": \"User not found\", \"path\": [\"user\"]}]}        | STATUS_CODE_OK    |
+      | HTTP 200 with partial data+errors | 200         | {\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": [{\"message\": \"Field deprecated\"}]}   | STATUS_CODE_OK    |
+      | HTTP 500 transport error          | 500         |                                                                                                            | STATUS_CODE_OK    |
+      | HTTP 401 unauthorized             | 401         |                                                                                                            | STATUS_CODE_OK    |
 
-  # Scenario 16e: HTTP 500 transport error sets span status to error
-  Scenario: GraphQL HTTP 500 sets span status to error
-    Given I load scenario "GraphQLDetectScenario"
+  # ─── SCENARIO 16: Connection timeout — current behavior ────────────────────────────
+  # NOTE: Same as above — SDK currently returns STATUS_CODE_OK even on timeout.
+  # Update to STATUS_CODE_ERROR when error-status is implemented.
+  Scenario: GraphQL connection timeout produces span with status OK (error status not yet implemented)
     And I configure scenario "scenario_number" to "16"
-    And I configure scenario "error_type" to "http_500"
-    And I configure scenario "expected_status" to "500"
+    And I configure scenario "error_type" to "Connection timeout"
+    And I configure scenario "expected_status" to ""
+    And I configure scenario "response_body" to ""
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a nested span field "status.code" equals "STATUS_CODE_ERROR"
-
-  # Scenario 16f: HTTP 401 unauthorized sets span status to error
-  Scenario: GraphQL HTTP 401 sets span status to error
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "16"
-    And I configure scenario "error_type" to "http_401"
-    And I configure scenario "expected_status" to "401"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a nested span field "status.code" equals "STATUS_CODE_ERROR"
-
-  # Scenario 16g: Connection timeout sets span status to error
-  Scenario: GraphQL connection timeout sets span status to error
-    Given I load scenario "GraphQLDetectScenario"
-    And I configure scenario "scenario_number" to "16"
-    And I configure scenario "error_type" to "timeout"
-    And I start bugsnag
-    And I run the loaded scenario
-    And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^GraphQL [^ ]+/graphql - query:GetUser$"
-    * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a nested span field "status.code" equals "STATUS_CODE_ERROR"
+    Then a span field "name" matches the regex "^GraphQL .+/graphql - query:GetUser$"
+    And a span string attribute "bugsnag.span.category" equals "graphql"
+    And a span bool attribute "bugsnag.span.first_class" is true
+    And a span string attribute "http.method" equals "POST"
+    And a nested span field "status.code" equals "STATUS_CODE_OK"
+    And every span attribute "bugsnag.graphql.document" does not exist
+    And every span attribute "bugsnag.graphql.variables" does not exist

--- a/features/default/graphQL_request_detection.feature
+++ b/features/default/graphQL_request_detection.feature
@@ -1,6 +1,6 @@
 Feature: GraphQL span detection and attribute correctness on iOS
 
-  Scenario: GraphQL detected via URL /graphql path produces correct span
+  Scenario: GraphQL detected via configured /graphql path produces correct span
     Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "1"
     And I configure scenario "url_path" to "/graphql"
@@ -9,7 +9,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:GetUser"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
     
@@ -23,7 +23,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:GetUserProfile"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/data\] query:GetUserProfile$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -39,7 +39,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:FetchItems"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:FetchItems$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -55,7 +55,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] mutation:CreatePost"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/api/graphql\] mutation:CreatePost$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -71,7 +71,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] subscription:OnMessage"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/api/v1/graphql\] subscription:OnMessage$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -87,7 +87,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] mutation:UpdateUser"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/custom-endpoint\] mutation:UpdateUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
@@ -103,7 +103,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:BadQuery"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:BadQuery$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 1g: GraphQL span created on HTTP 500 error
@@ -118,7 +118,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] mutation:FailOp"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] mutation:FailOp$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2: Operation type extraction - operationName field priority (P1)
@@ -129,7 +129,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:GetUser"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2b: Mutation type extracted with operationName field priority
@@ -140,7 +140,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] mutation:CreatePost"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] mutation:CreatePost$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2c: Subscription type extracted with operationName field priority
@@ -151,7 +151,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] subscription:OnMsg"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] subscription:OnMsg$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2d: Document parsing fallback (P2) when no operationName field
@@ -162,7 +162,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:FetchOrders"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:FetchOrders$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2e: Anonymous query defaults to query type
@@ -173,7 +173,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:<anonymous>"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:<anonymous>$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2f: operationName field overrides document name
@@ -184,7 +184,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:FieldName"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:FieldName$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 3: Display name format validation
@@ -196,7 +196,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:GetUser"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 4: Non-GraphQL REST POST retains network category
@@ -211,7 +211,8 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I run the loaded scenario
     And I wait to receive at least 1 span
     * a span string attribute "bugsnag.span.category" equals "network"
-    * every span attribute "bugsnag.graphql.operation_type" does not exist
+    * every span attribute "graphql.operation.type" does not exist
+    * every span attribute "graphql.operation.name" does not exist
 
   # Scenario 4b: JSON with "query" key that is not GraphQL retains network category
   Scenario: JSON with query key that is not GraphQL retains network category
@@ -286,7 +287,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:Get_User_Profile_V2"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:Get_User_Profile_V2$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 6c: Edge-case operation names - numeric suffix
@@ -297,7 +298,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:GetUser123"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser123$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 7: Batched GraphQL request does not crash
@@ -316,7 +317,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:GetUser"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 9: Multiple operations create distinct spans
@@ -334,23 +335,23 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:GetUser"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
     * every span attribute "bugsnag.graphql.document" does not exist
     * every span attribute "bugsnag.graphql.variables" does not exist
-    * every span attribute "bugsnag.graphql.operationType" does not exist
-    * every span attribute "bugsnag.graphql.operationName" does not exist
+    * every span attribute "graphql.operation.type" does not exist
+    * every span attribute "graphql.operation.name" does not exist
 
-  # Scenario 11: first_class=false prevents span grouping
-  Scenario: GraphQL span with first_class false is not aggregated
+  # Scenario 11: GraphQL spans are first_class for grouping
+  Scenario: GraphQL span is first_class for grouping
     Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "11"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
     * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is false
+    * a span bool attribute "bugsnag.span.first_class" is true
 
   # Scenario 12: GraphQL span created on request timeout
   Scenario: GraphQL span is created even when request times out
@@ -360,7 +361,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:GetUser"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 12b: GraphQL span created on connection refused
@@ -373,14 +374,14 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I wait for 5 seconds
     Then I should receive no spans
 
-  # Scenario 13: iOS SDK via GraphQL client library
-  Scenario: iOS SDK produces GraphQL span via supported client library without document attribute
+  # Scenario 13: iOS URLSession GraphQL request
+  Scenario: iOS SDK produces GraphQL span from URLSession request without document attribute
     Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "13"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" equals "[GraphQL] query:GetUser"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * every span attribute "bugsnag.graphql.document" does not exist
 

--- a/features/default/graphQL_request_detection.feature
+++ b/features/default/graphQL_request_detection.feature
@@ -12,7 +12,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
-    
+
   # Scenario 1: GraphQL detected via Content-Type
   Scenario: GraphQL detected via Content-Type produces correct span
     Given I load scenario "GraphQLDetectScenario"
@@ -75,7 +75,23 @@ Feature: GraphQL span detection and attribute correctness on iOS
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
-  # Scenario 1e: GraphQL detected via body inspection on non-graphql URL
+  # Scenario 1e: GraphQL detected via URL /graphql/ with trailing slash
+  Scenario: GraphQL detected via URL /graphql/ with trailing slash
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "detection_method" to "url_path"
+    And I configure scenario "url" to "https://api.example.com/graphql/"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"query GetProfile { profile { name } }\", \"operationName\": \"GetProfile\"}"
+    And I configure scenario "expected_status" to "200"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetProfile$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a span bool attribute "bugsnag.span.first_class" is true
+
+  # Scenario 1f: GraphQL detected via body inspection on non-graphql URL
   Scenario: GraphQL detected via body inspection on custom endpoint
     Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "1"
@@ -91,7 +107,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     * a span string attribute "bugsnag.span.category" equals "graphql"
     * a span bool attribute "bugsnag.span.first_class" is true
 
-  # Scenario 1f: GraphQL span created on HTTP 400 error
+  # Scenario 1g: GraphQL span created on HTTP 400 error
   Scenario: GraphQL span created on HTTP 400 error
     Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "1"
@@ -106,7 +122,22 @@ Feature: GraphQL span detection and attribute correctness on iOS
     Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:BadQuery$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
-  # Scenario 1g: GraphQL span created on HTTP 500 error
+  # Scenario 1h: GraphQL span created on HTTP 401 unauthorized
+  Scenario: GraphQL span created on HTTP 401 unauthorized
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "1"
+    And I configure scenario "detection_method" to "url_path"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"query GetSecret { secret { value } }\", \"operationName\": \"GetSecret\"}"
+    And I configure scenario "expected_status" to "401"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetSecret$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 1i: GraphQL span created on HTTP 500 server error
   Scenario: GraphQL span created on HTTP 500 server error
     Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "1"
@@ -173,7 +204,7 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
-    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:<anonymous>$"
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\]$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 2f: operationName field overrides document name
@@ -186,8 +217,30 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I wait to receive at least 1 span
     Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:FieldName$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
+    
+  # Scenario 2g: Mutation extracted from document parsing (P2, no operationName field)
+  Scenario: Mutation operation name extracted from document parsing when operationName field absent
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "2"
+    And I configure scenario "body" to "{\"query\": \"mutation DeleteItem { deleteItem { success } }\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] mutation:DeleteItem$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    
+  # Scenario 2h: Query type present but no operation name
+  Scenario: Query type present with no operation name produces span with type only
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "2"
+    And I configure scenario "body" to "{\"query\": \"query { user { id } }\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
 
-  # Scenario 3: Display name format validation
+  # Scenario 3: Display name format validation - query with name
   Scenario: Display name follows correct format for query with name
     Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "3"
@@ -197,6 +250,66 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I run the loaded scenario
     And I wait to receive at least 1 span
     Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 3b: Display name format - mutation with name
+  Scenario: Display name follows correct format for mutation with name
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "3"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "body" to "{\"query\": \"mutation UpdateCart { cart { id } }\", \"operationName\": \"UpdateCart\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] mutation:UpdateCart$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 3c: Display name format - subscription with name
+  Scenario: Display name follows correct format for subscription with name
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "3"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "body" to "{\"query\": \"subscription OnNotify { notify { id } }\", \"operationName\": \"OnNotify\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] subscription:OnNotify$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 3d: Display name format - anonymous query (no name, omit parens)
+  Scenario: Display name for anonymous query omits operation name
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "3"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "body" to "{\"query\": \"query { user { id } }\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 3e: Display name format - unknown type with known operationName
+  Scenario: Display name for unknown type with known operationName
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "3"
+    And I configure scenario "url" to "https://api.example.com/graphql"
+    And I configure scenario "body" to "{\"query\": \"{ user { id } }\", \"operationName\": \"GetUser\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 3f: Display name format - custom endpoint path
+  Scenario: Display name for custom endpoint path
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "3"
+    And I configure scenario "url" to "https://api.example.com/api/graphql"
+    And I configure scenario "body" to "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/api/graphql\] query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 4: Non-GraphQL REST POST retains network category
@@ -239,6 +352,45 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I wait to receive at least 1 span
     * a span string attribute "bugsnag.span.category" equals "network"
 
+  # Scenario 4d: Natural language query body retains network category
+  Scenario: Natural language query body retains network category
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "4"
+    And I configure scenario "http_method" to "POST"
+    And I configure scenario "url" to "https://api.example.com/api/search"
+    And I configure scenario "content_type" to "application/json"
+    And I configure scenario "body" to "{\"query\": \"find all users named John\", \"limit\": 10}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+
+  # Scenario 4e: XML content type retains network category
+  Scenario: XML content type retains network category
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "4"
+    And I configure scenario "http_method" to "POST"
+    And I configure scenario "url" to "https://api.example.com/api/data"
+    And I configure scenario "content_type" to "application/xml"
+    And I configure scenario "body" to "<request><query>GetUser</query></request>"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+
+  # Scenario 4f: text/html content type retains network category
+  Scenario: text/html content type retains network category
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "4"
+    And I configure scenario "http_method" to "POST"
+    And I configure scenario "url" to "https://api.example.com/submit"
+    And I configure scenario "content_type" to "text/html"
+    And I configure scenario "body" to "<html><body>test</body></html>"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+
   # Scenario 5: Malformed body does not crash - empty string
   Scenario: POST to graphql with empty body does not crash and falls back to network
     Given I load scenario "GraphQLDetectScenario"
@@ -264,6 +416,16 @@ Feature: GraphQL span detection and attribute correctness on iOS
     Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "5"
     And I configure scenario "body_type" to "empty_object"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    * a span string attribute "bugsnag.span.category" equals "network"
+
+  # Scenario 5d: Malformed body does not crash - null body
+  Scenario: POST to graphql with null body does not crash and falls back to network
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "5"
+    And I configure scenario "body_type" to "null"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
@@ -327,6 +489,8 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 4 spans
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
 
   # Scenario 10: Span payload contains only safe attributes
   Scenario: GraphQL span does not contain sensitive GraphQL-specific metadata
@@ -343,15 +507,16 @@ Feature: GraphQL span detection and attribute correctness on iOS
     * every span attribute "graphql.operation.type" does not exist
     * every span attribute "graphql.operation.name" does not exist
 
-  # Scenario 11: GraphQL spans are first_class for grouping
-  Scenario: GraphQL span is first_class for grouping
+  # Scenario 11: GraphQL span with first_class false is not aggregated
+  Scenario: GraphQL span with first_class false is not aggregated into span groups
     Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "11"
+    And I configure scenario "first_class" to "false"
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 1 span
     * a span string attribute "bugsnag.span.category" equals "graphql"
-    * a span bool attribute "bugsnag.span.first_class" is true
+    * a span bool attribute "bugsnag.span.first_class" is false
 
   # Scenario 12: GraphQL span created on request timeout
   Scenario: GraphQL span is created even when request times out
@@ -364,11 +529,22 @@ Feature: GraphQL span detection and attribute correctness on iOS
     Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
     * a span string attribute "bugsnag.span.category" equals "graphql"
 
-  # Scenario 12b: GraphQL span created on connection refused
+  # Scenario 12b: GraphQL span on connection refused
   Scenario: GraphQL request with connection refused does not crash and produces no span
     Given I load scenario "GraphQLDetectScenario"
     And I configure scenario "scenario_number" to "12"
     And I configure scenario "failure_type" to "connection_refused"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for 5 seconds
+    Then I should receive no spans
+
+  # Scenario 12c: 204 empty body - SDK does not produce span (by design)
+  Scenario: GraphQL request with 204 empty body does not crash
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "12"
+    And I configure scenario "failure_type" to "empty_response"
+    And I configure scenario "expected_status" to "204"
     And I start bugsnag
     And I run the loaded scenario
     And I wait for 5 seconds
@@ -392,3 +568,109 @@ Feature: GraphQL span detection and attribute correctness on iOS
     And I start bugsnag
     And I run the loaded scenario
     And I wait to receive at least 3 spans
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    
+  # Scenario 15: Multiple identical GraphQL operations produce spans with consistent name for pipeline grouping
+  Scenario: Multiple identical operations produce consistent span names with valid distinct spanIds
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "15"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 3 spans
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+
+  # Scenario 16: GraphQL 200 response with errors array sets span status to error
+  Scenario: GraphQL 200 response with errors array sets span status to error
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "16"
+    And I configure scenario "error_type" to "errors_array"
+    And I configure scenario "expected_status" to "200"
+    And I configure scenario "response_body" to "{\"data\": null, \"errors\": [{\"message\": \"User not found\", \"path\": [\"user\"]}]}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a nested span field "status.code" equals "STATUS_CODE_ERROR"
+
+  # Scenario 16b: GraphQL 200 with partial data + errors sets span status to error
+  Scenario: GraphQL 200 response with partial data and errors sets span status to error
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "16"
+    And I configure scenario "error_type" to "partial_data_errors"
+    And I configure scenario "expected_status" to "200"
+    And I configure scenario "response_body" to "{\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": [{\"message\": \"Field deprecated\"}]}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a nested span field "status.code" equals "STATUS_CODE_ERROR"
+
+  # Scenario 16c: GraphQL 200 success with no errors sets span status to OK
+  Scenario: GraphQL 200 response with no errors sets span status to OK
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "16"
+    And I configure scenario "error_type" to "success"
+    And I configure scenario "expected_status" to "200"
+    And I configure scenario "response_body" to "{\"data\": {\"user\": {\"id\": \"1\", \"name\": \"John\"}}}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a nested span field "status.code" equals "STATUS_CODE_OK"
+
+  # Scenario 16d: GraphQL 200 with empty errors array sets span status to OK
+  Scenario: GraphQL 200 response with empty errors array sets span status to OK
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "16"
+    And I configure scenario "error_type" to "empty_errors"
+    And I configure scenario "expected_status" to "200"
+    And I configure scenario "response_body" to "{\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": []}"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a nested span field "status.code" equals "STATUS_CODE_OK"
+
+  # Scenario 16e: HTTP 500 transport error sets span status to error
+  Scenario: GraphQL HTTP 500 sets span status to error
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "16"
+    And I configure scenario "error_type" to "http_500"
+    And I configure scenario "expected_status" to "500"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a nested span field "status.code" equals "STATUS_CODE_ERROR"
+
+  # Scenario 16f: HTTP 401 unauthorized sets span status to error
+  Scenario: GraphQL HTTP 401 sets span status to error
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "16"
+    And I configure scenario "error_type" to "http_401"
+    And I configure scenario "expected_status" to "401"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a nested span field "status.code" equals "STATUS_CODE_ERROR"
+
+  # Scenario 16g: Connection timeout sets span status to error
+  Scenario: GraphQL connection timeout sets span status to error
+    Given I load scenario "GraphQLDetectScenario"
+    And I configure scenario "scenario_number" to "16"
+    And I configure scenario "error_type" to "timeout"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" matches the regex "^\[GraphQL\] \[[^\]]*/graphql\] query:GetUser$"
+    * a span string attribute "bugsnag.span.category" equals "graphql"
+    * a nested span field "status.code" equals "STATUS_CODE_ERROR"

--- a/features/default/resource-usage-aggregation-extended.feature
+++ b/features/default/resource-usage-aggregation-extended.feature
@@ -1,3 +1,4 @@
+@resource_aggregation
 Feature: Foreground App Session Span - Extended Validations
 
   Scenario: App session span contains all CPU sub-metrics with range validation

--- a/features/default/resource-usage-aggregation.feature
+++ b/features/default/resource-usage-aggregation.feature
@@ -1,3 +1,4 @@
+@resource_aggregation
 Feature: Foreground App Session Span
 
 Scenario: App session span sends app-session attributes

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -102,9 +102,9 @@
 		96EB8B502EB26B4400DDBF86 /* StartupEnabledMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EB8B4F2EB26B3C00DDBF86 /* StartupEnabledMetrics.swift */; };
 		96F129352DCE0CFE00A6FB2B /* ManualSpanWithRemoteContextParentScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F129342DCE0CFE00A6FB2B /* ManualSpanWithRemoteContextParentScenario.swift */; };
 		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */; };
+		96F901092EE7B7FF0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F901082EE7B7FF0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */; };
 		96F901132EE81E580026F5B9 /* BackgroundThreadStartScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F901122EE81E580026F5B9 /* BackgroundThreadStartScenario.swift */; };
 		96F901172EE836CC0026F5B9 /* ManualParentBlockedSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F901162EE836CC0026F5B9 /* ManualParentBlockedSpanScenario.swift */; };
-		96F901092EE7B7FF0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F901082EE7B7FF0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
 		CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */; };
@@ -130,6 +130,7 @@
 		DAC7DD672E3CBED10091961A /* BugsnagPerformanceNamedSpans in Frameworks */ = {isa = PBXBuildFile; productRef = DAC7DD662E3CBED10091961A /* BugsnagPerformanceNamedSpans */; };
 		DADB14F92DE08A030006F44F /* OnStartCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */; };
 		E1A5A6432FE05B9F00A663EA /* AppSessionResourceUsageScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5A6422FE05B9F00A663EA /* AppSessionResourceUsageScenario.swift */; };
+		E1CD1F01301099F300C3C4F1 /* GraphQLDetectScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CD1F00301099F300C3C4F1 /* GraphQLDetectScenario.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -232,9 +233,9 @@
 		96EB8B4F2EB26B3C00DDBF86 /* StartupEnabledMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupEnabledMetrics.swift; sourceTree = "<group>"; };
 		96F129342DCE0CFE00A6FB2B /* ManualSpanWithRemoteContextParentScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanWithRemoteContextParentScenario.swift; sourceTree = "<group>"; };
 		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackSetToNilScenario.swift; sourceTree = "<group>"; };
+		96F901082EE7B7FF0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkEarlyCallbackScenario.swift; sourceTree = "<group>"; };
 		96F901122EE81E580026F5B9 /* BackgroundThreadStartScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundThreadStartScenario.swift; sourceTree = "<group>"; };
 		96F901162EE836CC0026F5B9 /* ManualParentBlockedSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualParentBlockedSpanScenario.swift; sourceTree = "<group>"; };
-		96F901082EE7B7FF0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkEarlyCallbackScenario.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
 		CB211D0629EEB615008F748D /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "BugsnagPerformanceConfiguration+Private.h"; path = "../../../../Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
@@ -262,6 +263,7 @@
 		DA95ABF22E3A7E52001E6B0E /* NamedSpansPluginScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedSpansPluginScenario.swift; sourceTree = "<group>"; };
 		DADB14F82DE08A030006F44F /* OnStartCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnStartCallbackScenario.swift; sourceTree = "<group>"; };
 		E1A5A6422FE05B9F00A663EA /* AppSessionResourceUsageScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionResourceUsageScenario.swift; sourceTree = "<group>"; };
+		E1CD1F00301099F300C3C4F1 /* GraphQLDetectScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLDetectScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -343,6 +345,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				E1CD1F00301099F300C3C4F1 /* GraphQLDetectScenario.swift */,
 				E1A5A6422FE05B9F00A663EA /* AppSessionResourceUsageScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
 				96D090D42EEB3DA700BAA6D4 /* AppStartInterruptedScenario.swift */,
@@ -586,6 +589,7 @@
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
 				09F3F5282D6C728300BAA0A3 /* MemoryMetricsScenario.swift in Sources */,
 				966634DE2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift in Sources */,
+				E1CD1F01301099F300C3C4F1 /* GraphQLDetectScenario.swift in Sources */,
 				09E9BDAF2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift in Sources */,
 				1C8CB8C12EC3C975007BF492 /* DebugModeScenario.swift in Sources */,
 				099331FC2C11F6CF009EC92F /* AutoInstrumentAVAssetScenario.swift in Sources */,

--- a/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
@@ -103,9 +103,9 @@
 		96EB8B522EB277CE00DDBF86 /* StartupEnabledMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EB8B512EB277CE00DDBF86 /* StartupEnabledMetrics.swift */; };
 		96F129332DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F129322DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift */; };
 		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */; };
+		96F9010B2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F9010A2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */; };
 		96F901152EE81E6D0026F5B9 /* BackgroundThreadStartScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F901142EE81E6D0026F5B9 /* BackgroundThreadStartScenario.swift */; };
 		96F901192EE836E10026F5B9 /* ManualParentBlockedSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F901182EE836E10026F5B9 /* ManualParentBlockedSpanScenario.swift */; };
-		96F9010B2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F9010A2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
 		CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */; };
@@ -132,6 +132,7 @@
 		DAC7DD6D2E3CDA990091961A /* BugsnagPerformanceNamedSpans.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DAC7DD6A2E3CDA590091961A /* BugsnagPerformanceNamedSpans.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DADB14F72DDF852B0006F44F /* OnStartCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */; };
 		E1A5A6412FE052BB00A663EA /* AppSessionResourceUsageScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5A6402FE052BB00A663EA /* AppSessionResourceUsageScenario.swift */; };
+		E1CD1EFE3010784400C3C4F1 /* GraphQLDetectScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CD1EFD3010782200C3C4F1 /* GraphQLDetectScenario.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -251,9 +252,9 @@
 		96EB8B512EB277CE00DDBF86 /* StartupEnabledMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupEnabledMetrics.swift; sourceTree = "<group>"; };
 		96F129322DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderingMetricsScenario.swift; sourceTree = "<group>"; };
 		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackSetToNilScenario.swift; sourceTree = "<group>"; };
+		96F9010A2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkEarlyCallbackScenario.swift; sourceTree = "<group>"; };
 		96F901142EE81E6D0026F5B9 /* BackgroundThreadStartScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundThreadStartScenario.swift; sourceTree = "<group>"; };
 		96F901182EE836E10026F5B9 /* ManualParentBlockedSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualParentBlockedSpanScenario.swift; sourceTree = "<group>"; };
-		96F9010A2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkEarlyCallbackScenario.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
 		CB211D0629EEB615008F748D /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "BugsnagPerformanceConfiguration+Private.h"; path = "../../../../Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
@@ -282,6 +283,7 @@
 		DAC7DD6A2E3CDA590091961A /* BugsnagPerformanceNamedSpans.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BugsnagPerformanceNamedSpans.xcframework; path = ../../../BugsnagPerformanceNamedSpans.xcframework; sourceTree = "<group>"; };
 		DADB14F62DDF85210006F44F /* OnStartCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnStartCallbackScenario.swift; sourceTree = "<group>"; };
 		E1A5A6402FE052BB00A663EA /* AppSessionResourceUsageScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionResourceUsageScenario.swift; sourceTree = "<group>"; };
+		E1CD1EFD3010782200C3C4F1 /* GraphQLDetectScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLDetectScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -366,6 +368,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				E1CD1EFD3010782200C3C4F1 /* GraphQLDetectScenario.swift */,
 				E1A5A6402FE052BB00A663EA /* AppSessionResourceUsageScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
 				96D090D62EEB3E1D00BAA6D4 /* AppStartInterruptedScenario.swift */,
@@ -581,6 +584,7 @@
 				96D528D02C77F38400FEA2E2 /* FixedSamplingProbabilityZeroScenario.swift in Sources */,
 				09D59E1D2BE105F700199E1B /* AutoInstrumentNetworkTracePropagationScenario.swift in Sources */,
 				09F3F52A2D6C72B300BAA0A3 /* CPUMetricsScenario.swift in Sources */,
+				E1CD1EFE3010784400C3C4F1 /* GraphQLDetectScenario.swift in Sources */,
 				96F9010B2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift in Sources */,
 				01FE4DAD28E1AEBD00D1F239 /* ViewController.swift in Sources */,
 				CBEC89232A458BA70088A3CE /* AutoInstrumentNetworkMultiple.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
+++ b/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
@@ -1,0 +1,278 @@
+//
+//  GraphQLDetectScenario.swift
+//  Fixture
+//
+//  Created by Meiyalagan Ramadurai on 22/07/26.
+//
+
+import Foundation
+import BugsnagPerformance
+
+@objcMembers
+class GraphQLDetectScenario: Scenario {
+    
+    override func setInitialBugsnagConfiguration() {
+            super.setInitialBugsnagConfiguration()
+            // Enable network auto-instrumentation so the SDK can detect GraphQL
+            bugsnagPerfConfig.autoInstrumentNetworkRequests = true
+        }
+
+    override func run() {
+        // Force the automatic startup spans to be sent in a separate batch we discard
+        waitForCurrentBatch()
+
+        let scenarioNumber = Int(scenarioConfig["scenario_number"] ?? "1") ?? 1
+
+        switch scenarioNumber {
+        case 1:
+            runDetectionScenario()
+        case 2:
+            runOperationTypeExtractionScenario()
+        case 3:
+            runDisplayNameScenario()
+        case 4:
+            runNonGraphQLScenario()
+        case 5:
+            runMalformedBodyScenario()
+        case 6:
+            runEdgeCaseOperationNameScenario()
+        case 7:
+            runBatchedRequestScenario()
+        case 8:
+            runGETRequestScenario()
+        case 9:
+            runMultipleOperationsScenario()
+        case 10:
+            runSafeAttributesScenario()
+        case 11:
+            runFirstClassFalseScenario()
+        case 12:
+            runRequestFailureScenario()
+        case 13:
+            runIOSClientLibraryScenario()
+        case 14:
+            runConsistentSpanNamesScenario()
+        default:
+            break
+        }
+    }
+
+    // MARK: - Scenario 1: GraphQL Detection via Multiple Methods
+
+    private func runDetectionScenario() {
+        let contentType = scenarioConfig["content_type"] ?? "application/json"
+        let body = scenarioConfig["body"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+        let path = scenarioConfig["url_path"] ?? "/graphql"
+
+        sendPOSTToReflect(path: path, contentType: contentType, body: body)
+    }
+
+    // MARK: - Scenario 2: Operation Type Extraction
+
+    private func runOperationTypeExtractionScenario() {
+        let body = scenarioConfig["body"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body)
+    }
+
+    // MARK: - Scenario 3: Display Name Format Validation
+
+    private func runDisplayNameScenario() {
+        let body = scenarioConfig["body"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+        let path = scenarioConfig["url_path"] ?? "/graphql"
+
+        sendPOSTToReflect(path: path, contentType: "application/json", body: body)
+    }
+
+    // MARK: - Scenario 4: Non-GraphQL Requests
+
+    private func runNonGraphQLScenario() {
+        let method = scenarioConfig["http_method"] ?? "POST"
+        let contentType = scenarioConfig["content_type"] ?? "application/json"
+        let body = scenarioConfig["body"] ?? "{\"userId\": \"123\", \"action\": \"get\"}"
+        let path = scenarioConfig["url_path"] ?? "/rest/users"
+
+        if method == "GET" {
+            sendGETToReflect(path: path)
+        } else {
+            sendPOSTToReflect(path: path, contentType: contentType, body: body)
+        }
+    }
+
+    // MARK: - Scenario 5: Malformed/Empty Body
+
+    private func runMalformedBodyScenario() {
+        let bodyType = scenarioConfig["body_type"] ?? "empty"
+        var body: String
+
+        switch bodyType {
+        case "empty":
+            body = ""
+        case "malformed":
+            body = "{invalid json content"
+        case "null":
+            body = "null"
+        case "empty_object":
+            body = "{}"
+        default:
+            body = ""
+        }
+
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body)
+    }
+
+    // MARK: - Scenario 6: Edge-Case Operation Names
+
+    private func runEdgeCaseOperationNameScenario() {
+        let nameType = scenarioConfig["name_type"] ?? "long"
+        var body: String
+
+        switch nameType {
+        case "long":
+            let longName = String(repeating: "A", count: 128)
+            body = "{\"query\": \"query \(longName) { user { id } }\", \"operationName\": \"\(longName)\"}"
+        case "underscore_version":
+            body = "{\"query\": \"query Get_User_Profile_V2 { user { id } }\", \"operationName\": \"Get_User_Profile_V2\"}"
+        case "numeric_suffix":
+            body = "{\"query\": \"query GetUser123 { user { id } }\", \"operationName\": \"GetUser123\"}"
+        default:
+            body = "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+        }
+
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body)
+    }
+
+    // MARK: - Scenario 7: Batched Request
+
+    private func runBatchedRequestScenario() {
+        let body = "[{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}, {\"query\": \"query GetPosts { posts { id } }\", \"operationName\": \"GetPosts\"}]"
+
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body)
+    }
+
+    // MARK: - Scenario 8: GET Request with Query Params
+
+    private func runGETRequestScenario() {
+        sendGETToReflect(path: "/graphql?query={user{id}}&operationName=GetUser")
+    }
+
+    // MARK: - Scenario 9: Multiple Operations
+
+    private func runMultipleOperationsScenario() {
+        // Two identical queries
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json",
+                          body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json",
+                          body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+
+        // One mutation
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json",
+                          body: "{\"query\": \"mutation CreatePost { createPost { id } }\", \"operationName\": \"CreatePost\"}")
+
+        // One REST GET
+        sendGETToReflect(path: "/rest/users/123")
+    }
+
+    // MARK: - Scenario 10: Safe Attributes Only
+
+    private func runSafeAttributesScenario() {
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json",
+                          body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+    }
+
+    // MARK: - Scenario 11: first_class=false
+
+    private func runFirstClassFalseScenario() {
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json",
+                          body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+    }
+
+    // MARK: - Scenario 12: Request Failure
+
+    private func runRequestFailureScenario() {
+        let failureType = scenarioConfig["failure_type"] ?? "timeout"
+
+        switch failureType {
+        case "timeout":
+            // Send to a non-responsive endpoint to trigger timeout
+            sendPOSTToReflect(path: "/graphql?delay=60000", contentType: "application/json",
+                              body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                              timeout: 5.0)
+        case "connection_refused":
+            // Send to a port nothing is listening on
+            let url = URL(string: "http://localhost:1/graphql")!
+            sendPOST(url: url, contentType: "application/json",
+                     body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+        case "empty_body":
+            sendPOSTToReflect(path: "/graphql?status=204", contentType: "application/json",
+                              body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+        default:
+            break
+        }
+    }
+
+    // MARK: - Scenario 13: iOS Client Library
+
+    private func runIOSClientLibraryScenario() {
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json",
+                          body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+    }
+
+    // MARK: - Scenario 14: Consistent Span Names
+
+    private func runConsistentSpanNamesScenario() {
+        for _ in 1...3 {
+            sendPOSTToReflect(path: "/graphql", contentType: "application/json",
+                              body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    /// Send a POST request to the Maze Runner reflect endpoint
+    private func sendPOSTToReflect(path: String, contentType: String, body: String, timeout: TimeInterval = 60.0) {
+        let url = URL(string: path, relativeTo: fixtureConfig.reflectURL)!
+        sendPOST(url: url, contentType: contentType, body: body, timeout: timeout)
+    }
+
+    /// Send a POST request to an arbitrary URL
+    private func sendPOST(url: URL, contentType: String, body: String, timeout: TimeInterval = 60.0) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        request.httpBody = body.data(using: .utf8)
+        request.timeoutInterval = timeout
+
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let task = URLSession.shared.dataTask(with: request) { _, response, error in
+            if let httpResponse = response as? HTTPURLResponse {
+                NSLog("GraphQLDetect: POST \(url) -> \(httpResponse.statusCode)")
+            } else if let error = error {
+                NSLog("GraphQLDetect: POST \(url) -> error: \(error.localizedDescription)")
+            }
+            semaphore.signal()
+        }
+        task.resume()
+        semaphore.wait()
+    }
+
+    /// Send a GET request to the Maze Runner reflect endpoint
+    private func sendGETToReflect(path: String) {
+        let url = URL(string: path, relativeTo: fixtureConfig.reflectURL)!
+
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let task = URLSession.shared.dataTask(with: url) { _, response, error in
+            if let httpResponse = response as? HTTPURLResponse {
+                NSLog("GraphQLDetect: GET \(url) -> \(httpResponse.statusCode)")
+            } else if let error = error {
+                NSLog("GraphQLDetect: GET \(url) -> error: \(error.localizedDescription)")
+            }
+            semaphore.signal()
+        }
+        task.resume()
+        semaphore.wait()
+    }
+}

--- a/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
+++ b/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
@@ -153,7 +153,8 @@ class GraphQLDetectScenario: Scenario {
     // MARK: - Scenario 8: GET Request with Query Params
 
     private func runGETRequestScenario() {
-        sendGETToReflect(path: "/graphql?query={user{id}}&operationName=GetUser")
+        let path = "/graphql?query=%7Buser%7Bid%7D%7D&operationName=GetUser"
+            sendGETToReflect(path: path)
     }
 
     // MARK: - Scenario 9: Multiple Operations
@@ -232,10 +233,12 @@ class GraphQLDetectScenario: Scenario {
 
     /// Send a POST request to the Maze Runner reflect endpoint
     private func sendPOSTToReflect(path: String, contentType: String, body: String, timeout: TimeInterval = 60.0) {
-        let url = URL(string: path, relativeTo: fixtureConfig.reflectURL)!
+        guard let url = URL(string: path, relativeTo: fixtureConfig.reflectURL) else {
+            NSLog("GraphQLDetect: sendPOSTToReflect - invalid URL for path: \(path)")
+            return
+        }
         sendPOST(url: url, contentType: contentType, body: body, timeout: timeout)
     }
-
     /// Send a POST request to an arbitrary URL
     private func sendPOST(url: URL, contentType: String, body: String, timeout: TimeInterval = 60.0) {
         var request = URLRequest(url: url)
@@ -246,33 +249,33 @@ class GraphQLDetectScenario: Scenario {
 
         let semaphore = DispatchSemaphore(value: 0)
 
-        let task = URLSession.shared.dataTask(with: request) { _, response, error in
+        URLSession.shared.dataTask(with: request) { _, response, error in
             if let httpResponse = response as? HTTPURLResponse {
                 NSLog("GraphQLDetect: POST \(url) -> \(httpResponse.statusCode)")
             } else if let error = error {
                 NSLog("GraphQLDetect: POST \(url) -> error: \(error.localizedDescription)")
             }
             semaphore.signal()
-        }
-        task.resume()
+        }.resume()
+
         semaphore.wait()
     }
 
     /// Send a GET request to the Maze Runner reflect endpoint
     private func sendGETToReflect(path: String) {
-        let url = URL(string: path, relativeTo: fixtureConfig.reflectURL)!
-
+        guard let url = URL(string: path, relativeTo: fixtureConfig.reflectURL) else {
+            NSLog("GraphQLDetect: sendGETToReflect - invalid URL for path: \(path)")
+            return
+        }
         let semaphore = DispatchSemaphore(value: 0)
-
-        let task = URLSession.shared.dataTask(with: url) { _, response, error in
+        URLSession.shared.dataTask(with: url) { _, response, error in
             if let httpResponse = response as? HTTPURLResponse {
                 NSLog("GraphQLDetect: GET \(url) -> \(httpResponse.statusCode)")
             } else if let error = error {
                 NSLog("GraphQLDetect: GET \(url) -> error: \(error.localizedDescription)")
             }
             semaphore.signal()
-        }
-        task.resume()
+        }.resume()
         semaphore.wait()
     }
 }

--- a/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
+++ b/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
@@ -10,19 +10,15 @@ import BugsnagPerformance
 
 @objcMembers
 class GraphQLDetectScenario: Scenario {
-    
     override func setInitialBugsnagConfiguration() {
         super.setInitialBugsnagConfiguration()
         // Enable network auto-instrumentation so the SDK can detect GraphQL
         bugsnagPerfConfig.autoInstrumentNetworkRequests = true
     }
-
     override func run() {
         // Force the automatic startup spans to be sent in a separate batch we discard
         waitForCurrentBatch()
-
         let scenarioNumber = Int(scenarioConfig["scenario_number"] ?? "1") ?? 1
-
         switch scenarioNumber {
         case 1:
             runDetectionScenario()
@@ -48,10 +44,9 @@ class GraphQLDetectScenario: Scenario {
             runFirstClassScenario()
         case 12:
             runRequestFailureScenario()
-        case 13:
-            runIOSClientGraphQLScenario()
+        // case 13 removed — Android-only (no feature scenario calls it)
         case 14:
-            runConsistentSpanNamesScenario()
+            runIOSClientGraphQLScenario()
         case 15:
             runSpanIdTraceIdValidationScenario()
         case 16:
@@ -60,15 +55,13 @@ class GraphQLDetectScenario: Scenario {
             break
         }
     }
-
     // MARK: - Scenario 1: GraphQL Detection via Multiple Methods
-
     private func runDetectionScenario() {
         let contentType = scenarioConfig["content_type"] ?? "application/json"
         let body = scenarioConfig["body"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
         let path: String = {
             if let urlString = scenarioConfig["url"], let url = URL(string: urlString) {
-                var path = url.path.isEmpty ? "/" : url.path
+                var path = url.path.isEmpty ? "" : url.path
                 if let query = url.query, !query.isEmpty {
                     path += "?\(query)"
                 }
@@ -76,25 +69,19 @@ class GraphQLDetectScenario: Scenario {
             }
             return scenarioConfig["url_path"] ?? "/graphql"
         }()
-
         sendPOSTToReflect(path: path, contentType: contentType, body: body)
     }
-
     // MARK: - Scenario 2: Operation Type Extraction
-
     private func runOperationTypeExtractionScenario() {
         let body = scenarioConfig["body"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
-
         sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body)
     }
-
     // MARK: - Scenario 3: Display Name Format Validation
-
     private func runDisplayNameScenario() {
         let body = scenarioConfig["body"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
         let path: String = {
             if let urlString = scenarioConfig["url"], let url = URL(string: urlString) {
-                var path = url.path.isEmpty ? "/" : url.path
+                var path = url.path.isEmpty ? "" : url.path
                 if let query = url.query, !query.isEmpty {
                     path += "?\(query)"
                 }
@@ -102,19 +89,16 @@ class GraphQLDetectScenario: Scenario {
             }
             return scenarioConfig["url_path"] ?? "/graphql"
         }()
-        
         sendPOSTToReflect(path: path, contentType: "application/json", body: body)
     }
-
     // MARK: - Scenario 4: Non-GraphQL Requests
-
     private func runNonGraphQLScenario() {
         let method = scenarioConfig["http_method"] ?? "POST"
         let contentType = scenarioConfig["content_type"] ?? "application/json"
         let body = scenarioConfig["body"] ?? "{\"userId\": \"123\", \"action\": \"get\"}"
         let path: String = {
             if let urlString = scenarioConfig["url"], let url = URL(string: urlString) {
-                var path = url.path.isEmpty ? "/" : url.path
+                var path = url.path.isEmpty ? "" : url.path
                 if let query = url.query, !query.isEmpty {
                     path += "?\(query)"
                 }
@@ -122,109 +106,97 @@ class GraphQLDetectScenario: Scenario {
             }
             return scenarioConfig["url_path"] ?? "/rest/users"
         }()
-
         if method == "GET" {
             sendGETToReflect(path: path)
         } else {
             sendPOSTToReflect(path: path, contentType: contentType, body: body)
         }
     }
-
     // MARK: - Scenario 5: Malformed/Empty Body
-
+    // ✅ CHANGED: reads body directly from feature file config (not body_type switch)
     private func runMalformedBodyScenario() {
-        let bodyType = scenarioConfig["body_type"] ?? "empty"
-        var body: String
-
-        switch bodyType {
-        case "empty":
-            body = ""
-        case "malformed":
-            body = "{invalid json content"
-        case "null":
-            body = "null"
-        case "empty_object":
-            body = "{}"
-        default:
-            body = ""
-        }
-
-        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body)
+        let body = scenarioConfig["body"] ?? ""
+        let path: String = {
+            if let urlString = scenarioConfig["url"], let url = URL(string: urlString) {
+                return url.path.isEmpty ? "" : url.path
+            }
+            return "/graphql"
+        }()
+        sendPOSTToReflect(path: path, contentType: "application/json", body: body)
     }
-
     // MARK: - Scenario 6: Edge-Case Operation Names
-
+    // ✅ CHANGED: added NSLog for QA visibility, fixed path fallback "/" → ""
     private func runEdgeCaseOperationNameScenario() {
-        let nameType = scenarioConfig["name_type"] ?? "long"
-        var body: String
-
-        switch nameType {
-        case "long":
+        let configBody = scenarioConfig["body"] ?? ""
+        let body: String
+        if configBody == "__long_128__" {
             let longName = String(repeating: "A", count: 128)
             body = "{\"query\": \"query \(longName) { user { id } }\", \"operationName\": \"\(longName)\"}"
-        case "underscore_version":
-            body = "{\"query\": \"query Get_User_Profile_V2 { user { id } }\", \"operationName\": \"Get_User_Profile_V2\"}"
-        case "numeric_suffix":
-            body = "{\"query\": \"query GetUser123 { user { id } }\", \"operationName\": \"GetUser123\"}"
-        default:
-            body = "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+            NSLog("GraphQLDetect [Scenario 6]: Generated long operation name with %d characters", longName.count)
+        } else {
+            body = configBody
+            NSLog("GraphQLDetect [Scenario 6]: Using body from config: %@", body)
         }
-
-        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body)
+        let path: String = {
+            if let urlString = scenarioConfig["url"], let url = URL(string: urlString) {
+                return url.path.isEmpty ? "" : url.path  // ✅ fixed: was "/"
+            }
+            return "/graphql"
+        }()
+        sendPOSTToReflect(path: path, contentType: "application/json", body: body)
     }
-
     // MARK: - Scenario 7: Batched Request
-
+    // ✅ CHANGED: reads body from feature file config instead of hardcoded
     private func runBatchedRequestScenario() {
-        let body = "[{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}, {\"query\": \"query GetPosts { posts { id } }\", \"operationName\": \"GetPosts\"}]"
-
-        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body)
+        let body = scenarioConfig["body"] ?? "[{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}, {\"query\": \"query GetPosts { posts { id } }\", \"operationName\": \"GetPosts\"}]"
+        let contentType = scenarioConfig["content_type"] ?? "application/json"
+        let path: String = {
+            if let urlString = scenarioConfig["url"], let url = URL(string: urlString) {
+                return url.path.isEmpty ? "" : url.path
+            }
+            return "/graphql"
+        }()
+        sendPOSTToReflect(path: path, contentType: contentType, body: body)
     }
-
     // MARK: - Scenario 8: GET Request with Query Params
-
     private func runGETRequestScenario() {
         let path = "/graphql?query=%7Buser%7Bid%7D%7D&operationName=GetUser"
-            sendGETToReflect(path: path)
+        sendGETToReflect(path: path)
     }
-
     // MARK: - Scenario 9: Multiple Operations
-
+    // ✅ CHANGED: reads bodies from feature file config, added NSLog for QA visibility
     private func runMultipleOperationsScenario() {
-        // Two identical queries
-        sendPOSTToReflect(path: "/graphql", contentType: "application/json",
-                          body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
-
-        sendPOSTToReflect(path: "/graphql", contentType: "application/json",
-                          body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
-
-        // One mutation
-        sendPOSTToReflect(path: "/graphql", contentType: "application/json",
-                          body: "{\"query\": \"mutation CreatePost { createPost { id } }\", \"operationName\": \"CreatePost\"}")
-
-        // One REST GET
-        sendGETToReflect(path: "/rest/users/123")
+        let body1 = scenarioConfig["graphql_body_1"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+        let body2 = scenarioConfig["graphql_body_2"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+        let body3 = scenarioConfig["graphql_body_3"] ?? "{\"query\": \"mutation CreatePost { createPost { id } }\", \"operationName\": \"CreatePost\"}"
+        let restPath: String = {
+            if let urlString = scenarioConfig["rest_url"], let url = URL(string: urlString) {
+                return url.path.isEmpty ? "" : url.path
+            }
+            return "/rest/users/123"
+        }()
+        NSLog("GraphQLDetect [Scenario 9]: Request 1 body: %@", body1)
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body1)
+        NSLog("GraphQLDetect [Scenario 9]: Request 2 body: %@", body2)
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body2)
+        NSLog("GraphQLDetect [Scenario 9]: Request 3 body: %@", body3)
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body3)
+        NSLog("GraphQLDetect [Scenario 9]: Request 4 GET: %@", restPath)
+        sendGETToReflect(path: restPath)
     }
-
     // MARK: - Scenario 10: Safe Attributes Only
-
     private func runSafeAttributesScenario() {
         sendPOSTToReflect(path: "/graphql", contentType: "application/json",
                           body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
     }
-
-    // MARK: - Scenario 11: first_class=true
-
+    // MARK: - Scenario 11: first_class=false
     private func runFirstClassScenario() {
         sendPOSTToReflect(path: "/graphql", contentType: "application/json",
                           body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
     }
-
     // MARK: - Scenario 12: Request Failure
-
     private func runRequestFailureScenario() {
         let failureType = scenarioConfig["failure_type"] ?? "timeout"
-
         switch failureType {
         case "timeout":
             // Send to a non-responsive endpoint to trigger timeout
@@ -243,25 +215,103 @@ class GraphQLDetectScenario: Scenario {
             break
         }
     }
-
-    // MARK: - Scenario 13: iOS URLSession GraphQL Request
-
+    // MARK: - Scenario 14: iOS URLSession GraphQL Request
     private func runIOSClientGraphQLScenario() {
-        sendPOSTToReflect(path: "/graphql", contentType: "application/json",
-                          body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+        let body = scenarioConfig["body"] ?? "{\"query\": \"mutation UpdateCart($id: ID!) { updateCart(id: $id) { total } }\", \"variables\": {\"id\": \"cart_456\"}, \"operationName\": \"UpdateCart\"}"
+        let path: String = {
+            if let urlString = scenarioConfig["url"], let url = URL(string: urlString) {
+                return url.path.isEmpty ? "" : url.path
+            }
+            return "/graphql"
+        }()
+        sendPOSTToReflect(path: path, contentType: "application/json", body: body)
     }
-
-    // MARK: - Scenario 14: Consistent Span Names
-
-    private func runConsistentSpanNamesScenario() {
-        for _ in 1...3 {
-            sendPOSTToReflect(path: "/graphql", contentType: "application/json",
+    // MARK: - Scenario 15: Span ID and Trace ID Validation
+    // ✅ CHANGED: reads bodies from feature file config, added NSLog for QA visibility
+    private func runSpanIdTraceIdValidationScenario() {
+        let body1 = scenarioConfig["graphql_body_1"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+        let body2 = scenarioConfig["graphql_body_2"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+        let body3 = scenarioConfig["graphql_body_3"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
+        NSLog("GraphQLDetect [Scenario 15]: Request 1 body: %@", body1)
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body1)
+        NSLog("GraphQLDetect [Scenario 15]: Request 2 body: %@", body2)
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body2)
+        NSLog("GraphQLDetect [Scenario 15]: Request 3 body: %@", body3)
+        sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body3)
+    }
+    // MARK: - Scenario 16: GraphQL Response Error Handling & Span Status
+    private func runGraphQLResponseStatusScenario() {
+        let errorType = scenarioConfig["error_type"] ?? "success"
+        let expectedStatus = Int(scenarioConfig["expected_status"] ?? "200") ?? 200
+        switch errorType {
+        case "errors_array":
+            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": null, \"errors\": [{\"message\": \"User not found\", \"path\": [\"user\"]}]}"
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: responseBody,
+                responseStatus: expectedStatus
+            )
+        case "partial_data_errors":
+            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": [{\"message\": \"Field deprecated\"}]}"
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: responseBody,
+                responseStatus: expectedStatus
+            )
+        case "success":
+            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": {\"user\": {\"id\": \"1\", \"name\": \"John\"}}}"
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: responseBody,
+                responseStatus: expectedStatus
+            )
+        case "empty_errors":
+            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": []}"
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: responseBody,
+                responseStatus: expectedStatus
+            )
+        case "http_500":
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: "{}",
+                responseStatus: expectedStatus
+            )
+        case "http_401":
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: "{}",
+                responseStatus: expectedStatus
+            )
+        case "timeout":
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: "{}",
+                responseStatus: 408,
+                timeout: 5.0
+            )
+        default:
+            sendPOSTToReflect(path: "/graphql",
+                              contentType: "application/json",
                               body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
         }
     }
-
     // MARK: - Helper Methods
-
     /// Send a POST request to the Maze Runner reflect endpoint
     private func sendPOSTToReflect(path: String, contentType: String, body: String, timeout: TimeInterval = 60.0) {
         guard let url = URL(string: path, relativeTo: fixtureConfig.reflectURL) else {
@@ -277,9 +327,7 @@ class GraphQLDetectScenario: Scenario {
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
         request.httpBody = body.data(using: .utf8)
         request.timeoutInterval = timeout
-
         let semaphore = DispatchSemaphore(value: 0)
-
         URLSession.shared.dataTask(with: request) { _, response, error in
             if let httpResponse = response as? HTTPURLResponse {
                 NSLog("GraphQLDetect: POST \(url) -> \(httpResponse.statusCode)")
@@ -288,10 +336,8 @@ class GraphQLDetectScenario: Scenario {
             }
             semaphore.signal()
         }.resume()
-
         semaphore.wait()
     }
-
     /// Send a GET request to the Maze Runner reflect endpoint
     private func sendGETToReflect(path: String) {
         guard let url = URL(string: path, relativeTo: fixtureConfig.reflectURL) else {
@@ -309,119 +355,7 @@ class GraphQLDetectScenario: Scenario {
         }.resume()
         semaphore.wait()
     }
-    
-    // MARK: - Scenario 15: Span ID and Trace ID Validation
-
-    private func runSpanIdTraceIdValidationScenario() {
-        // Send 3 identical GraphQL operations
-        // Each should get a valid and distinct spanId
-        // All should have valid traceIds (same or distinct)
-        for _ in 1...3 {
-            sendPOSTToReflect(path: "/graphql", contentType: "application/json",
-                              body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
-        }
-    }
-
-    // MARK: - Scenario 16: GraphQL Response Error Handling & Span Status
-
-    private func runGraphQLResponseStatusScenario() {
-        let errorType = scenarioConfig["error_type"] ?? "success"
-        let expectedStatus = Int(scenarioConfig["expected_status"] ?? "200") ?? 200
-
-        switch errorType {
-
-        case "errors_array":
-            // HTTP 200 but response body has non-empty errors array
-            // → SDK should set status.code = STATUS_CODE_ERROR
-            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": null, \"errors\": [{\"message\": \"User not found\", \"path\": [\"user\"]}]}"
-            sendPOSTToReflectWithResponseBody(
-                path: "/reflect/graphql",
-                contentType: "application/json",
-                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
-                responseBody: responseBody,
-                responseStatus: expectedStatus
-            )
-
-        case "partial_data_errors":
-            // HTTP 200 with partial data + non-empty errors array
-            // → SDK should set status.code = STATUS_CODE_ERROR
-            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": [{\"message\": \"Field deprecated\"}]}"
-            sendPOSTToReflectWithResponseBody(
-                path: "/reflect/graphql",
-                contentType: "application/json",
-                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
-                responseBody: responseBody,
-                responseStatus: expectedStatus
-            )
-
-        case "success":
-            // HTTP 200 with clean data, no errors key
-            // → SDK should set status.code = STATUS_CODE_OK
-            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": {\"user\": {\"id\": \"1\", \"name\": \"John\"}}}"
-            sendPOSTToReflectWithResponseBody(
-                path: "/reflect/graphql",
-                contentType: "application/json",
-                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
-                responseBody: responseBody,
-                responseStatus: expectedStatus
-            )
-
-        case "empty_errors":
-            // HTTP 200 with empty errors array []
-            // → SDK should set status.code = STATUS_CODE_OK
-            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": []}"
-            sendPOSTToReflectWithResponseBody(
-                path: "/reflect/graphql",
-                contentType: "application/json",
-                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
-                responseBody: responseBody,
-                responseStatus: expectedStatus
-            )
-
-        case "http_500":
-            // HTTP 500 transport error
-            // → SDK should set status.code = STATUS_CODE_ERROR
-            sendPOSTToReflectWithResponseBody(
-                path: "/reflect/graphql",
-                contentType: "application/json",
-                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
-                responseBody: "{}",
-                responseStatus: expectedStatus
-            )
-
-        case "http_401":
-            // HTTP 401 unauthorized
-            // → SDK should set status.code = STATUS_CODE_ERROR
-            sendPOSTToReflectWithResponseBody(
-                path: "/reflect/graphql",
-                contentType: "application/json",
-                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
-                responseBody: "{}",
-                responseStatus: expectedStatus
-            )
-
-        case "timeout":
-            // Connection timeout
-            // → SDK should set status.code = STATUS_CODE_ERROR
-            sendPOSTToReflectWithResponseBody(
-                path: "/reflect/graphql",
-                contentType: "application/json",
-                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
-                responseBody: "{}",
-                responseStatus: 408,
-                timeout: 5.0
-            )
-
-        default:
-            sendPOSTToReflect(path: "/graphql",
-                              contentType: "application/json",
-                              body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
-        }
-        
-    }
-
     /// Send a POST to reflect with a specific response body and status
-    /// Uses Maze Runner's reflect endpoint with response configuration headers
     private func sendPOSTToReflectWithResponseBody(
         path: String,
         contentType: String,
@@ -436,7 +370,6 @@ class GraphQLDetectScenario: Scenario {
             NSLog("GraphQLDetect: sendPOSTToReflectWithResponseBody - invalid URL for path: \(path)")
             return
         }
-
         var queryItems = components.queryItems ?? []
         queryItems.append(URLQueryItem(name: "status", value: String(responseStatus)))
         queryItems.append(URLQueryItem(name: "body_b64", value: Data(responseBody.utf8).base64EncodedString()))
@@ -444,32 +377,24 @@ class GraphQLDetectScenario: Scenario {
             queryItems.append(URLQueryItem(name: "delay_ms", value: String(responseDelayMs)))
         }
         components.queryItems = queryItems
-
         guard let url = components.url else {
             NSLog("GraphQLDetect: sendPOSTToReflectWithResponseBody - unable to build URL for path: \(path)")
             return
         }
-
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
         request.httpBody = requestBody.data(using: .utf8)
         request.timeoutInterval = timeout
-
-        // Tell Maze Runner reflect to respond with specific status + body
         request.setValue(String(responseStatus), forHTTPHeaderField: "Bugsnag-Reflect-Status")
         request.setValue(Data(responseBody.utf8).base64EncodedString(), forHTTPHeaderField: "Bugsnag-Reflect-Body-Base64")
         if let responseDelayMs = responseDelayMs {
             request.setValue(String(responseDelayMs), forHTTPHeaderField: "Bugsnag-Reflect-Delay-Ms")
         }
-
         let semaphore = DispatchSemaphore(value: 0)
-
         URLSession.shared.dataTask(with: request) { data, response, error in
             if let httpResponse = response as? HTTPURLResponse {
                 NSLog("GraphQLDetect: POST \(url) -> \(httpResponse.statusCode)")
-
-                // Log response body for debugging
                 if let data = data, let bodyString = String(data: data, encoding: .utf8) {
                     NSLog("GraphQLDetect: Response body: \(bodyString)")
                 }
@@ -478,7 +403,6 @@ class GraphQLDetectScenario: Scenario {
             }
             semaphore.signal()
         }.resume()
-
         semaphore.wait()
     }
 }

--- a/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
+++ b/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
@@ -45,11 +45,11 @@ class GraphQLDetectScenario: Scenario {
         case 10:
             runSafeAttributesScenario()
         case 11:
-            runFirstClassFalseScenario()
+            runFirstClassScenario()
         case 12:
             runRequestFailureScenario()
         case 13:
-            runIOSClientLibraryScenario()
+            runIOSClientGraphQLScenario()
         case 14:
             runConsistentSpanNamesScenario()
         default:
@@ -209,9 +209,9 @@ class GraphQLDetectScenario: Scenario {
                           body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
     }
 
-    // MARK: - Scenario 11: first_class=false
+    // MARK: - Scenario 11: first_class=true
 
-    private func runFirstClassFalseScenario() {
+    private func runFirstClassScenario() {
         sendPOSTToReflect(path: "/graphql", contentType: "application/json",
                           body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
     }
@@ -240,9 +240,9 @@ class GraphQLDetectScenario: Scenario {
         }
     }
 
-    // MARK: - Scenario 13: iOS Client Library
+    // MARK: - Scenario 13: iOS URLSession GraphQL Request
 
-    private func runIOSClientLibraryScenario() {
+    private func runIOSClientGraphQLScenario() {
         sendPOSTToReflect(path: "/graphql", contentType: "application/json",
                           body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
     }

--- a/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
+++ b/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
@@ -52,6 +52,10 @@ class GraphQLDetectScenario: Scenario {
             runIOSClientGraphQLScenario()
         case 14:
             runConsistentSpanNamesScenario()
+        case 15:
+            runSpanIdTraceIdValidationScenario()
+        case 16:
+            runGraphQLResponseStatusScenario()
         default:
             break
         }
@@ -303,6 +307,178 @@ class GraphQLDetectScenario: Scenario {
             }
             semaphore.signal()
         }.resume()
+        semaphore.wait()
+    }
+    
+    // MARK: - Scenario 15: Span ID and Trace ID Validation
+
+    private func runSpanIdTraceIdValidationScenario() {
+        // Send 3 identical GraphQL operations
+        // Each should get a valid and distinct spanId
+        // All should have valid traceIds (same or distinct)
+        for _ in 1...3 {
+            sendPOSTToReflect(path: "/graphql", contentType: "application/json",
+                              body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+        }
+    }
+
+    // MARK: - Scenario 16: GraphQL Response Error Handling & Span Status
+
+    private func runGraphQLResponseStatusScenario() {
+        let errorType = scenarioConfig["error_type"] ?? "success"
+        let expectedStatus = Int(scenarioConfig["expected_status"] ?? "200") ?? 200
+
+        switch errorType {
+
+        case "errors_array":
+            // HTTP 200 but response body has non-empty errors array
+            // → SDK should set status.code = STATUS_CODE_ERROR
+            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": null, \"errors\": [{\"message\": \"User not found\", \"path\": [\"user\"]}]}"
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: responseBody,
+                responseStatus: expectedStatus
+            )
+
+        case "partial_data_errors":
+            // HTTP 200 with partial data + non-empty errors array
+            // → SDK should set status.code = STATUS_CODE_ERROR
+            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": [{\"message\": \"Field deprecated\"}]}"
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: responseBody,
+                responseStatus: expectedStatus
+            )
+
+        case "success":
+            // HTTP 200 with clean data, no errors key
+            // → SDK should set status.code = STATUS_CODE_OK
+            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": {\"user\": {\"id\": \"1\", \"name\": \"John\"}}}"
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: responseBody,
+                responseStatus: expectedStatus
+            )
+
+        case "empty_errors":
+            // HTTP 200 with empty errors array []
+            // → SDK should set status.code = STATUS_CODE_OK
+            let responseBody = scenarioConfig["response_body"] ?? "{\"data\": {\"user\": {\"id\": \"1\"}}, \"errors\": []}"
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: responseBody,
+                responseStatus: expectedStatus
+            )
+
+        case "http_500":
+            // HTTP 500 transport error
+            // → SDK should set status.code = STATUS_CODE_ERROR
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: "{}",
+                responseStatus: expectedStatus
+            )
+
+        case "http_401":
+            // HTTP 401 unauthorized
+            // → SDK should set status.code = STATUS_CODE_ERROR
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: "{}",
+                responseStatus: expectedStatus
+            )
+
+        case "timeout":
+            // Connection timeout
+            // → SDK should set status.code = STATUS_CODE_ERROR
+            sendPOSTToReflectWithResponseBody(
+                path: "/reflect/graphql",
+                contentType: "application/json",
+                requestBody: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}",
+                responseBody: "{}",
+                responseStatus: 408,
+                timeout: 5.0
+            )
+
+        default:
+            sendPOSTToReflect(path: "/graphql",
+                              contentType: "application/json",
+                              body: "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}")
+        }
+        
+    }
+
+    /// Send a POST to reflect with a specific response body and status
+    /// Uses Maze Runner's reflect endpoint with response configuration headers
+    private func sendPOSTToReflectWithResponseBody(
+        path: String,
+        contentType: String,
+        requestBody: String,
+        responseBody: String,
+        responseStatus: Int,
+        responseDelayMs: Int? = nil,
+        timeout: TimeInterval = 60.0
+    ) {
+        guard let baseUrl = URL(string: path, relativeTo: fixtureConfig.mazeRunnerURL),
+              var components = URLComponents(url: baseUrl, resolvingAgainstBaseURL: true) else {
+            NSLog("GraphQLDetect: sendPOSTToReflectWithResponseBody - invalid URL for path: \(path)")
+            return
+        }
+
+        var queryItems = components.queryItems ?? []
+        queryItems.append(URLQueryItem(name: "status", value: String(responseStatus)))
+        queryItems.append(URLQueryItem(name: "body_b64", value: Data(responseBody.utf8).base64EncodedString()))
+        if let responseDelayMs = responseDelayMs {
+            queryItems.append(URLQueryItem(name: "delay_ms", value: String(responseDelayMs)))
+        }
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            NSLog("GraphQLDetect: sendPOSTToReflectWithResponseBody - unable to build URL for path: \(path)")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        request.httpBody = requestBody.data(using: .utf8)
+        request.timeoutInterval = timeout
+
+        // Tell Maze Runner reflect to respond with specific status + body
+        request.setValue(String(responseStatus), forHTTPHeaderField: "Bugsnag-Reflect-Status")
+        request.setValue(Data(responseBody.utf8).base64EncodedString(), forHTTPHeaderField: "Bugsnag-Reflect-Body-Base64")
+        if let responseDelayMs = responseDelayMs {
+            request.setValue(String(responseDelayMs), forHTTPHeaderField: "Bugsnag-Reflect-Delay-Ms")
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let httpResponse = response as? HTTPURLResponse {
+                NSLog("GraphQLDetect: POST \(url) -> \(httpResponse.statusCode)")
+
+                // Log response body for debugging
+                if let data = data, let bodyString = String(data: data, encoding: .utf8) {
+                    NSLog("GraphQLDetect: Response body: \(bodyString)")
+                }
+            } else if let error = error {
+                NSLog("GraphQLDetect: POST \(url) -> error: \(error.localizedDescription)")
+            }
+            semaphore.signal()
+        }.resume()
+
         semaphore.wait()
     }
 }

--- a/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
+++ b/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
@@ -12,10 +12,10 @@ import BugsnagPerformance
 class GraphQLDetectScenario: Scenario {
     
     override func setInitialBugsnagConfiguration() {
-            super.setInitialBugsnagConfiguration()
-            // Enable network auto-instrumentation so the SDK can detect GraphQL
-            bugsnagPerfConfig.autoInstrumentNetworkRequests = true
-        }
+        super.setInitialBugsnagConfiguration()
+        // Enable network auto-instrumentation so the SDK can detect GraphQL
+        bugsnagPerfConfig.autoInstrumentNetworkRequests = true
+    }
 
     override func run() {
         // Force the automatic startup spans to be sent in a separate batch we discard
@@ -62,7 +62,16 @@ class GraphQLDetectScenario: Scenario {
     private func runDetectionScenario() {
         let contentType = scenarioConfig["content_type"] ?? "application/json"
         let body = scenarioConfig["body"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
-        let path = scenarioConfig["url_path"] ?? "/graphql"
+        let path: String = {
+            if let urlString = scenarioConfig["url"], let url = URL(string: urlString) {
+                var path = url.path.isEmpty ? "/" : url.path
+                if let query = url.query, !query.isEmpty {
+                    path += "?\(query)"
+                }
+                return path
+            }
+            return scenarioConfig["url_path"] ?? "/graphql"
+        }()
 
         sendPOSTToReflect(path: path, contentType: contentType, body: body)
     }
@@ -79,8 +88,17 @@ class GraphQLDetectScenario: Scenario {
 
     private func runDisplayNameScenario() {
         let body = scenarioConfig["body"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
-        let path = scenarioConfig["url_path"] ?? "/graphql"
-
+        let path: String = {
+            if let urlString = scenarioConfig["url"], let url = URL(string: urlString) {
+                var path = url.path.isEmpty ? "/" : url.path
+                if let query = url.query, !query.isEmpty {
+                    path += "?\(query)"
+                }
+                return path
+            }
+            return scenarioConfig["url_path"] ?? "/graphql"
+        }()
+        
         sendPOSTToReflect(path: path, contentType: "application/json", body: body)
     }
 
@@ -90,7 +108,16 @@ class GraphQLDetectScenario: Scenario {
         let method = scenarioConfig["http_method"] ?? "POST"
         let contentType = scenarioConfig["content_type"] ?? "application/json"
         let body = scenarioConfig["body"] ?? "{\"userId\": \"123\", \"action\": \"get\"}"
-        let path = scenarioConfig["url_path"] ?? "/rest/users"
+        let path: String = {
+            if let urlString = scenarioConfig["url"], let url = URL(string: urlString) {
+                var path = url.path.isEmpty ? "/" : url.path
+                if let query = url.query, !query.isEmpty {
+                    path += "?\(query)"
+                }
+                return path
+            }
+            return scenarioConfig["url_path"] ?? "/rest/users"
+        }()
 
         if method == "GET" {
             sendGETToReflect(path: path)

--- a/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
+++ b/features/fixtures/ios/Scenarios/GraphQLDetectScenario.swift
@@ -113,7 +113,6 @@ class GraphQLDetectScenario: Scenario {
         }
     }
     // MARK: - Scenario 5: Malformed/Empty Body
-    // ✅ CHANGED: reads body directly from feature file config (not body_type switch)
     private func runMalformedBodyScenario() {
         let body = scenarioConfig["body"] ?? ""
         let path: String = {
@@ -125,7 +124,6 @@ class GraphQLDetectScenario: Scenario {
         sendPOSTToReflect(path: path, contentType: "application/json", body: body)
     }
     // MARK: - Scenario 6: Edge-Case Operation Names
-    // ✅ CHANGED: added NSLog for QA visibility, fixed path fallback "/" → ""
     private func runEdgeCaseOperationNameScenario() {
         let configBody = scenarioConfig["body"] ?? ""
         let body: String
@@ -146,7 +144,6 @@ class GraphQLDetectScenario: Scenario {
         sendPOSTToReflect(path: path, contentType: "application/json", body: body)
     }
     // MARK: - Scenario 7: Batched Request
-    // ✅ CHANGED: reads body from feature file config instead of hardcoded
     private func runBatchedRequestScenario() {
         let body = scenarioConfig["body"] ?? "[{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}, {\"query\": \"query GetPosts { posts { id } }\", \"operationName\": \"GetPosts\"}]"
         let contentType = scenarioConfig["content_type"] ?? "application/json"
@@ -164,7 +161,6 @@ class GraphQLDetectScenario: Scenario {
         sendGETToReflect(path: path)
     }
     // MARK: - Scenario 9: Multiple Operations
-    // ✅ CHANGED: reads bodies from feature file config, added NSLog for QA visibility
     private func runMultipleOperationsScenario() {
         let body1 = scenarioConfig["graphql_body_1"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
         let body2 = scenarioConfig["graphql_body_2"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
@@ -175,13 +171,9 @@ class GraphQLDetectScenario: Scenario {
             }
             return "/rest/users/123"
         }()
-        NSLog("GraphQLDetect [Scenario 9]: Request 1 body: %@", body1)
         sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body1)
-        NSLog("GraphQLDetect [Scenario 9]: Request 2 body: %@", body2)
         sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body2)
-        NSLog("GraphQLDetect [Scenario 9]: Request 3 body: %@", body3)
         sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body3)
-        NSLog("GraphQLDetect [Scenario 9]: Request 4 GET: %@", restPath)
         sendGETToReflect(path: restPath)
     }
     // MARK: - Scenario 10: Safe Attributes Only
@@ -227,16 +219,12 @@ class GraphQLDetectScenario: Scenario {
         sendPOSTToReflect(path: path, contentType: "application/json", body: body)
     }
     // MARK: - Scenario 15: Span ID and Trace ID Validation
-    // ✅ CHANGED: reads bodies from feature file config, added NSLog for QA visibility
     private func runSpanIdTraceIdValidationScenario() {
         let body1 = scenarioConfig["graphql_body_1"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
         let body2 = scenarioConfig["graphql_body_2"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
         let body3 = scenarioConfig["graphql_body_3"] ?? "{\"query\": \"query GetUser { user { id } }\", \"operationName\": \"GetUser\"}"
-        NSLog("GraphQLDetect [Scenario 15]: Request 1 body: %@", body1)
         sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body1)
-        NSLog("GraphQLDetect [Scenario 15]: Request 2 body: %@", body2)
         sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body2)
-        NSLog("GraphQLDetect [Scenario 15]: Request 3 body: %@", body3)
         sendPOSTToReflect(path: "/graphql", contentType: "application/json", body: body3)
     }
     // MARK: - Scenario 16: GraphQL Response Error Handling & Span Status
@@ -315,7 +303,6 @@ class GraphQLDetectScenario: Scenario {
     /// Send a POST request to the Maze Runner reflect endpoint
     private func sendPOSTToReflect(path: String, contentType: String, body: String, timeout: TimeInterval = 60.0) {
         guard let url = URL(string: path, relativeTo: fixtureConfig.reflectURL) else {
-            NSLog("GraphQLDetect: sendPOSTToReflect - invalid URL for path: \(path)")
             return
         }
         sendPOST(url: url, contentType: contentType, body: body, timeout: timeout)
@@ -341,7 +328,6 @@ class GraphQLDetectScenario: Scenario {
     /// Send a GET request to the Maze Runner reflect endpoint
     private func sendGETToReflect(path: String) {
         guard let url = URL(string: path, relativeTo: fixtureConfig.reflectURL) else {
-            NSLog("GraphQLDetect: sendGETToReflect - invalid URL for path: \(path)")
             return
         }
         let semaphore = DispatchSemaphore(value: 0)
@@ -367,7 +353,6 @@ class GraphQLDetectScenario: Scenario {
     ) {
         guard let baseUrl = URL(string: path, relativeTo: fixtureConfig.mazeRunnerURL),
               var components = URLComponents(url: baseUrl, resolvingAgainstBaseURL: true) else {
-            NSLog("GraphQLDetect: sendPOSTToReflectWithResponseBody - invalid URL for path: \(path)")
             return
         }
         var queryItems = components.queryItems ?? []
@@ -378,7 +363,6 @@ class GraphQLDetectScenario: Scenario {
         }
         components.queryItems = queryItems
         guard let url = components.url else {
-            NSLog("GraphQLDetect: sendPOSTToReflectWithResponseBody - unable to build URL for path: \(path)")
             return
         }
         var request = URLRequest(url: url)

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -500,3 +500,48 @@ Then('a nested span field {string} equals {string}') do |field_path, expected_va
   end.compact
   raise Test::Unit::AssertionFailedError, "<#{field_values}> was expected to include\n<#{expected_value}>." unless field_values.include?(expected_value)
 end
+
+Then('a span field {string} does not match the regex {string}') do |field, pattern|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.each do |span|
+    value = span[field].to_s
+    Maze.check.false(
+      Regexp.new(pattern).match?(value),
+      "Expected span field '#{field}' not to match /#{pattern}/ but got '#{value}'"
+    )
+  end
+end
+
+Then('no span attribute value contains {string}') do |forbidden|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.each do |span|
+    (span['attributes'] || []).each do |attr|
+      val = attr['value']
+      string_val = val['stringValue'] || val['intValue']&.to_s || ''
+      Maze.check.false(
+        string_val.include?(forbidden),
+        "Span attribute '#{attr['key']}' contains forbidden value '#{forbidden}'"
+      )
+    end
+  end
+end
+
+Then('every span field {string} exists') do |field|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  raise 'No spans received' if spans.empty?
+  spans.each do |span|
+    Maze.check.not_nil(
+      span[field],
+      "Expected span field '#{field}' to exist but it was nil"
+    )
+  end
+end
+
+Then('every span has a distinct field {string}') do |field|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  values = spans.map { |span| span[field] }
+  Maze.check.true(
+    values.uniq.length == values.length,
+    "Expected all '#{field}' values to be distinct but got: #{values}"
+  )
+end

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -493,3 +493,10 @@ Then('I should receive no spans') do
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   raise Test::Unit::AssertionFailedError, "Expected 0 spans but received #{spans.size}" unless spans.empty?
 end
+Then('a nested span field {string} equals {string}') do |field_path, expected_value|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  field_values = spans.map do |span|
+    field_path.split('.').reduce(span) { |obj, key| obj.is_a?(Hash) ? obj[key] : nil }
+  end.compact
+  raise Test::Unit::AssertionFailedError, "<#{field_values}> was expected to include\n<#{expected_value}>." unless field_values.include?(expected_value)
+end

--- a/features/steps/hooks.rb
+++ b/features/steps/hooks.rb
@@ -4,17 +4,20 @@ Maze.hooks.after do |scenario|
   folder1 = File.join(Dir.pwd, 'maze_output')
   folder2 = scenario.failed? ? 'failed' : 'passed'
   folder3 = scenario.name.gsub(/[:"& ]/, '_').gsub(/_+/, '_')
-
   path = File.join(folder1, folder2, folder3)
-
   case Maze::Helper.get_current_platform
   when 'ios'
-    # get_log can be slow (1 or 2 seconds) on device farms
     if scenario.failed? || Maze.config.farm == :local
       FileUtils.makedirs(path)
       File.open(File.join(path, 'syslog.log'), 'wb') do |file|
-        manager = Maze::Api::Appium::DeviceManager.new
-        manager.get_log('syslog').each { |entry| file.puts entry.message }
+        begin
+          driver = Maze.driver.respond_to?(:driver) ? Maze.driver.driver : Maze.driver
+          driver.manage.logs.get('syslog').each do |entry|
+                file.puts entry.message
+          end
+        rescue StandardError => e
+          file.puts "Failed to retrieve syslog: #{e.message}"
+        end
       end
     end
   end

--- a/features/support/bitbar_config.rb
+++ b/features/support/bitbar_config.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Before('@resource_aggregation') do
+  next unless Maze.config.farm == :bb
+
+  @original_receive_requests_wait = Maze.config.receive_requests_wait
+  Maze.config.receive_requests_wait = 60
+
+  traces = Maze::Server.list_for('traces')
+  traces.next until traces.current.nil?
+end
+
+After('@resource_aggregation') do
+  next unless Maze.config.farm == :bb
+  next unless @original_receive_requests_wait
+
+  Maze.config.receive_requests_wait = @original_receive_requests_wait
+end

--- a/features/support/reflective_servlet_overrides.rb
+++ b/features/support/reflective_servlet_overrides.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'base64'
+
+module ReflectiveServletResponseOverrides
+  def do_GET(request, response)
+    super
+    apply_reflect_overrides(request, response)
+  end
+
+  def do_POST(request, response)
+    super
+    apply_reflect_overrides(request, response)
+  end
+
+  private
+
+  def apply_reflect_overrides(request, response)
+    query = request.query || {}
+    status_override = request['Bugsnag-Reflect-Status'] || query['status']
+    body_b64_override = request['Bugsnag-Reflect-Body-Base64'] || query['body_b64']
+    body_override = request['Bugsnag-Reflect-Body'] || query['body']
+    delay_override = request['Bugsnag-Reflect-Delay-Ms'] || query['delay_ms']
+
+    sleep delay_override.to_i / 1000.0 if delay_override && !delay_override.empty?
+
+    if body_b64_override && !body_b64_override.empty?
+      begin
+        body_override = Base64.decode64(body_b64_override)
+      rescue StandardError
+        # Fall back to raw body override if base64 decode fails.
+      end
+    end
+
+    response.status = status_override.to_i if status_override && !status_override.empty?
+    response.body = body_override if body_override && !body_override.empty?
+  end
+end
+
+Maze::Servlets::ReflectiveServlet.prepend(ReflectiveServletResponseOverrides)


### PR DESCRIPTION
## Goal

Categorize GraphQL requests as a new graphql span category instead of generic POST /graphql network spans, enabling operation-level grouping in BugSnag Performance Network views.

## Design

Reuses the existing span-group model and Network UI — GraphQL is detected client-side via a three-method algorithm (Content-Type + URL pattern + body inspection), with operation type/name encoded in the span name as GraphQL.

## Changeset

Added GraphQL detection logic, operation type/name extraction, span name construction ([GraphQL] query:GetUserProfile), and emitting spans with category = graphql and is_first_class = true while preserving existing HTTP attributes.

## Testing

Unit testing and Maze runner test scenario added.