### PR TITLE
ROAD-2233: Disk IOPS iOS

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -9,7 +9,7 @@ steps:
   - group: "Unit tests"
     steps:
       - label: ":xcode_simulator: iOS 18 Unit tests"
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         commands:
           - "./scripts/run-unit-tests.sh PLATFORM=iOS OS=18.4 DEVICE=\"iPhone 16\""
         plugins:
@@ -18,7 +18,7 @@ steps:
               - "logs/*"
 
       - label: ":xcode_simulator: iOS 17 Unit tests"
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         commands:
           - "./scripts/run-unit-tests.sh PLATFORM=iOS OS=17.5 DEVICE=\"iPhone 15\""
         plugins:
@@ -27,7 +27,7 @@ steps:
               - "logs/*"
 
       - label: ":xcode_simulator: iOS 16 Unit tests"
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         commands:
           - "./scripts/run-unit-tests.sh PLATFORM=iOS OS=16.4 DEVICE=\"iPhone 14\""
         plugins:
@@ -36,7 +36,7 @@ steps:
               - "logs/*"
 
       - label: ":xcode_simulator: iOS 15 Unit tests"
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         commands:
           - "./scripts/run-unit-tests.sh PLATFORM=iOS OS=15.5 DEVICE=\"iPhone 13\""
         plugins:
@@ -45,7 +45,7 @@ steps:
               - "logs/*"
 
       - label: ":xcode_simulator: iOS 14 Unit tests"
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         commands:
           - "./scripts/run-unit-tests.sh PLATFORM=iOS OS=14.5 DEVICE=\"iPhone 12\""
         plugins:

--- a/BugsnagPerformance.xcodeproj/project.pbxproj
+++ b/BugsnagPerformance.xcodeproj/project.pbxproj
@@ -86,6 +86,13 @@
 		1C68DBA52E535E21002621D1 /* BugsnagPerformanceAppStartTypePlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C68DBA42E535E1E002621D1 /* BugsnagPerformanceAppStartTypePlugin.mm */; };
 		1C7852A22E5F5B3000BB8E2D /* SpanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C7852A12E5F5B2E00BB8E2D /* SpanContext.h */; };
 		1C7852A42E5F698300BB8E2D /* SpanContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C7852A32E5F697D00BB8E2D /* SpanContext.mm */; };
+		3208308C301FF28000E0958A /* DiskIOCollectorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3208308B301FF27900E0958A /* DiskIOCollectorTests.mm */; };
+		3208308E301FF30400E0958A /* DiskIOMetricsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3208308D301FF2F900E0958A /* DiskIOMetricsTests.mm */; };
+		32083090301FF33400E0958A /* DiskIOSnapshotTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3208308F301FF32E00E0958A /* DiskIOSnapshotTests.mm */; };
+		3299CB1430209ACF008774D3 /* BSGDiskIOCollector.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3299CB1330209ACD008774D3 /* BSGDiskIOCollector.mm */; };
+		3299CB1630209ADC008774D3 /* BSGDiskIOCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 3299CB1530209AD6008774D3 /* BSGDiskIOCollector.h */; };
+		3299CB1830209AE6008774D3 /* BSGDiskIOMetrics.h in Headers */ = {isa = PBXBuildFile; fileRef = 3299CB1730209AE3008774D3 /* BSGDiskIOMetrics.h */; };
+		3299CB1A30209AFA008774D3 /* BSGDiskIOSnapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 3299CB1930209AF6008774D3 /* BSGDiskIOSnapshot.h */; };
 		8A80DA8B2966CE940035BDA9 /* BugsnagPerformance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */; };
 		8A80DA912966CEB30035BDA9 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A80DA80296588840035BDA9 /* ConfigurationTests.swift */; };
 		960EECF12B23DF9B009FAA11 /* BugsnagPerformanceTrackedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960EECED2B237561009FAA11 /* BugsnagPerformanceTrackedViewController.swift */; };
@@ -515,6 +522,13 @@
 		1C68DBA42E535E1E002621D1 /* BugsnagPerformanceAppStartTypePlugin.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceAppStartTypePlugin.mm; sourceTree = "<group>"; };
 		1C7852A12E5F5B2E00BB8E2D /* SpanContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpanContext.h; sourceTree = "<group>"; };
 		1C7852A32E5F697D00BB8E2D /* SpanContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SpanContext.mm; sourceTree = "<group>"; };
+		3208308B301FF27900E0958A /* DiskIOCollectorTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DiskIOCollectorTests.mm; sourceTree = "<group>"; };
+		3208308D301FF2F900E0958A /* DiskIOMetricsTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DiskIOMetricsTests.mm; sourceTree = "<group>"; };
+		3208308F301FF32E00E0958A /* DiskIOSnapshotTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DiskIOSnapshotTests.mm; sourceTree = "<group>"; };
+		3299CB1330209ACD008774D3 /* BSGDiskIOCollector.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGDiskIOCollector.mm; sourceTree = "<group>"; };
+		3299CB1530209AD6008774D3 /* BSGDiskIOCollector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGDiskIOCollector.h; sourceTree = "<group>"; };
+		3299CB1730209AE3008774D3 /* BSGDiskIOMetrics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGDiskIOMetrics.h; sourceTree = "<group>"; };
+		3299CB1930209AF6008774D3 /* BSGDiskIOSnapshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGDiskIOSnapshot.h; sourceTree = "<group>"; };
 		72E4BB63359EA30E80116E2A /* BugsnagPerformance.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagPerformance.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A80DA80296588840035BDA9 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		8A80DA872966CE940035BDA9 /* BugsnagPerformance-iOSTestsSwift.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagPerformance-iOSTestsSwift.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -907,6 +921,7 @@
 		0122C21F29019770002D243C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				3299CB1130209A72008774D3 /* DiskIO */,
 				CB572EA829BB783200FD7A2A /* AppStateTracker.h */,
 				CB572EA929BB783200FD7A2A /* AppStateTracker.m */,
 				CBE8EA1C294B5E1500702950 /* Batch.h */,
@@ -1050,6 +1065,9 @@
 		0122C25C29019C05002D243C /* BugsnagPerformanceTests */ = {
 			isa = PBXGroup;
 			children = (
+				3208308F301FF32E00E0958A /* DiskIOSnapshotTests.mm */,
+				3208308D301FF2F900E0958A /* DiskIOMetricsTests.mm */,
+				3208308B301FF27900E0958A /* DiskIOCollectorTests.mm */,
 				CB0AD75C29641B59002A3FB6 /* BatchTests.mm */,
 				963726D92DEFBA5200C739E6 /* BSGCompositeSpanControlProviderTests.m */,
 				963726D62DEFB2BE00C739E6 /* BSGPrioritizedStoreTests.m */,
@@ -1118,6 +1136,17 @@
 				09D807F42B9756B000D01DF5 /* BugsnagPerformanceSwiftUI.docc */,
 			);
 			path = BugsnagPerformanceSwiftUI;
+			sourceTree = "<group>";
+		};
+		3299CB1130209A72008774D3 /* DiskIO */ = {
+			isa = PBXGroup;
+			children = (
+				3299CB1930209AF6008774D3 /* BSGDiskIOSnapshot.h */,
+				3299CB1730209AE3008774D3 /* BSGDiskIOMetrics.h */,
+				3299CB1530209AD6008774D3 /* BSGDiskIOCollector.h */,
+				3299CB1330209ACD008774D3 /* BSGDiskIOCollector.mm */,
+			);
+			path = DiskIO;
 			sourceTree = "<group>";
 		};
 		450CB5014AAED50046482044 /* Products */ = {
@@ -1554,6 +1583,7 @@
 				CB04969729150D860097E526 /* OtlpPackage.h in Headers */,
 				960EECF32B24CA24009FAA11 /* BugsnagPerformanceTrackedViewContainer.h in Headers */,
 				966634D52C8A3647004A934D /* FrameMetricsSnapshot.h in Headers */,
+				3299CB1A30209AFA008774D3 /* BSGDiskIOSnapshot.h in Headers */,
 				CB34772029068C350033759C /* BSGURLSessionPerformanceProxy.h in Headers */,
 				963726E42DF19D7F00C739E6 /* BugsnagPerformanceSpanControlProvider+Private.h in Headers */,
 				963726DD2DF0B43500C739E6 /* BugsnagPerformancePluginContext.h in Headers */,
@@ -1567,6 +1597,7 @@
 				967949BD2E99373E005FD87F /* SpanStore.h in Headers */,
 				963726C12DEA4E5700C739E6 /* BugsnagPerformancePriority.h in Headers */,
 				962CE7E82E6123E700380522 /* ViewLoadLoadingIndicatorsHandlerImpl.h in Headers */,
+				3299CB1830209AE6008774D3 /* BSGDiskIOMetrics.h in Headers */,
 				962CE7E92E6123E700380522 /* ViewLoadLoadingIndicatorsHandler.h in Headers */,
 				CB7FD930299D2EF200499E13 /* BugsnagPerformanceSpanOptions.h in Headers */,
 				965FBD152DF24D3300D6BACB /* Logging.h in Headers */,
@@ -1636,6 +1667,7 @@
 				CB572EAA29BB783200FD7A2A /* AppStateTracker.h in Headers */,
 				CBEC51DC2976F1F9009C0CE3 /* RetryQueue.h in Headers */,
 				963726CE2DEAB34B00C739E6 /* BSGPrioritizedStore.h in Headers */,
+				3299CB1630209ADC008774D3 /* BSGDiskIOCollector.h in Headers */,
 				01A414CD2913C0F0003152A4 /* SpanAttributes.h in Headers */,
 				963829162E54972600404F3A /* AppStartupSpanFactoryImpl.h in Headers */,
 				0122C25129019770002D243C /* Tracer.h in Headers */,
@@ -2046,7 +2078,9 @@
 				963726D72DEFB2CC00C739E6 /* BSGPrioritizedStoreTests.m in Sources */,
 				CBEC51DF29782471009C0CE3 /* OtlpPackageTests.mm in Sources */,
 				CB0AD75B295F27DD002A3FB6 /* WorkerTests.mm in Sources */,
+				32083090301FF33400E0958A /* DiskIOSnapshotTests.mm in Sources */,
 				CBEC51C3296EC0AC009C0CE3 /* JSONTests.mm in Sources */,
+				3208308C301FF28000E0958A /* DiskIOCollectorTests.mm in Sources */,
 				01A414C52912B93F003152A4 /* ResourceAttributesTests.mm in Sources */,
 				09B4730A2B2313570024CF11 /* WeakSpansListTests.mm in Sources */,
 				CB2B8A9B2A0924A50054FBBE /* SpanTests.mm in Sources */,
@@ -2061,6 +2095,7 @@
 				0122C27129019CEF002D243C /* OtlpTraceEncodingTests.mm in Sources */,
 				098FC8792D3FADFE001B627D /* SpanAttributesTests.mm in Sources */,
 				962F80F229DB03A400BE82BC /* PerformanceMicrobenchmarkTests.swift in Sources */,
+				3208308E301FF30400E0958A /* DiskIOMetricsTests.mm in Sources */,
 				CB747D1F299E4984003CA1B4 /* SpanOptionsTests.mm in Sources */,
 				CB0AD76C296578D9002A3FB6 /* BugsnagPerformanceConfigurationTests.mm in Sources */,
 				96F1292F2DCD1BE200A6FB2B /* BugsnagPerformanceRemoteSpanContextTests.m in Sources */,
@@ -2137,6 +2172,7 @@
 				968AA5FD2CCA5AB000BA69CF /* BSGPerformanceSharedSessionProxy.mm in Sources */,
 				967949C12E993750005FD87F /* SpanStoreImpl.mm in Sources */,
 				964B78562D4B924C00FF077D /* BugsnagPerformanceSpanCondition.mm in Sources */,
+				3299CB1430209ACF008774D3 /* BSGDiskIOCollector.mm in Sources */,
 				CBEC51DD2976F1F9009C0CE3 /* RetryQueue.mm in Sources */,
 				01A414CE2913C0F0003152A4 /* SpanAttributes.mm in Sources */,
 				CBE8EA1B294B5AB800702950 /* Worker.mm in Sources */,

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -32,10 +32,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Disable automatic URLSession request instrumentation:
         //config.autoInstrumentNetworkRequests = false
-
         // ... or control whether spans are created on a per-instance basis:
-        config.viewControllerInstrumentationCallback = {
-            !($0 is IgnoredViewController)
+        config.viewControllerInstrumentationCallback = { viewController in
+            !(viewController is IgnoredViewController)
         }
 
         BugsnagPerformance.start(configuration: config)

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -850,8 +850,8 @@ final class DiskIOPSViewController: UIViewController {
                     ? now.bytesRead - lastSampleSnap.bytesRead : 0
                 let wd1s = now.bytesWritten >= lastSampleSnap.bytesWritten
                     ? now.bytesWritten - lastSampleSnap.bytesWritten : 0
-                let readOps1s  = Int64((Double(rd1s) / 16384.0 / windowDur).rounded())
-                let writeOps1s = Int64((Double(wd1s) / 16384.0 / windowDur).rounded())
+                let readOps1s  = Int64((Double(rd1s) / DiskIOSample.blockSizeBytes / windowDur).rounded())
+                let writeOps1s = Int64((Double(wd1s) / DiskIOSample.blockSizeBytes / windowDur).rounded())
                 let totalOps1s = readOps1s + writeOps1s
 
                 // Cumulative delta from span start (matches SDK Step 4).
@@ -920,8 +920,8 @@ final class DiskIOPSViewController: UIViewController {
             let writeDelta = endSnap.bytesWritten >= startSnap.bytesWritten
                 ? endSnap.bytesWritten - startSnap.bytesWritten : 0
 
-            let readOps  = Int64((Double(readDelta)  / 16384.0 / durationActual).rounded())
-            let writeOps = Int64((Double(writeDelta) / 16384.0 / durationActual).rounded())
+            let readOps  = Int64((Double(readDelta)  / DiskIOSample.blockSizeBytes / durationActual).rounded())
+            let writeOps = Int64((Double(writeDelta) / DiskIOSample.blockSizeBytes / durationActual).rounded())
             let totalOps = readOps + writeOps
 
             NSLog("[DiskIO Live] long-span target=\(Int(duration))s " +

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -14,6 +14,11 @@ var globalSessionSpan: BugsnagPerformanceSpan?
 
 class ViewController: UIViewController {
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        installDiskIOPSOperationsButton()
+    }
+
     @IBAction func showGenericView(_ sender: Any) {
         let vc = GenericViewController<Int>()
         show(vc, sender:sender)
@@ -44,11 +49,1119 @@ class ViewController: UIViewController {
         usleep(100000 + waitTime)
         span.end()
     }
-    
+
     @IBAction func DoSessionSpan(_ sender: Any) {
         globalSessionSpan = BugsnagPerformance.startAppSessionSpan("my session span")
         // Navigate to Session Span Test Flow
         let endVC = SessionEndViewController()
         navigationController?.pushViewController(endVC, animated: true)
+    }
+
+    // MARK: - Disk IOPS Operation (TEMP: showcase code)
+
+    private func installDiskIOPSOperationsButton() {
+        // Match the visual style of the storyboard buttons ("Manual Span",
+        // "Session Span", etc.): plain blue text, no background, centered.
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Disk IOPS", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 17)
+        button.addTarget(self, action: #selector(openDiskIOPSOperations), for: .touchUpInside)
+        view.addSubview(button)
+
+        NSLayoutConstraint.activate([
+            button.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            // Position just above the bottom safe-area, matching the vertical
+            // rhythm of the storyboard's button column.
+            button.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32),
+        ])
+    }
+
+    @objc private func openDiskIOPSOperations() {
+        let vc = DiskIOPSViewController()
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    // --- END ---
+}
+
+// =============================================================================
+// MARK: - Disk IOPS Live Operation VC (TEMP: showcase code)
+// =============================================================================
+
+/// Standalone screen that continuously fires first-class spans while running
+/// disk work, then shows the read / write / total IOPS values live and plots
+/// a rolling chart of read (blue) vs write (orange) ops/sec.
+///
+/// Values shown on this screen are computed **in the app** by calling
+/// `proc_pid_rusage` directly. This is identical to what the SDK does
+/// internally, so the numbers you see match the SDK's captured span
+/// attributes (visible in the console with the "[DiskIO] Step 4/onSpanEnd"
+/// log line).
+final class DiskIOPSViewController: UIViewController {
+
+    private let readLabel   = UILabel()
+    private let writeLabel  = UILabel()
+    private let totalLabel  = UILabel()
+    private let statusLabel = UILabel()
+    private let chartView   = DiskIOPSChartView()
+    private let startStopButton = UIButton(type: .system)
+
+    // Snapshot data (matches the SDK's [DiskIO] Step 1 & Step 2 logs).
+    private let snapshotHeaderLabel = UILabel()
+    private let snapshotStartLabel  = UILabel()
+    private let snapshotEndLabel    = UILabel()
+    private let snapshotDeltaLabel  = UILabel()
+
+    // Latest span lifecycle indicator (spanId, start ts, end ts, current phase).
+    private let spanHeaderLabel = UILabel()
+    private let spanIdLabel     = UILabel()
+    private let spanStartLabel  = UILabel()
+    private let spanEndLabel    = UILabel()
+    private let spanPhaseLabel  = UILabel()
+    private let spanPhaseDot    = UIView()
+
+    // Span-type selector — lets each tick create a different span kind so the
+    // Operations can showcase disk IOPS across custom, session, and non-first-class
+    // spans (the last one is expected to omit disk metrics via tri-state gating).
+    private enum SpanKind: Int, CaseIterable {
+        case customFirstClass = 0
+        case appSession       = 1
+        case customNonFirstClass = 2
+        var title: String {
+            switch self {
+            case .customFirstClass:     return "Custom"
+            case .appSession:           return "Session"
+            case .customNonFirstClass:  return "Non-1st"
+            }
+        }
+        var explanation: String {
+            switch self {
+            case .customFirstClass:
+                return "Custom first-class span. Disk metrics ATTACHED."
+            case .appSession:
+                return "AppSessionSpan (long-running session). Disk metrics ATTACHED."
+            case .customNonFirstClass:
+                return "Custom NON-first-class span. Disk metrics OMITTED " +
+                       "by tri-state gating (this proves the SDK filter works)."
+            }
+        }
+    }
+    private let spanKindControl = UISegmentedControl(
+        items: SpanKind.allCases.map(\.title))
+    private var selectedKind: SpanKind = .customFirstClass
+
+    // Span-duration selector — lets the user run either the "loop" mode (a new
+    // span every second) or a single long-running span so the Operations can showcase
+    // how disk IOPS is averaged across arbitrarily long time windows.
+    private enum SpanDuration: Int, CaseIterable {
+        case loop = 0
+        case thirtySeconds = 1
+        case oneMinute = 2
+        case fiveMinutes = 3
+        case twentyMinutes = 4
+        case fortyMinutes = 5
+
+        /// Longer label used inside the dropdown menu.
+        var displayLabel: String {
+            switch self {
+            case .loop:             return "Loop (1s cycle)"
+            case .thirtySeconds:    return "30 seconds"
+            case .oneMinute:        return "1 minute"
+            case .fiveMinutes:      return "5 minutes"
+            case .twentyMinutes:    return "20 minutes"
+            case .fortyMinutes:     return "40 minutes"
+            }
+        }
+
+        /// Total wall-clock seconds the span should stay open. `nil` means
+        /// use the legacy loop mode (open+close a span every second).
+        var seconds: TimeInterval? {
+            switch self {
+            case .loop:             return nil
+            case .thirtySeconds:    return 30
+            case .oneMinute:        return 60
+            case .fiveMinutes:      return 300
+            case .twentyMinutes:    return 1200
+            case .fortyMinutes:     return 2400
+            }
+        }
+
+        /// Educational text describing what to expect in the numbers panel.
+        /// Long spans do sustained per-second I/O so live IOPS is visible.
+        var explanation: String {
+            switch self {
+            case .loop:             return "Rolling 1s spans — steady-state IOPS."
+            case .thirtySeconds:    return "Single 30s span. Sustained I/O every second → live IOPS."
+            case .oneMinute:        return "Single 1m span. Sustained I/O every second → live IOPS."
+            case .fiveMinutes:      return "Single 5m span. Sustained I/O every second → live IOPS."
+            case .twentyMinutes:    return "Single 20m span. Sustained I/O every second → live IOPS."
+            case .fortyMinutes:     return "Single 40m span. Sustained I/O every second → live IOPS."
+            }
+        }
+    }
+    private let spanDurationButton = UIButton(type: .system)
+    private var selectedDuration: SpanDuration = .loop
+
+    private var timer: Timer?
+    private var running = false
+    private var sampleCount = 0
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Disk IOPS Live Operations"
+        view.backgroundColor = .systemBackground
+        buildUI()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        stop()
+    }
+
+    // MARK: UI
+
+    private func buildUI() {
+        let readTitle  = makeTitle("Read ops/sec",  color: .systemBlue)
+        let writeTitle = makeTitle("Write ops/sec", color: .systemOrange)
+        let totalTitle = makeTitle("Total ops/sec", color: .label)
+
+        [readLabel, writeLabel, totalLabel].forEach {
+            $0.font = .monospacedDigitSystemFont(ofSize: 36, weight: .semibold)
+            $0.textAlignment = .center
+            $0.text = "—"
+        }
+        readLabel.textColor  = .systemBlue
+        writeLabel.textColor = .systemOrange
+        totalLabel.textColor = .label
+
+        statusLabel.font = .systemFont(ofSize: 12)
+        statusLabel.textColor = .secondaryLabel
+        statusLabel.textAlignment = .center
+        statusLabel.numberOfLines = 0
+        statusLabel.text = "Tap Start to begin sampling every 1 second. " +
+                           "Each sample opens+closes a first-class span, so the SDK " +
+                           "captures the same values (see console '[DiskIO]' logs)."
+
+        startStopButton.setTitle("▶ Start", for: .normal)
+        startStopButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .bold)
+        startStopButton.setTitleColor(.white, for: .normal)
+        startStopButton.backgroundColor = .systemGreen
+        startStopButton.layer.cornerRadius = 10
+        startStopButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 24, bottom: 12, right: 24)
+        startStopButton.addTarget(self, action: #selector(toggle), for: .touchUpInside)
+
+        let readCol  = makeColumn(title: readTitle,  value: readLabel)
+        let writeCol = makeColumn(title: writeTitle, value: writeLabel)
+        let totalCol = makeColumn(title: totalTitle, value: totalLabel)
+
+        let numbersRow = UIStackView(arrangedSubviews: [readCol, writeCol, totalCol])
+        numbersRow.axis = .horizontal
+        numbersRow.distribution = .fillEqually
+        numbersRow.spacing = 8
+        numbersRow.translatesAutoresizingMaskIntoConstraints = false
+
+        // Snapshot data card: exactly what the SDK captures at span start/end.
+        snapshotHeaderLabel.text = "Snapshot data (matches SDK's Step 1 & Step 2)"
+        snapshotHeaderLabel.font = .systemFont(ofSize: 11, weight: .semibold)
+        snapshotHeaderLabel.textColor = .secondaryLabel
+        snapshotHeaderLabel.textAlignment = .center
+
+        [snapshotStartLabel, snapshotEndLabel, snapshotDeltaLabel].forEach {
+            $0.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+            $0.textColor = .label
+            $0.numberOfLines = 2
+            $0.lineBreakMode = .byWordWrapping
+            $0.adjustsFontSizeToFitWidth = true
+            $0.minimumScaleFactor = 0.75
+        }
+        snapshotStartLabel.text = "start: —"
+        snapshotEndLabel.text   = "end:   —"
+        snapshotDeltaLabel.text = "delta: —"
+
+        let snapshotStack = UIStackView(arrangedSubviews: [
+            snapshotHeaderLabel, snapshotStartLabel, snapshotEndLabel, snapshotDeltaLabel,
+        ])
+        snapshotStack.axis = .vertical
+        snapshotStack.spacing = 2
+        snapshotStack.alignment = .fill
+        snapshotStack.translatesAutoresizingMaskIntoConstraints = false
+        snapshotStack.isLayoutMarginsRelativeArrangement = true
+        snapshotStack.layoutMargins = UIEdgeInsets(top: 8, left: 10, bottom: 8, right: 10)
+        snapshotStack.backgroundColor = .secondarySystemBackground
+        snapshotStack.layer.cornerRadius = 8
+        snapshotStack.layer.borderWidth = 1
+        snapshotStack.layer.borderColor = UIColor.systemGray4.cgColor
+
+        // Latest-span lifecycle card.
+        spanHeaderLabel.text = "Latest span (SDK boundaries)"
+        spanHeaderLabel.font = .systemFont(ofSize: 11, weight: .semibold)
+        spanHeaderLabel.textColor = .secondaryLabel
+        spanHeaderLabel.textAlignment = .center
+
+        [spanIdLabel, spanStartLabel, spanEndLabel].forEach {
+            $0.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+            $0.textColor = .label
+            $0.numberOfLines = 1
+        }
+        spanIdLabel.text    = "id:      —"
+        spanStartLabel.text = "started: —"
+        spanEndLabel.text   = "ended:   —"
+
+        spanPhaseDot.translatesAutoresizingMaskIntoConstraints = false
+        spanPhaseDot.backgroundColor = .systemGray3
+        spanPhaseDot.layer.cornerRadius = 6
+        NSLayoutConstraint.activate([
+            spanPhaseDot.widthAnchor.constraint(equalToConstant: 12),
+            spanPhaseDot.heightAnchor.constraint(equalToConstant: 12),
+        ])
+
+        spanPhaseLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        spanPhaseLabel.textColor = .label
+        spanPhaseLabel.text = "phase: idle"
+
+        let phaseRow = UIStackView(arrangedSubviews: [spanPhaseDot, spanPhaseLabel])
+        phaseRow.axis = .horizontal
+        phaseRow.spacing = 8
+        phaseRow.alignment = .center
+
+        let spanStack = UIStackView(arrangedSubviews: [
+            spanHeaderLabel, spanIdLabel, spanStartLabel, spanEndLabel, phaseRow,
+        ])
+        spanStack.axis = .vertical
+        spanStack.spacing = 2
+        spanStack.alignment = .fill
+        spanStack.translatesAutoresizingMaskIntoConstraints = false
+        spanStack.isLayoutMarginsRelativeArrangement = true
+        spanStack.layoutMargins = UIEdgeInsets(top: 8, left: 10, bottom: 8, right: 10)
+        spanStack.backgroundColor = .secondarySystemBackground
+        spanStack.layer.cornerRadius = 8
+        spanStack.layer.borderWidth = 1
+        spanStack.layer.borderColor = UIColor.systemGray4.cgColor
+
+        chartView.translatesAutoresizingMaskIntoConstraints = false
+        chartView.layer.borderWidth = 1
+        chartView.layer.borderColor = UIColor.systemGray4.cgColor
+        chartView.layer.cornerRadius = 8
+
+        startStopButton.translatesAutoresizingMaskIntoConstraints = false
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let legend = UILabel()
+        legend.translatesAutoresizingMaskIntoConstraints = false
+        legend.font = .systemFont(ofSize: 12, weight: .medium)
+        legend.textAlignment = .center
+        legend.attributedText = Self.legendText()
+
+        // Configure the span-kind segmented control.
+        spanKindControl.selectedSegmentIndex = 0
+        spanKindControl.translatesAutoresizingMaskIntoConstraints = false
+        spanKindControl.addTarget(self, action: #selector(spanKindChanged),
+                                  for: .valueChanged)
+
+        // Configure the span-duration dropdown button (UIMenu on iOS 14+,
+        // action sheet fallback on iOS 13). Picking an item selects the
+        // span-duration for the next Start; disk I/O runs continuously for
+        // the chosen duration and Read/Write ops update live.
+        spanDurationButton.translatesAutoresizingMaskIntoConstraints = false
+        spanDurationButton.setTitleColor(.label, for: .normal)
+        spanDurationButton.titleLabel?.font = .systemFont(ofSize: 14, weight: .medium)
+        spanDurationButton.backgroundColor = .secondarySystemBackground
+        spanDurationButton.layer.cornerRadius = 6
+        spanDurationButton.layer.borderWidth = 1
+        spanDurationButton.layer.borderColor = UIColor.systemGray4.cgColor
+        spanDurationButton.contentEdgeInsets = UIEdgeInsets(top: 6, left: 12, bottom: 6, right: 12)
+        updateSpanDurationButtonTitle()
+        if #available(iOS 14.0, *) {
+            spanDurationButton.showsMenuAsPrimaryAction = true
+            spanDurationButton.menu = buildSpanDurationMenu()
+        } else {
+            spanDurationButton.addTarget(self,
+                                         action: #selector(showSpanDurationActionSheet),
+                                         for: .touchUpInside)
+        }
+
+        view.addSubview(spanKindControl)
+        view.addSubview(spanDurationButton)
+        view.addSubview(numbersRow)
+        view.addSubview(snapshotStack)
+        view.addSubview(spanStack)
+        view.addSubview(chartView)
+        view.addSubview(legend)
+        view.addSubview(startStopButton)
+        view.addSubview(statusLabel)
+
+        NSLayoutConstraint.activate([
+            spanKindControl.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            spanKindControl.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),
+            spanKindControl.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12),
+
+            spanDurationButton.topAnchor.constraint(equalTo: spanKindControl.bottomAnchor, constant: 6),
+            spanDurationButton.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            spanDurationButton.heightAnchor.constraint(equalToConstant: 34),
+
+            numbersRow.topAnchor.constraint(equalTo: spanDurationButton.bottomAnchor, constant: 8),
+            numbersRow.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),
+            numbersRow.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12),
+
+            snapshotStack.topAnchor.constraint(equalTo: numbersRow.bottomAnchor, constant: 8),
+            snapshotStack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),
+            snapshotStack.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12),
+
+            spanStack.topAnchor.constraint(equalTo: snapshotStack.bottomAnchor, constant: 8),
+            spanStack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),
+            spanStack.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12),
+
+            chartView.topAnchor.constraint(equalTo: spanStack.bottomAnchor, constant: 8),
+            chartView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),
+            chartView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12),
+            chartView.heightAnchor.constraint(equalToConstant: 130),
+
+            legend.topAnchor.constraint(equalTo: chartView.bottomAnchor, constant: 4),
+            legend.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+
+            startStopButton.topAnchor.constraint(equalTo: legend.bottomAnchor, constant: 8),
+            startStopButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+
+            statusLabel.topAnchor.constraint(equalTo: startStopButton.bottomAnchor, constant: 6),
+            statusLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            statusLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+        ])
+    }
+
+    /// Update the "Latest span" card to reflect the current phase. Must be
+    /// called from the main thread.
+    private func setSpanPhase(_ phase: String, color: UIColor) {
+        spanPhaseLabel.text = "phase: \(phase)"
+        spanPhaseDot.backgroundColor = color
+    }
+
+    private static let clockFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
+
+    private static func clock(_ absTime: CFAbsoluteTime) -> String {
+        let date = Date(timeIntervalSinceReferenceDate: absTime)
+        return clockFormatter.string(from: date)
+    }
+
+    /// Compact byte formatter — 4194304 -> "4.00 MB", 262144 -> "256 KB",
+    /// 8192 -> "8192 B". Keeps the delta card readable even for GB-sized values.
+    private static func humanBytes(_ value: UInt64) -> String {
+        if value >= 1024 * 1024 {
+            return String(format: "%.2f MB", Double(value) / (1024.0 * 1024.0))
+        }
+        if value >= 1024 {
+            return String(format: "%.0f KB", Double(value) / 1024.0)
+        }
+        return "\(value) B"
+    }
+
+    private static func legendText() -> NSAttributedString {
+        let out = NSMutableAttributedString()
+        out.append(NSAttributedString(string: "■ ", attributes: [.foregroundColor: UIColor.systemBlue]))
+        out.append(NSAttributedString(string: "read   "))
+        out.append(NSAttributedString(string: "■ ", attributes: [.foregroundColor: UIColor.systemOrange]))
+        out.append(NSAttributedString(string: "write"))
+        return out
+    }
+
+    private func makeTitle(_ text: String, color: UIColor) -> UILabel {
+        let l = UILabel()
+        l.text = text
+        l.font = .systemFont(ofSize: 12, weight: .semibold)
+        l.textColor = color
+        l.textAlignment = .center
+        return l
+    }
+
+    private func makeColumn(title: UILabel, value: UILabel) -> UIView {
+        let stack = UIStackView(arrangedSubviews: [title, value])
+        stack.axis = .vertical
+        stack.spacing = 2
+        stack.alignment = .fill
+        return stack
+    }
+
+    // MARK: Sampling
+
+    @objc private func toggle() {
+        running ? stop() : start()
+    }
+
+    @objc private func spanKindChanged() {
+        selectedKind = SpanKind(rawValue: spanKindControl.selectedSegmentIndex) ?? .customFirstClass
+        statusLabel.text = selectedKind.explanation
+    }
+
+    // MARK: Span-duration dropdown helpers
+
+    private func updateSpanDurationButtonTitle() {
+        spanDurationButton.setTitle("Span duration: \(selectedDuration.displayLabel)  ▾",
+                                    for: .normal)
+    }
+
+    private func selectSpanDuration(_ d: SpanDuration) {
+        selectedDuration = d
+        updateSpanDurationButtonTitle()
+        statusLabel.text = d.explanation
+        if #available(iOS 14.0, *) {
+            // Rebuild so the .on checkmark tracks the new selection.
+            spanDurationButton.menu = buildSpanDurationMenu()
+        }
+    }
+
+    @available(iOS 14.0, *)
+    private func buildSpanDurationMenu() -> UIMenu {
+        let actions = SpanDuration.allCases.map { d -> UIAction in
+            UIAction(title: d.displayLabel,
+                     state: (d == selectedDuration ? .on : .off)) { [weak self] _ in
+                self?.selectSpanDuration(d)
+            }
+        }
+        return UIMenu(title: "Span duration", children: actions)
+    }
+
+    @objc private func showSpanDurationActionSheet() {
+        let sheet = UIAlertController(title: "Span duration",
+                                       message: nil,
+                                       preferredStyle: .actionSheet)
+        SpanDuration.allCases.forEach { d in
+            sheet.addAction(UIAlertAction(title: d.displayLabel, style: .default) { [weak self] _ in
+                self?.selectSpanDuration(d)
+            })
+        }
+        sheet.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        // iPad requires a popover source when presenting an action sheet.
+        sheet.popoverPresentationController?.sourceView = spanDurationButton
+        sheet.popoverPresentationController?.sourceRect = spanDurationButton.bounds
+        present(sheet, animated: true)
+    }
+
+    private func start() {
+        // Defensive: any leftover loop-mode timer must be killed before a
+        // long-span run, otherwise its per-second tick() would keep firing
+        // and overwriting the "started:" label — making it look like the
+        // long span keeps re-opening.
+        timer?.invalidate()
+        timer = nil
+
+        running = true
+        startStopButton.setTitle("■ Stop", for: .normal)
+        startStopButton.backgroundColor = .systemRed
+        sampleCount = 0
+        chartView.reset()
+
+        if let longDuration = selectedDuration.seconds {
+            statusLabel.text = "Running one \(selectedDuration.displayLabel) span. " +
+                "Tap Stop to abort. See console '[DiskIO] Step 4' log at end."
+            runLongSpan(duration: longDuration)
+        } else {
+            statusLabel.text = "Sampling every 1 second. Each tick fires a first-class span."
+            timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+                self?.tick()
+            }
+        }
+    }
+
+    private func stop() {
+        running = false
+        timer?.invalidate()
+        timer = nil
+        startStopButton.setTitle("▶ Start", for: .normal)
+        startStopButton.backgroundColor = .systemGreen
+        statusLabel.text = "Stopped. Tap Start to sample again."
+        setSpanPhase("idle", color: .systemGray3)
+    }
+
+    private func tick() {
+        // Run everything on a background queue so the ~1s settle sleep
+        // doesn't freeze the UI. Marshal results back to main for display.
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+
+            // Capture the START snapshot BEFORE opening the span so the
+            // on-screen snapshot exactly matches the SDK's
+            // "[DiskIO] Step 1/onSpanStart" log for this same tick.
+            guard let startSnap = DiskIOSample.capture() else { return }
+
+            // Read the currently-selected span kind on the main thread so we
+            // don't touch a UIKit view from a background queue.
+            var kindLocal: SpanKind = .customFirstClass
+            DispatchQueue.main.sync { kindLocal = self.selectedKind }
+
+            // Build the span based on the chosen kind.
+            //   - customFirstClass:   first-class custom span (disk ATTACHED)
+            //   - appSession:         long-running session span (disk ATTACHED)
+            //   - customNonFirstClass: firstClass=.no + metrics.disk=.unset
+            //                          (disk OMITTED via tri-state gating)
+            let span: BugsnagPerformanceSpan
+            let spanKindLabel: String
+            switch kindLocal {
+            case .customFirstClass:
+                let opts = BugsnagPerformanceSpanOptions()
+                opts.setFirstClass(.yes)
+                opts.metricsOptions.disk = .yes
+                span = BugsnagPerformance.startSpan(name: "DiskIOPSLiveTick.Custom",
+                                                    options: opts)
+                spanKindLabel = "Custom (1st-class)"
+            case .appSession:
+                span = BugsnagPerformance.startAppSessionSpan("DiskIOPSLive")
+                spanKindLabel = "AppSession"
+            case .customNonFirstClass:
+                let opts = BugsnagPerformanceSpanOptions()
+                opts.setFirstClass(.no)
+                // Leaving metrics.disk = .unset so the tri-state gate falls
+                // back to the firstClass check and blocks disk metrics.
+                span = BugsnagPerformance.startSpan(name: "DiskIOPSLiveTick.NonFirstClass",
+                                                    options: opts)
+                spanKindLabel = "Custom (non-1st)"
+            }
+
+            // span.spanId is UInt64; convert to Int64 via bitPattern (no trap for high-bit values),
+            // then let %llx render the 16-hex-digit form. Guards against Swift crashing on IDs > 2^63.
+            let spanIdHex = String(format: "%016llx",
+                                   Int64(bitPattern: UInt64(span.spanId)))
+            let startWallClock = Self.clock(startSnap.timestamp)
+
+            // Update the "Latest span" card — span has just opened.
+            DispatchQueue.main.async {
+                self.spanIdLabel.text    = "id:      \(spanIdHex)  [\(spanKindLabel)]"
+                self.spanStartLabel.text = "started: \(startWallClock)"
+                self.spanEndLabel.text   = "ended:   —"
+                self.setSpanPhase("opened  (\(spanKindLabel))", color: .systemGreen)
+            }
+
+            // 4–16 MB of random bytes, chunked write with F_FULLFSYNC.
+            let bytes = Int.random(in: 4...16) * 1024 * 1024
+            var payload = Data(count: bytes)
+            payload.withUnsafeMutableBytes { raw in
+                if let base = raw.baseAddress { arc4random_buf(base, bytes) }
+            }
+            let path = FileManager.default.temporaryDirectory
+                .appendingPathComponent("bsg-diskio-live-\(UUID().uuidString).bin")
+            DispatchQueue.main.async {
+                self.setSpanPhase("writing \(bytes / (1024 * 1024)) MB", color: .systemOrange)
+            }
+
+            path.withUnsafeFileSystemRepresentation { cpath in
+                guard let cpath = cpath else { return }
+                let fd = open(cpath, O_WRONLY | O_CREAT | O_TRUNC, 0o644)
+                if fd < 0 { return }
+                payload.withUnsafeBytes { raw in
+                    guard let base = raw.baseAddress else { return }
+                    var offset = 0
+                    let total = payload.count
+                    while offset < total {
+                        let chunk = min(1 << 20, total - offset)
+                        let written = write(fd, base.advanced(by: offset), chunk)
+                        if written <= 0 { break }
+                        offset += written
+                    }
+                }
+                _ = fcntl(fd, F_FULLFSYNC)
+                close(fd)
+            }
+            _ = try? Data(contentsOf: path)
+            try? FileManager.default.removeItem(at: path)
+
+            // Settle window so the kernel has time to attribute pending writes
+            // to this process. On the simulator, ri_diskio_byteswritten updates
+            // asynchronously even after F_FULLFSYNC returns.
+            DispatchQueue.main.async {
+                self.setSpanPhase("settling (kernel catch-up)", color: .systemYellow)
+            }
+            Thread.sleep(forTimeInterval: 0.9)
+
+            guard let endSnap = DiskIOSample.capture() else {
+                DispatchQueue.main.async {
+                    span.end()
+                    self.setSpanPhase("ended (endSnap invalid)", color: .systemRed)
+                }
+                return
+            }
+            let endWallClock = Self.clock(endSnap.timestamp)
+            DispatchQueue.main.async {
+                span.end()
+                self.spanEndLabel.text = "ended:   \(endWallClock)"
+                self.setSpanPhase("ended  (SDK Step 2 → 3 → 4 fired)", color: .systemRed)
+            }
+
+            let duration = endSnap.timestamp - startSnap.timestamp
+            guard duration > 0 else { return }
+
+            let readDelta  = endSnap.bytesRead  >= startSnap.bytesRead
+                ? endSnap.bytesRead  - startSnap.bytesRead  : 0
+            let writeDelta = endSnap.bytesWritten >= startSnap.bytesWritten
+                ? endSnap.bytesWritten - startSnap.bytesWritten : 0
+
+            let readOps  = Int64((Double(readDelta)  / 16384.0 / duration).rounded())
+            let writeOps = Int64((Double(writeDelta) / 16384.0 / duration).rounded())
+            let totalOps = readOps + writeOps
+
+            NSLog("[DiskIO Live] tick=\(self.sampleCount + 1) " +
+                  "start(R=\(startSnap.bytesRead) W=\(startSnap.bytesWritten)) " +
+                  "end(R=\(endSnap.bytesRead) W=\(endSnap.bytesWritten)) " +
+                  "Δt=\(String(format: "%.4f", duration))s " +
+                  "read=\(readOps) write=\(writeOps) total=\(totalOps)")
+
+            DispatchQueue.main.async {
+                self.sampleCount += 1
+                self.readLabel.text  = "\(readOps)"
+                self.writeLabel.text = "\(writeOps)"
+                self.totalLabel.text = "\(totalOps)"
+
+                let startTs = String(format: "%.4f", startSnap.timestamp)
+                let endTs   = String(format: "%.4f", endSnap.timestamp)
+                let dt      = String(format: "%.4f", duration)
+                self.snapshotStartLabel.text =
+                    "start:  R=\(Self.humanBytes(startSnap.bytesRead))  " +
+                    "W=\(Self.humanBytes(startSnap.bytesWritten))  t=\(startTs)"
+                self.snapshotEndLabel.text =
+                    "end:    R=\(Self.humanBytes(endSnap.bytesRead))  " +
+                    "W=\(Self.humanBytes(endSnap.bytesWritten))  t=\(endTs)"
+                self.snapshotDeltaLabel.text =
+                    "delta:  ΔR=\(Self.humanBytes(readDelta))  " +
+                    "ΔW=\(Self.humanBytes(writeDelta))  Δt=\(dt)s"
+
+                self.chartView.appendSample(read: readOps, write: writeOps)
+            }
+        }
+    }
+
+    // MARK: Long-span mode
+    //
+    // Opens a single span, performs one 8 MB write near the start, then
+    // waits for the selected duration before closing. This showcases how
+    // IOPS is averaged across arbitrarily large time windows — the same
+    // byte-delta divided by a larger `duration` yields smaller ops/sec,
+    // and at long enough durations both counters round to 0 because the
+    // metrics helper divides bytes by an assumed 16 KB block size.
+    //
+    // Values shown on-screen are computed locally via `proc_pid_rusage`.
+    // They should match the SDK's own computation, visible at span end
+    // in the console log line prefixed "[DiskIO] Step 4/onSpanEnd".
+    private func runLongSpan(duration: TimeInterval) {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+
+            guard let startSnap = DiskIOSample.capture() else {
+                DispatchQueue.main.async {
+                    self.statusLabel.text = "Failed to capture starting snapshot."
+                    self.stop()
+                }
+                return
+            }
+
+            var kindLocal: SpanKind = .customFirstClass
+            DispatchQueue.main.sync { kindLocal = self.selectedKind }
+
+            let span: BugsnagPerformanceSpan
+            let spanKindLabel: String
+            let nameSuffix = "\(Int(duration))s"
+            switch kindLocal {
+            case .customFirstClass:
+                let opts = BugsnagPerformanceSpanOptions()
+                opts.setFirstClass(.yes)
+                opts.metricsOptions.disk = .yes
+                span = BugsnagPerformance.startSpan(name: "DiskIOPSLong.\(nameSuffix).Custom",
+                                                    options: opts)
+                spanKindLabel = "Custom (1st-class)"
+            case .appSession:
+                span = BugsnagPerformance.startAppSessionSpan("DiskIOPSLong.\(nameSuffix)")
+                spanKindLabel = "AppSession"
+            case .customNonFirstClass:
+                let opts = BugsnagPerformanceSpanOptions()
+                opts.setFirstClass(.no)
+                span = BugsnagPerformance.startSpan(name: "DiskIOPSLong.\(nameSuffix).NonFirstClass",
+                                                    options: opts)
+                spanKindLabel = "Custom (non-1st)"
+            }
+
+            let spanIdHex = String(format: "%016llx",
+                                   Int64(bitPattern: UInt64(span.spanId)))
+            let startWallClock = Self.clock(startSnap.timestamp)
+            // Show the predicted end time upfront so the user can visually
+            // confirm the "started → ends" gap equals the chosen duration
+            // (e.g. 30s) without waiting for the span to close. The label
+            // is renamed to "ended:" once the actual end fires below.
+            let predictedEndWallClock = Self.clock(startSnap.timestamp + duration)
+
+            DispatchQueue.main.async {
+                self.spanIdLabel.text    = "id:      \(spanIdHex)  [\(spanKindLabel)]"
+                self.spanStartLabel.text = "started: \(startWallClock)"
+                self.spanEndLabel.text   = "ends:    \(predictedEndWallClock)  (in \(Int(duration))s)"
+                self.setSpanPhase("SPAN OPEN — \(Int(duration))s to go",
+                                  color: .systemGreen)
+            }
+
+            // Live-workload loop.
+            //
+            // Per tick (~1s):
+            //  1. Perform one write+read+delete cycle. The byte-count
+            //     ROTATES through workloadCycle so the live values
+            //     visibly oscillate — a fixed size would show a flat
+            //     steady-state value which is indistinguishable from a
+            //     stalled UI.
+            //  2. Take a fresh snapshot and compute the "1s rolling
+            //     window" IOPS for the Read/Write/Total labels + chart.
+            //  3. Update the cumulative ΔR/ΔW/Δt card so the user can
+            //     watch the SDK's end-of-span numbers accumulate.
+            //
+            // Expected live values (read side, on any device):
+            //   128KB → 8  ops/s   |   512KB → 32 ops/s
+            //   1MB   → 64 ops/s   |   2MB   → 128 ops/s
+            //
+            // On the SIMULATOR the write counter (ri_diskio_byteswritten)
+            // under-reports by ~99% because macOS's disk-buffer-cache
+            // absorbs the write before it reaches the block layer that
+            // proc_pid_rusage measures. F_NOCACHE (inside
+            // performDiskWorkload) forces uncached I/O to try to bypass
+            // that, but simulator behavior is still unreliable — on
+            // real devices the write side tracks correctly.
+            let workloadCycle: [Int] = [
+                128 * 1024,   // → read=8   ops/s (min)
+                512 * 1024,   // → read=32  ops/s
+                1024 * 1024,  // → read=64  ops/s (max)
+                512 * 1024,   // → read=32  ops/s (returning)
+            ]
+            let tickInterval: TimeInterval = 1.0
+            let baseT = startSnap.timestamp
+            var lastSampleSnap = startSnap
+            var iteration = 0
+
+            while self.running {
+                let elapsed = CFAbsoluteTimeGetCurrent() - baseT
+                if elapsed >= duration { break }
+
+                let sustainedBytes = workloadCycle[iteration % workloadCycle.count]
+                self.performDiskWorkload(bytes: sustainedBytes)
+
+                guard let now = DiskIOSample.capture() else {
+                    iteration += 1
+                    Thread.sleep(forTimeInterval: tickInterval)
+                    continue
+                }
+
+                // 1s rolling window (what the numbers panel + chart show).
+                let windowDur = max(0.001, now.timestamp - lastSampleSnap.timestamp)
+                let rd1s = now.bytesRead >= lastSampleSnap.bytesRead
+                    ? now.bytesRead - lastSampleSnap.bytesRead : 0
+                let wd1s = now.bytesWritten >= lastSampleSnap.bytesWritten
+                    ? now.bytesWritten - lastSampleSnap.bytesWritten : 0
+                let readOps1s  = Int64((Double(rd1s) / 16384.0 / windowDur).rounded())
+                let writeOps1s = Int64((Double(wd1s) / 16384.0 / windowDur).rounded())
+                let totalOps1s = readOps1s + writeOps1s
+
+                // Cumulative delta from span start (matches SDK Step 4).
+                let rdCum = now.bytesRead >= startSnap.bytesRead
+                    ? now.bytesRead - startSnap.bytesRead : 0
+                let wdCum = now.bytesWritten >= startSnap.bytesWritten
+                    ? now.bytesWritten - startSnap.bytesWritten : 0
+
+                lastSampleSnap = now
+                let remaining = max(0, Int((duration - elapsed).rounded()))
+                // First sample's window is unusually short (windowDur ≈
+                // performDiskWorkload duration ≈ 50-100ms) because we
+                // compare against startSnap, which was taken BEFORE the
+                // workload. That inflates the first ops/s value by 10x+
+                // and, once charted, ruins the Y-axis auto-scale so
+                // subsequent bars look like a flat zero baseline. Skip
+                // it from the chart only; labels still update.
+                let isFirstSample = iteration == 0
+                let tickLabel = iteration + 1
+
+                DispatchQueue.main.async {
+                    self.readLabel.text  = "\(readOps1s)"
+                    self.writeLabel.text = "\(writeOps1s)"
+                    self.totalLabel.text = "\(totalOps1s)"
+                    self.setSpanPhase("SPAN OPEN — tick #\(tickLabel), \(remaining)s left",
+                                      color: .systemBlue)
+                    self.snapshotDeltaLabel.text =
+                        "delta:  ΔR=\(Self.humanBytes(rdCum))  " +
+                        "ΔW=\(Self.humanBytes(wdCum))  " +
+                        "Δt=\(String(format: "%.1f", elapsed))s"
+                    if !isFirstSample {
+                        self.chartView.appendSample(read: readOps1s, write: writeOps1s)
+                    }
+                }
+
+                iteration += 1
+                Thread.sleep(forTimeInterval: tickInterval)
+            }
+
+            // Capture end snap, close span, publish results.
+            guard let endSnap = DiskIOSample.capture() else {
+                DispatchQueue.main.async {
+                    span.end()
+                    self.setSpanPhase("ended (endSnap invalid)", color: .systemRed)
+                    self.stop()
+                }
+                return
+            }
+
+            let endWallClock = Self.clock(endSnap.timestamp)
+            DispatchQueue.main.async {
+                span.end()
+                self.spanEndLabel.text = "ended:   \(endWallClock)"
+                self.setSpanPhase("ended  (SDK Step 2 → 3 → 4 fired)",
+                                  color: .systemRed)
+            }
+
+            let durationActual = endSnap.timestamp - startSnap.timestamp
+            guard durationActual > 0 else {
+                DispatchQueue.main.async { self.stop() }
+                return
+            }
+
+            let readDelta  = endSnap.bytesRead  >= startSnap.bytesRead
+                ? endSnap.bytesRead  - startSnap.bytesRead  : 0
+            let writeDelta = endSnap.bytesWritten >= startSnap.bytesWritten
+                ? endSnap.bytesWritten - startSnap.bytesWritten : 0
+
+            let readOps  = Int64((Double(readDelta)  / 16384.0 / durationActual).rounded())
+            let writeOps = Int64((Double(writeDelta) / 16384.0 / durationActual).rounded())
+            let totalOps = readOps + writeOps
+
+            NSLog("[DiskIO Live] long-span target=\(Int(duration))s " +
+                  "actual=\(String(format: "%.4f", durationActual))s " +
+                  "kind=\(spanKindLabel) " +
+                  "start(R=\(startSnap.bytesRead) W=\(startSnap.bytesWritten)) " +
+                  "end(R=\(endSnap.bytesRead) W=\(endSnap.bytesWritten)) " +
+                  "ΔR=\(readDelta) ΔW=\(writeDelta) " +
+                  "read=\(readOps) write=\(writeOps) total=\(totalOps)")
+
+            DispatchQueue.main.async {
+                self.sampleCount = 1
+                self.readLabel.text  = "\(readOps)"
+                self.writeLabel.text = "\(writeOps)"
+                self.totalLabel.text = "\(totalOps)"
+
+                let startTs = String(format: "%.4f", startSnap.timestamp)
+                let endTs   = String(format: "%.4f", endSnap.timestamp)
+                let dt      = String(format: "%.4f", durationActual)
+                self.snapshotStartLabel.text =
+                    "start:  R=\(Self.humanBytes(startSnap.bytesRead))  " +
+                    "W=\(Self.humanBytes(startSnap.bytesWritten))  t=\(startTs)"
+                self.snapshotEndLabel.text =
+                    "end:    R=\(Self.humanBytes(endSnap.bytesRead))  " +
+                    "W=\(Self.humanBytes(endSnap.bytesWritten))  t=\(endTs)"
+                self.snapshotDeltaLabel.text =
+                    "delta:  ΔR=\(Self.humanBytes(readDelta))  " +
+                    "ΔW=\(Self.humanBytes(writeDelta))  Δt=\(dt)s"
+
+                self.chartView.appendSample(read: readOps, write: writeOps)
+
+                let aborted = durationActual < duration - 1.0
+                self.statusLabel.text = aborted
+                    ? "Aborted at \(dt)s. read=\(readOps) write=\(writeOps) " +
+                      "total=\(totalOps). Compare with '[DiskIO] Step 4' in console."
+                    : "Done (\(dt)s). read=\(readOps) write=\(writeOps) " +
+                      "total=\(totalOps). '[DiskIO] Step 4' in console should match."
+                self.stop()
+            }
+        }
+    }
+
+    /// Synchronous 1-file disk workload used by the long-span mode:
+    /// write `bytes` random bytes uncached, F_FULLFSYNC, read them back
+    /// uncached, delete. Called on a background queue; ~tens of ms.
+    ///
+    /// F_NOCACHE is the critical bit for the simulator — without it,
+    /// macOS's disk buffer cache absorbs the write before it reaches
+    /// the block layer that `proc_pid_rusage` reads, so
+    /// ri_diskio_byteswritten under-reports by ~99% and the Operations shows
+    /// write=0 forever. F_NOCACHE forces uncached direct I/O so the
+    /// write is properly attributed to this process.
+    private func performDiskWorkload(bytes: Int) {
+        var payload = Data(count: bytes)
+        payload.withUnsafeMutableBytes { raw in
+            if let base = raw.baseAddress { arc4random_buf(base, bytes) }
+        }
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bsg-diskio-long-\(UUID().uuidString).bin")
+
+        // Write path — uncached, then F_FULLFSYNC to guarantee it hits storage.
+        path.withUnsafeFileSystemRepresentation { cpath in
+            guard let cpath = cpath else { return }
+            let fd = open(cpath, O_WRONLY | O_CREAT | O_TRUNC, 0o644)
+            if fd < 0 { return }
+            _ = fcntl(fd, F_NOCACHE, 1)
+            payload.withUnsafeBytes { raw in
+                guard let base = raw.baseAddress else { return }
+                var offset = 0
+                let total = payload.count
+                while offset < total {
+                    let chunk = min(1 << 20, total - offset)
+                    let written = write(fd, base.advanced(by: offset), chunk)
+                    if written <= 0 { break }
+                    offset += written
+                }
+            }
+            _ = fcntl(fd, F_FULLFSYNC)
+            close(fd)
+        }
+
+        // Read-back — also uncached so ri_diskio_bytesread reflects a real
+        // storage read, not a page-cache hit against the bytes we just wrote.
+        path.withUnsafeFileSystemRepresentation { cpath in
+            guard let cpath = cpath else { return }
+            let fd = open(cpath, O_RDONLY, 0)
+            if fd < 0 { return }
+            _ = fcntl(fd, F_NOCACHE, 1)
+            var buffer = [UInt8](repeating: 0, count: 1 << 20)
+            buffer.withUnsafeMutableBufferPointer { bp in
+                guard let base = bp.baseAddress else { return }
+                var totalRead = 0
+                while totalRead < bytes {
+                    let want = min(bp.count, bytes - totalRead)
+                    let n = read(fd, base, want)
+                    if n <= 0 { break }
+                    totalRead += n
+                }
+            }
+            close(fd)
+        }
+        try? FileManager.default.removeItem(at: path)
+    }
+}
+
+// =============================================================================
+// MARK: - Rolling line chart for read + write
+// =============================================================================
+
+final class DiskIOPSChartView: UIView {
+
+    private var readSamples:  [Int64] = []
+    private var writeSamples: [Int64] = []
+    private let maxSamples = 60
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .secondarySystemBackground
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        backgroundColor = .secondarySystemBackground
+    }
+
+    func reset() {
+        readSamples.removeAll()
+        writeSamples.removeAll()
+        setNeedsDisplay()
+    }
+
+    func appendSample(read: Int64, write: Int64) {
+        readSamples.append(read)
+        writeSamples.append(write)
+        if readSamples.count > maxSamples {
+            readSamples.removeFirst(readSamples.count - maxSamples)
+            writeSamples.removeFirst(writeSamples.count - maxSamples)
+        }
+        setNeedsDisplay()
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard let ctx = UIGraphicsGetCurrentContext() else { return }
+        // Background grid
+        ctx.setStrokeColor(UIColor.systemGray4.cgColor)
+        ctx.setLineWidth(0.5)
+        let gridLines = 4
+        for i in 0...gridLines {
+            let y = rect.height * CGFloat(i) / CGFloat(gridLines)
+            ctx.move(to: CGPoint(x: 0, y: y))
+            ctx.addLine(to: CGPoint(x: rect.width, y: y))
+        }
+        ctx.strokePath()
+
+        if readSamples.isEmpty && writeSamples.isEmpty {
+            let p = NSMutableParagraphStyle(); p.alignment = .center
+            let attrs: [NSAttributedString.Key: Any] = [
+                .foregroundColor: UIColor.tertiaryLabel,
+                .font: UIFont.systemFont(ofSize: 12),
+                .paragraphStyle: p,
+            ]
+            let text: NSString = "no samples yet"
+            let size = text.size(withAttributes: attrs)
+            text.draw(in: CGRect(x: 0, y: rect.midY - size.height / 2, width: rect.width, height: size.height),
+                      withAttributes: attrs)
+            return
+        }
+
+        let maxValue = max(1, Int64((readSamples + writeSamples).max() ?? 1))
+        drawLine(readSamples, in: rect, ctx: ctx, color: UIColor.systemBlue.cgColor, maxValue: maxValue)
+        drawLine(writeSamples, in: rect, ctx: ctx, color: UIColor.systemOrange.cgColor, maxValue: maxValue)
+
+        // Max-value label (top-right)
+        let scaleText = "max ≈ \(maxValue)"
+        (scaleText as NSString).draw(
+            at: CGPoint(x: rect.width - 90, y: 4),
+            withAttributes: [
+                .foregroundColor: UIColor.secondaryLabel,
+                .font: UIFont.monospacedDigitSystemFont(ofSize: 10, weight: .regular),
+            ])
+    }
+
+    private func drawLine(_ samples: [Int64], in rect: CGRect, ctx: CGContext,
+                          color: CGColor, maxValue: Int64) {
+        guard samples.count > 1 else { return }
+        ctx.setStrokeColor(color)
+        ctx.setLineWidth(2)
+        ctx.setLineJoin(.round)
+        let stepX = rect.width / CGFloat(max(1, maxSamples - 1))
+        let padding: CGFloat = 8
+
+        for (i, v) in samples.enumerated() {
+            let x = CGFloat(i) * stepX
+            let yFraction = 1.0 - CGFloat(v) / CGFloat(maxValue)
+            let y = padding + yFraction * (rect.height - padding * 2)
+            if i == 0 { ctx.move(to: CGPoint(x: x, y: y)) }
+            else      { ctx.addLine(to: CGPoint(x: x, y: y)) }
+        }
+        ctx.strokePath()
+    }
+}
+
+// =============================================================================
+// MARK: - Local proc_pid_rusage helper (matches what the SDK does internally)
+// =============================================================================
+
+/// Forward-declaration for `proc_pid_rusage` — libproc.h isn't in the iOS
+/// public SDK, but the symbol is available at runtime via libSystem.
+@_silgen_name("proc_pid_rusage")
+private func c_proc_pid_rusage(_ pid: Int32,
+                               _ flavor: Int32,
+                               _ buffer: UnsafeMutableRawPointer) -> Int32
+
+struct DiskIOSample {
+    let timestamp: CFAbsoluteTime
+    let bytesRead: UInt64
+    let bytesWritten: UInt64
+
+    /// Reads the current process's disk byte counters. Returns nil if the
+    /// platform read fails (e.g., locked down or unavailable).
+    ///
+    /// Offset math: `rusage_info_v4` starts with a 16-byte UUID (offset 0)
+    /// followed by 17 `uint64_t` fields, then `ri_diskio_bytesread` (offset 152)
+    /// and `ri_diskio_byteswritten` (offset 160). We allocate a comfortably
+    /// large buffer to hold the whole struct without needing to declare it.
+    static func capture() -> DiskIOSample? {
+        let RUSAGE_INFO_V4: Int32 = 4
+        let bufferSize = 512  // rusage_info_v4 is ~304 bytes; 512 is safe headroom
+        let buffer = UnsafeMutableRawPointer.allocate(byteCount: bufferSize,
+                                                       alignment: MemoryLayout<UInt64>.alignment)
+        defer { buffer.deallocate() }
+        buffer.initializeMemory(as: UInt8.self, repeating: 0, count: bufferSize)
+
+        let rc = c_proc_pid_rusage(getpid(), RUSAGE_INFO_V4, buffer)
+        guard rc == 0 else { return nil }
+
+        let bytesRead    = buffer.load(fromByteOffset: 152, as: UInt64.self)
+        let bytesWritten = buffer.load(fromByteOffset: 160, as: UInt64.self)
+        return DiskIOSample(timestamp: CFAbsoluteTimeGetCurrent(),
+                            bytesRead: bytesRead,
+                            bytesWritten: bytesWritten)
     }
 }

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -1140,6 +1140,18 @@ struct DiskIOSample {
     let bytesRead: UInt64
     let bytesWritten: UInt64
 
+    /// The filesystem's native block size in bytes, read once per process.
+    /// Mirrors the SDK's BSGDiskBlockSizeBytes(): bytes transferred are divided
+    /// by this to approximate operation counts. Falls back to the APFS default
+    /// of 4 KB if statfs() fails.
+    static let blockSizeBytes: Double = {
+        var sfs = statfs()
+        if statfs(NSTemporaryDirectory(), &sfs) == 0 && sfs.f_bsize > 0 {
+            return Double(sfs.f_bsize)
+        }
+        return 4096.0
+    }()
+
     /// Reads the current process's disk byte counters. Returns nil if the
     /// platform read fails (e.g., locked down or unavailable).
     ///

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h
@@ -41,6 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic,readwrite) NSTimeInterval initialRecurringWorkDelay;
 
+/**
+ * Test-only. A `BSGDiskIOSnapshotFaultMode` bitmask used by the e2e fixtures to
+ * drive the disk-IOPS omission paths (which are otherwise unreachable because
+ * the platform snapshot source cannot be made to fail on demand).
+ * Defaults to 0 (`BSGDiskIOSnapshotFaultModeNone`).
+ */
+@property(nonatomic,readwrite) NSUInteger diskIOSnapshotFaultMode;
+
 @end
 
 @interface BugsnagPerformanceConfiguration ()

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -10,9 +10,7 @@
 
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
-#import <TargetConditionals.h>
-
-@class BugsnagPerformanceLoadingIndicatorView;
+#import <BugsnagPerformance/BugsnagPerformanceLoadingIndicatorView.h>
 
 #import "BugsnagPerformanceSpan+Private.h"
 #import "OtlpUploader.h"
@@ -123,7 +121,7 @@ private:
     std::shared_ptr<Tracer> tracer_;
     std::unique_ptr<RetryQueue> retryQueue_;
     AppStateTracker *appStateTracker_;
-    NSMapTable *viewControllersToSpans_;
+    NSMapTable<UIViewController *, BugsnagPerformanceSpan *> *viewControllersToSpans_;
     std::shared_ptr<Instrumentation> instrumentation_;
     Worker *worker_;
     std::shared_ptr<PersistentDeviceID> deviceID_;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.h
@@ -10,7 +10,9 @@
 
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration.h>
 #import <BugsnagPerformance/BugsnagPerformanceViewType.h>
-#import <BugsnagPerformance/BugsnagPerformanceLoadingIndicatorView.h>
+#import <TargetConditionals.h>
+
+@class BugsnagPerformanceLoadingIndicatorView;
 
 #import "BugsnagPerformanceSpan+Private.h"
 #import "OtlpUploader.h"
@@ -28,6 +30,7 @@
 #import "Instrumentation/NetworkInstrumentation/System/NetworkHeaderInjector.h"
 #import "OtlpTraceEncoding.h"
 #import "FrameRateMetrics/FrameMetricsCollector.h"
+#import "DiskIO/BSGDiskIOCollector.h"
 #import "ConditionTimeoutExecutor.h"
 #import "SystemInfoSampler.h"
 #import "SpanControl/BSGCompositeSpanControlProvider.h"
@@ -106,6 +109,7 @@ private:
     std::shared_ptr<class Sampler> sampler_;
     std::shared_ptr<NetworkHeaderInjector> networkHeaderInjector_;
     FrameMetricsCollector *frameMetricsCollector_;
+    BSGDiskIOCollector *diskIOCollector_;
     std::shared_ptr<ConditionTimeoutExecutor> conditionTimeoutExecutor_;
     BSGCompositeSpanControlProvider *spanControlProvider_;
     BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> *spanStartCallbacks_;
@@ -119,7 +123,7 @@ private:
     std::shared_ptr<Tracer> tracer_;
     std::unique_ptr<RetryQueue> retryQueue_;
     AppStateTracker *appStateTracker_;
-    NSMapTable<UIViewController *, BugsnagPerformanceSpan *> *viewControllersToSpans_;
+    NSMapTable *viewControllersToSpans_;
     std::shared_ptr<Instrumentation> instrumentation_;
     Worker *worker_;
     std::shared_ptr<PersistentDeviceID> deviceID_;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -275,10 +275,6 @@ void BugsnagPerformanceImpl::start() noexcept {
 
     if (configuration_.internal.clearPersistenceOnStart) {
         persistence_->clearPerformanceData();
-        // Clearing persistence removes on-disk state, but preStartSetup may have
-        // already loaded an old probability into memory. Re-apply configured
-        // defaults so this run does not inherit stale sampling values.
-        persistentState_->configure(configuration_);
     }
 
     persistentState_->start();

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -227,6 +227,7 @@ void BugsnagPerformanceImpl::configure(BugsnagPerformanceConfiguration *config) 
     instrumentation_->configure(config);
     [worker_ configure:config];
     [frameMetricsCollector_ configure:config];
+    diskIOCollector_.faultMode = (BSGDiskIOSnapshotFaultMode)config.internal.diskIOSnapshotFaultMode;
     [BugsnagPerformanceCrossTalkAPI.sharedInstance configure:config];
 }
 

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -275,6 +275,10 @@ void BugsnagPerformanceImpl::start() noexcept {
 
     if (configuration_.internal.clearPersistenceOnStart) {
         persistence_->clearPerformanceData();
+        // Clearing persistence removes on-disk state, but preStartSetup may have
+        // already loaded an old probability into memory. Re-apply configured
+        // defaults so this run does not inherit stale sampling values.
+        persistentState_->configure(configuration_);
     }
 
     persistentState_->start();
@@ -670,12 +674,10 @@ void BugsnagPerformanceImpl::onSpanDiscarded(BugsnagPerformanceSpan *span) noexc
     finishedSessionAccumulators_.erase((__bridge void *)span);
 }
 
-#if BSG_TARGET_UIKIT
 void BugsnagPerformanceImpl::loadingIndicatorWasAdded(BugsnagPerformanceLoadingIndicatorView *loadingViewIndicator) noexcept {
     this->instrumentation_->loadingIndicatorWasAdded(loadingViewIndicator);
 }
 
-#endif
 
 void BugsnagPerformanceImpl::onWorkInterval() noexcept {
     BSGLogTrace(@"BugsnagPerformanceImpl::onWorkInterval()");
@@ -820,7 +822,6 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *clas
     return span;
 }
 
-#if BSG_TARGET_UIKIT
 void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, BugsnagPerformanceSpanOptions *optionsIn) noexcept {
     auto options = SpanOptions(optionsIn);
     auto viewType = BugsnagPerformanceViewTypeUIKit;
@@ -832,8 +833,6 @@ void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, Bug
     [viewControllersToSpans_ setObject:span forKey:controller];
 }
 
-#endif
-
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadPhaseSpan(NSString *className, NSString *phase,
                                                                        BugsnagPerformanceSpanContext *parentContext) noexcept {
     auto span = tracer_->startViewLoadPhaseSpan(className, phase, parentContext, @[]);
@@ -841,7 +840,6 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadPhaseSpan(NSString 
     return span;
 }
 
-#if BSG_TARGET_UIKIT
 void BugsnagPerformanceImpl::endViewLoadSpan(UIViewController *controller, NSDate *endTime) noexcept {
     /* Although NSMapTable supports weak keys, zeroed keys are not actually removed
      * until certain internal operations occur (such as the map resizing itself).
@@ -860,8 +858,6 @@ void BugsnagPerformanceImpl::endViewLoadSpan(UIViewController *controller, NSDat
     }
     [span endWithEndTime:endTime];
 }
-
-#endif
 
 void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept {
     BugsnagPerformanceSpan *span = nil;

--- a/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
+++ b/Sources/BugsnagPerformance/Private/BugsnagPerformanceImpl.mm
@@ -94,6 +94,7 @@ BugsnagPerformanceImpl::BugsnagPerformanceImpl(std::shared_ptr<Reachability> rea
 , spanAttributesProvider_(std::make_shared<SpanAttributesProvider>())
 , networkHeaderInjector_(std::make_shared<NetworkHeaderInjector>(spanAttributesProvider_, spanStackingHandler_, sampler_))
 , frameMetricsCollector_([FrameMetricsCollector new])
+, diskIOCollector_([BSGDiskIOCollector new])
 , conditionTimeoutExecutor_(std::make_shared<ConditionTimeoutExecutor>())
 , spanControlProvider_([BSGCompositeSpanControlProvider new])
 , spanStartCallbacks_([BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new])
@@ -112,6 +113,7 @@ BugsnagPerformanceImpl::BugsnagPerformanceImpl(std::shared_ptr<Reachability> rea
                                                                     plainSpanFactory_,
                                                                     batch_,
                                                                     frameMetricsCollector_,
+                                                                    diskIOCollector_,
                                                                     spanStartCallbacks_,
                                                                     spanEndCallbacks_,
                                                                     ^{ this->onSpanStarted(); },
@@ -668,10 +670,12 @@ void BugsnagPerformanceImpl::onSpanDiscarded(BugsnagPerformanceSpan *span) noexc
     finishedSessionAccumulators_.erase((__bridge void *)span);
 }
 
+#if BSG_TARGET_UIKIT
 void BugsnagPerformanceImpl::loadingIndicatorWasAdded(BugsnagPerformanceLoadingIndicatorView *loadingViewIndicator) noexcept {
     this->instrumentation_->loadingIndicatorWasAdded(loadingViewIndicator);
 }
 
+#endif
 
 void BugsnagPerformanceImpl::onWorkInterval() noexcept {
     BSGLogTrace(@"BugsnagPerformanceImpl::onWorkInterval()");
@@ -816,6 +820,7 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadSpan(NSString *clas
     return span;
 }
 
+#if BSG_TARGET_UIKIT
 void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, BugsnagPerformanceSpanOptions *optionsIn) noexcept {
     auto options = SpanOptions(optionsIn);
     auto viewType = BugsnagPerformanceViewTypeUIKit;
@@ -827,6 +832,8 @@ void BugsnagPerformanceImpl::startViewLoadSpan(UIViewController *controller, Bug
     [viewControllersToSpans_ setObject:span forKey:controller];
 }
 
+#endif
+
 BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadPhaseSpan(NSString *className, NSString *phase,
                                                                        BugsnagPerformanceSpanContext *parentContext) noexcept {
     auto span = tracer_->startViewLoadPhaseSpan(className, phase, parentContext, @[]);
@@ -834,6 +841,7 @@ BugsnagPerformanceSpan *BugsnagPerformanceImpl::startViewLoadPhaseSpan(NSString 
     return span;
 }
 
+#if BSG_TARGET_UIKIT
 void BugsnagPerformanceImpl::endViewLoadSpan(UIViewController *controller, NSDate *endTime) noexcept {
     /* Although NSMapTable supports weak keys, zeroed keys are not actually removed
      * until certain internal operations occur (such as the map resizing itself).
@@ -852,6 +860,8 @@ void BugsnagPerformanceImpl::endViewLoadSpan(UIViewController *controller, NSDat
     }
     [span endWithEndTime:endTime];
 }
+
+#endif
 
 void BugsnagPerformanceImpl::reportNetworkSpan(NSURLSessionTask *task, NSURLSessionTaskMetrics *metrics) noexcept {
     BugsnagPerformanceSpan *span = nil;

--- a/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.h
+++ b/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.h
@@ -1,0 +1,50 @@
+//
+//  BSGDiskIOCollector.h
+//  BugsnagPerformance
+//
+//  Created by gaurav agarawal on 03/08/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+@class BugsnagPerformanceSpan;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The three attribute keys written by the collector on span end.
+/// All three are optional — if the platform source is unavailable or the
+/// span duration is <= 0, the collector returns nil and no attributes are
+/// added to the span.
+extern NSString *const BSGDiskIOAttributeKeyIOPSRead;
+extern NSString *const BSGDiskIOAttributeKeyIOPSWrite;
+extern NSString *const BSGDiskIOAttributeKeyIOPSTotal;
+
+@interface BSGDiskIOCollector : NSObject
+
+/// Capture the start snapshot for a span. Silently no-ops if the platform
+/// source is unavailable — the matching -onSpanEnd: will then return nil.
+- (void)onSpanStart:(BugsnagPerformanceSpan *)span;
+
+/// Capture the end snapshot immediately, retrieve+remove the start
+/// snapshot under a lock, and compute the IOPS metrics.
+///
+/// Returns a dictionary keyed by the three BSGDiskIOAttributeKey* keys
+/// whose values are int64_t NSNumbers, or nil if no valid metrics could
+/// be computed (missing start snapshot, invalid platform read, or
+/// duration <= 0).
+- (nullable NSDictionary<NSString *, NSNumber *> *)onSpanEnd:(BugsnagPerformanceSpan *)span;
+
+/// Drop any stored start snapshot for a span that will never end.
+/// Called for cancelled / discarded spans to keep the map bounded.
+- (void)abandonSpan:(BugsnagPerformanceSpan *)span;
+
+/// Testing only — number of pending start snapshots currently held.
+- (NSUInteger)pendingSpanCount;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.h
+++ b/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.h
@@ -22,7 +22,33 @@ extern NSString *const BSGDiskIOAttributeKeyIOPSRead;
 extern NSString *const BSGDiskIOAttributeKeyIOPSWrite;
 extern NSString *const BSGDiskIOAttributeKeyIOPSTotal;
 
+/// Test-only fault injection.
+///
+/// The platform snapshot source (`proc_pid_rusage`) cannot be made to fail on
+/// demand, so the negative paths of the collector are unreachable from an
+/// end-to-end fixture. These flags let the e2e fixtures drive those paths
+/// through the *real* span lifecycle and exporter.
+///
+/// `BSGDiskIOSnapshotFaultModeNone` is the default and is what production
+/// always uses — the injection block in `-onSpanEnd:` is inert unless a fault
+/// mode is explicitly set via `BSGInternalConfiguration.diskIOSnapshotFaultMode`.
+typedef NS_OPTIONS(NSUInteger, BSGDiskIOSnapshotFaultMode) {
+    /// Normal production behaviour.
+    BSGDiskIOSnapshotFaultModeNone          = 0,
+    /// Skip storing the start snapshot, as if the platform read failed.
+    BSGDiskIOSnapshotFaultModeFailAtStart   = 1 << 0,
+    /// Mark the end snapshot invalid, as if the platform read failed.
+    BSGDiskIOSnapshotFaultModeFailAtEnd     = 1 << 1,
+    /// Force `end.timestamp == start.timestamp` so duration <= 0.
+    BSGDiskIOSnapshotFaultModeZeroDuration  = 1 << 2,
+    /// Force `end.bytes* < start.bytes*` to exercise the counter-regression path.
+    BSGDiskIOSnapshotFaultModeNegativeDelta = 1 << 3,
+};
+
 @interface BSGDiskIOCollector : NSObject
+
+/// Test-only. Defaults to `BSGDiskIOSnapshotFaultModeNone`.
+@property (atomic, assign) BSGDiskIOSnapshotFaultMode faultMode;
 
 /// Capture the start snapshot for a span. Silently no-ops if the platform
 /// source is unavailable — the matching -onSpanEnd: will then return nil.

--- a/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.mm
+++ b/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.mm
@@ -12,27 +12,21 @@
 #import "BSGDiskIOMetrics.h"
 #import "../BugsnagPerformanceSpan+Private.h"
 
-#include <cstdio>
+#include <cstdint>
 #include <mutex>
-#include <string>
 #include <unordered_map>
 
 NSString *const BSGDiskIOAttributeKeyIOPSRead = @"bugsnag.system.disk.iops_read";
 NSString *const BSGDiskIOAttributeKeyIOPSWrite = @"bugsnag.system.disk.iops_write";
 NSString *const BSGDiskIOAttributeKeyIOPSTotal = @"bugsnag.system.disk.iops_total";
 
-namespace {
-std::string spanKey(BugsnagPerformanceSpan *span) {
-    // spanId is a 64-bit identifier; format as a fixed-width hex string
-    // so ordering and equality match the wire representation.
-    char buf[17];
-    std::snprintf(buf, sizeof(buf), "%016llx", (unsigned long long)span.spanId);
-    return std::string(buf);
-}
-}
+// spanId is already a 64-bit identifier, so it is used directly as the map
+// key. Formatting it into a string would add a heap allocation and a
+// snprintf on every span start, end and abandon - measurable overhead for
+// apps creating spans at a high rate.
 
 @implementation BSGDiskIOCollector {
-    std::unordered_map<std::string, BSGDiskIOSnapshot> _startSnapshots;
+    std::unordered_map<uint64_t, BSGDiskIOSnapshot> _startSnapshots;
     std::mutex _mutex;
 }
 
@@ -43,13 +37,16 @@ std::string spanKey(BugsnagPerformanceSpan *span) {
     if (span == nil) {
         return;
     }
+    if ((self.faultMode & BSGDiskIOSnapshotFaultModeFailAtStart) != 0) {
+        // Test-only: behave exactly as if BSGCaptureDiskIOSnapshot() failed.
+        return;
+    }
     BSGDiskIOSnapshot snapshot = BSGCaptureDiskIOSnapshot();
     if (!snapshot.valid) {
         return;
     }
-    std::string key = spanKey(span);
     std::lock_guard<std::mutex> lock(_mutex);
-    _startSnapshots[key] = snapshot;
+    _startSnapshots[(uint64_t)span.spanId] = snapshot;
 }
 
 - (NSDictionary<NSString *, NSNumber *> *)onSpanEnd:(BugsnagPerformanceSpan *)span {
@@ -65,9 +62,8 @@ std::string spanKey(BugsnagPerformanceSpan *span) {
     BSGDiskIOSnapshot startSnapshot;
     bool hasStart = false;
     {
-        std::string key = spanKey(span);
         std::lock_guard<std::mutex> lock(_mutex);
-        auto it = _startSnapshots.find(key);
+        auto it = _startSnapshots.find((uint64_t)span.spanId);
         if (it != _startSnapshots.end()) {
             startSnapshot = it->second;
             _startSnapshots.erase(it);
@@ -75,10 +71,28 @@ std::string spanKey(BugsnagPerformanceSpan *span) {
         }
     }
 
+    // Test-only fault injection. `faultMode` is
+    // BSGDiskIOSnapshotFaultModeNone in production, so this block is inert
+    // outside of e2e fixtures. Note that it deliberately runs *after* the
+    // start snapshot has been erased above, so cleanup is still exercised on
+    // every simulated failure path.
+    BSGDiskIOSnapshotFaultMode faultMode = self.faultMode;
+    if (faultMode != BSGDiskIOSnapshotFaultModeNone) {
+        if ((faultMode & BSGDiskIOSnapshotFaultModeFailAtEnd) != 0) {
+            endSnapshot.valid = false;
+        }
+        if (hasStart && (faultMode & BSGDiskIOSnapshotFaultModeZeroDuration) != 0) {
+            endSnapshot.timestamp = startSnapshot.timestamp;
+        }
+        if (hasStart && (faultMode & BSGDiskIOSnapshotFaultModeNegativeDelta) != 0) {
+            endSnapshot.bytesRead = startSnapshot.bytesRead > 0 ? startSnapshot.bytesRead - 1 : 0;
+            endSnapshot.bytesWritten = startSnapshot.bytesWritten > 0 ? startSnapshot.bytesWritten - 1 : 0;
+        }
+    }
+
     if (!hasStart || !endSnapshot.valid) {
         return nil;
     }
-
     BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(startSnapshot, endSnapshot);
     if (!metrics.valid) {
         return nil;
@@ -95,9 +109,8 @@ std::string spanKey(BugsnagPerformanceSpan *span) {
     if (span == nil) {
         return;
     }
-    std::string key = spanKey(span);
     std::lock_guard<std::mutex> lock(_mutex);
-    _startSnapshots.erase(key);
+    _startSnapshots.erase((uint64_t)span.spanId);
 }
 
 - (NSUInteger)pendingSpanCount {

--- a/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.mm
+++ b/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.mm
@@ -11,7 +11,6 @@
 #import "BSGDiskIOSnapshot.h"
 #import "BSGDiskIOMetrics.h"
 #import "../BugsnagPerformanceSpan+Private.h"
-#import "../Logging.h"  // TEMP: flow logs
 
 #include <cstdio>
 #include <mutex>
@@ -42,32 +41,19 @@ std::string spanKey(BugsnagPerformanceSpan *span) {
 
 - (void)onSpanStart:(BugsnagPerformanceSpan *)span {
     if (span == nil) {
-        BSGLogInfo(@"[DiskIO] Step 1/onSpanStart: skipped (span=nil)");
         return;
     }
     BSGDiskIOSnapshot snapshot = BSGCaptureDiskIOSnapshot();
     if (!snapshot.valid) {
-        BSGLogInfo(@"[DiskIO] Step 1/onSpanStart: proc_pid_rusage failed for span=%@ (spanId=%016llx) -- start snapshot NOT stored",
-                   span.name, (unsigned long long)span.spanId);
         return;
     }
     std::string key = spanKey(span);
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        _startSnapshots[key] = snapshot;
-    }
-    BSGLogInfo(@"[DiskIO] Step 1/onSpanStart: START snapshot stored -- span=%@ (spanId=%016llx) t=%.4f bytesRead=%llu bytesWritten=%llu pending=%zu",
-               span.name,
-               (unsigned long long)span.spanId,
-               snapshot.timestamp,
-               (unsigned long long)snapshot.bytesRead,
-               (unsigned long long)snapshot.bytesWritten,
-               _startSnapshots.size());
+    std::lock_guard<std::mutex> lock(_mutex);
+    _startSnapshots[key] = snapshot;
 }
 
 - (NSDictionary<NSString *, NSNumber *> *)onSpanEnd:(BugsnagPerformanceSpan *)span {
     if (span == nil) {
-        BSGLogInfo(@"[DiskIO] Step 2/onSpanEnd: skipped (span=nil)");
         return nil;
     }
 
@@ -75,17 +61,9 @@ std::string spanKey(BugsnagPerformanceSpan *span) {
     // subsequent processing (batching, callbacks, retry queue) can
     // move disk counters.
     BSGDiskIOSnapshot endSnapshot = BSGCaptureDiskIOSnapshot();
-    BSGLogInfo(@"[DiskIO] Step 2/onSpanEnd: END snapshot captured -- span=%@ (spanId=%016llx) valid=%d t=%.4f bytesRead=%llu bytesWritten=%llu",
-               span.name,
-               (unsigned long long)span.spanId,
-               endSnapshot.valid ? 1 : 0,
-               endSnapshot.timestamp,
-               (unsigned long long)endSnapshot.bytesRead,
-               (unsigned long long)endSnapshot.bytesWritten);
 
     BSGDiskIOSnapshot startSnapshot;
     bool hasStart = false;
-    size_t remaining = 0;
     {
         std::string key = spanKey(span);
         std::lock_guard<std::mutex> lock(_mutex);
@@ -95,30 +73,16 @@ std::string spanKey(BugsnagPerformanceSpan *span) {
             _startSnapshots.erase(it);
             hasStart = true;
         }
-        remaining = _startSnapshots.size();
     }
-    BSGLogInfo(@"[DiskIO] Step 3/onSpanEnd: retrieved matching start for span=%@ hasStart=%d pending=%zu",
-               span.name, hasStart ? 1 : 0, remaining);
 
     if (!hasStart || !endSnapshot.valid) {
-        BSGLogInfo(@"[DiskIO] Step 4/onSpanEnd: no metrics emitted (hasStart=%d endValid=%d) -- span=%@",
-                   hasStart ? 1 : 0, endSnapshot.valid ? 1 : 0, span.name);
         return nil;
     }
 
     BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(startSnapshot, endSnapshot);
     if (!metrics.valid) {
-        BSGLogInfo(@"[DiskIO] Step 4/onSpanEnd: metrics INVALID (duration<=0 or bad snapshot) -- span=%@ startT=%.4f endT=%.4f",
-                   span.name, startSnapshot.timestamp, endSnapshot.timestamp);
         return nil;
     }
-
-    BSGLogInfo(@"[DiskIO] Step 4/onSpanEnd: emitting attributes -- span=%@ duration=%.4fs iops_read=%lld iops_write=%lld iops_total=%lld",
-               span.name,
-               endSnapshot.timestamp - startSnapshot.timestamp,
-               (long long)metrics.iopsRead,
-               (long long)metrics.iopsWrite,
-               (long long)metrics.iopsTotal);
 
     return @{
         BSGDiskIOAttributeKeyIOPSRead: @(metrics.iopsRead),
@@ -132,18 +96,8 @@ std::string spanKey(BugsnagPerformanceSpan *span) {
         return;
     }
     std::string key = spanKey(span);
-    size_t erased = 0;
-    size_t remaining = 0;
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        erased = _startSnapshots.erase(key);
-        remaining = _startSnapshots.size();
-    }
-    BSGLogInfo(@"[DiskIO] abandonSpan (cancelled/discarded) -- span=%@ (spanId=%016llx) erased=%zu pending=%zu",
-               span.name,
-               (unsigned long long)span.spanId,
-               erased,
-               remaining);
+    std::lock_guard<std::mutex> lock(_mutex);
+    _startSnapshots.erase(key);
 }
 
 - (NSUInteger)pendingSpanCount {

--- a/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.mm
+++ b/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.mm
@@ -1,0 +1,156 @@
+//
+//  BSGDiskIOCollector.mm
+//  BugsnagPerformance
+//
+//  Created by gaurav agarawal on 03/08/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+#import "BSGDiskIOCollector.h"
+
+#import "BSGDiskIOSnapshot.h"
+#import "BSGDiskIOMetrics.h"
+#import "../BugsnagPerformanceSpan+Private.h"
+#import "../Logging.h"  // TEMP: flow logs
+
+#include <cstdio>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+NSString *const BSGDiskIOAttributeKeyIOPSRead = @"bugsnag.system.disk.iops_read";
+NSString *const BSGDiskIOAttributeKeyIOPSWrite = @"bugsnag.system.disk.iops_write";
+NSString *const BSGDiskIOAttributeKeyIOPSTotal = @"bugsnag.system.disk.iops_total";
+
+namespace {
+std::string spanKey(BugsnagPerformanceSpan *span) {
+    // spanId is a 64-bit identifier; format as a fixed-width hex string
+    // so ordering and equality match the wire representation.
+    char buf[17];
+    std::snprintf(buf, sizeof(buf), "%016llx", (unsigned long long)span.spanId);
+    return std::string(buf);
+}
+}
+
+@implementation BSGDiskIOCollector {
+    std::unordered_map<std::string, BSGDiskIOSnapshot> _startSnapshots;
+    std::mutex _mutex;
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+
+- (void)onSpanStart:(BugsnagPerformanceSpan *)span {
+    if (span == nil) {
+        BSGLogInfo(@"[DiskIO] Step 1/onSpanStart: skipped (span=nil)");
+        return;
+    }
+    BSGDiskIOSnapshot snapshot = BSGCaptureDiskIOSnapshot();
+    if (!snapshot.valid) {
+        BSGLogInfo(@"[DiskIO] Step 1/onSpanStart: proc_pid_rusage failed for span=%@ (spanId=%016llx) -- start snapshot NOT stored",
+                   span.name, (unsigned long long)span.spanId);
+        return;
+    }
+    std::string key = spanKey(span);
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _startSnapshots[key] = snapshot;
+    }
+    BSGLogInfo(@"[DiskIO] Step 1/onSpanStart: START snapshot stored -- span=%@ (spanId=%016llx) t=%.4f bytesRead=%llu bytesWritten=%llu pending=%zu",
+               span.name,
+               (unsigned long long)span.spanId,
+               snapshot.timestamp,
+               (unsigned long long)snapshot.bytesRead,
+               (unsigned long long)snapshot.bytesWritten,
+               _startSnapshots.size());
+}
+
+- (NSDictionary<NSString *, NSNumber *> *)onSpanEnd:(BugsnagPerformanceSpan *)span {
+    if (span == nil) {
+        BSGLogInfo(@"[DiskIO] Step 2/onSpanEnd: skipped (span=nil)");
+        return nil;
+    }
+
+    // Capture the end snapshot immediately at span end, before any
+    // subsequent processing (batching, callbacks, retry queue) can
+    // move disk counters.
+    BSGDiskIOSnapshot endSnapshot = BSGCaptureDiskIOSnapshot();
+    BSGLogInfo(@"[DiskIO] Step 2/onSpanEnd: END snapshot captured -- span=%@ (spanId=%016llx) valid=%d t=%.4f bytesRead=%llu bytesWritten=%llu",
+               span.name,
+               (unsigned long long)span.spanId,
+               endSnapshot.valid ? 1 : 0,
+               endSnapshot.timestamp,
+               (unsigned long long)endSnapshot.bytesRead,
+               (unsigned long long)endSnapshot.bytesWritten);
+
+    BSGDiskIOSnapshot startSnapshot;
+    bool hasStart = false;
+    size_t remaining = 0;
+    {
+        std::string key = spanKey(span);
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto it = _startSnapshots.find(key);
+        if (it != _startSnapshots.end()) {
+            startSnapshot = it->second;
+            _startSnapshots.erase(it);
+            hasStart = true;
+        }
+        remaining = _startSnapshots.size();
+    }
+    BSGLogInfo(@"[DiskIO] Step 3/onSpanEnd: retrieved matching start for span=%@ hasStart=%d pending=%zu",
+               span.name, hasStart ? 1 : 0, remaining);
+
+    if (!hasStart || !endSnapshot.valid) {
+        BSGLogInfo(@"[DiskIO] Step 4/onSpanEnd: no metrics emitted (hasStart=%d endValid=%d) -- span=%@",
+                   hasStart ? 1 : 0, endSnapshot.valid ? 1 : 0, span.name);
+        return nil;
+    }
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(startSnapshot, endSnapshot);
+    if (!metrics.valid) {
+        BSGLogInfo(@"[DiskIO] Step 4/onSpanEnd: metrics INVALID (duration<=0 or bad snapshot) -- span=%@ startT=%.4f endT=%.4f",
+                   span.name, startSnapshot.timestamp, endSnapshot.timestamp);
+        return nil;
+    }
+
+    BSGLogInfo(@"[DiskIO] Step 4/onSpanEnd: emitting attributes -- span=%@ duration=%.4fs iops_read=%lld iops_write=%lld iops_total=%lld",
+               span.name,
+               endSnapshot.timestamp - startSnapshot.timestamp,
+               (long long)metrics.iopsRead,
+               (long long)metrics.iopsWrite,
+               (long long)metrics.iopsTotal);
+
+    return @{
+        BSGDiskIOAttributeKeyIOPSRead: @(metrics.iopsRead),
+        BSGDiskIOAttributeKeyIOPSWrite: @(metrics.iopsWrite),
+        BSGDiskIOAttributeKeyIOPSTotal: @(metrics.iopsTotal),
+    };
+}
+
+- (void)abandonSpan:(BugsnagPerformanceSpan *)span {
+    if (span == nil) {
+        return;
+    }
+    std::string key = spanKey(span);
+    size_t erased = 0;
+    size_t remaining = 0;
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        erased = _startSnapshots.erase(key);
+        remaining = _startSnapshots.size();
+    }
+    BSGLogInfo(@"[DiskIO] abandonSpan (cancelled/discarded) -- span=%@ (spanId=%016llx) erased=%zu pending=%zu",
+               span.name,
+               (unsigned long long)span.spanId,
+               erased,
+               remaining);
+}
+
+- (NSUInteger)pendingSpanCount {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _startSnapshots.size();
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOMetrics.h
+++ b/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOMetrics.h
@@ -13,11 +13,6 @@
 #include <cmath>
 #include <cstdint>
 
-// APFS default block size. Bytes read/written are divided by this to
-// approximate the operation count when the OS does not expose op counts
-// directly on iOS.
-constexpr double kBSGAssumedDiskOperationSizeBytes = 16.0 * 1024.0;
-
 struct BSGDiskIOMetrics {
     int64_t iopsRead{0};
     int64_t iopsWrite{0};
@@ -26,6 +21,10 @@ struct BSGDiskIOMetrics {
 };
 
 /// Compute a BSGDiskIOMetrics from two ordered snapshots.
+///
+/// proc_pid_rusage reports bytes transferred rather than operation counts, so
+/// the byte delta is divided by the filesystem's block size (captured on the
+/// snapshot, see BSGDiskBlockSizeBytes) to approximate the operation count.
 ///
 /// Returns valid = false if either snapshot is invalid, if the duration
 /// is not strictly positive, or if the block size is not positive. Negative
@@ -42,7 +41,11 @@ static inline BSGDiskIOMetrics BSGComputeDiskIOMetrics(const BSGDiskIOSnapshot &
         return metrics;
     }
 
-    if (kBSGAssumedDiskOperationSizeBytes <= 0.0) {
+    // Both snapshots are taken in the same process against the same volume, so
+    // the block size is expected to match. Use the end snapshot's value and
+    // reject anything non-positive rather than dividing by zero.
+    double blockSize = static_cast<double>(end.blockSize);
+    if (blockSize <= 0.0) {
         return metrics;
     }
 
@@ -53,8 +56,8 @@ static inline BSGDiskIOMetrics BSGComputeDiskIOMetrics(const BSGDiskIOSnapshot &
         ? (end.bytesWritten - start.bytesWritten)
         : 0;
 
-    double readOpsPerSec = (static_cast<double>(readDelta) / kBSGAssumedDiskOperationSizeBytes) / duration;
-    double writeOpsPerSec = (static_cast<double>(writeDelta) / kBSGAssumedDiskOperationSizeBytes) / duration;
+    double readOpsPerSec = (static_cast<double>(readDelta) / blockSize) / duration;
+    double writeOpsPerSec = (static_cast<double>(writeDelta) / blockSize) / duration;
 
     metrics.iopsRead = static_cast<int64_t>(std::llround(readOpsPerSec));
     metrics.iopsWrite = static_cast<int64_t>(std::llround(writeOpsPerSec));

--- a/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOMetrics.h
+++ b/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOMetrics.h
@@ -1,0 +1,64 @@
+//
+//  BSGDiskIOMetrics.h
+//  BugsnagPerformance
+//
+//  Created by gaurav agarawal on 03/08/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import "BSGDiskIOSnapshot.h"
+
+#include <cmath>
+#include <cstdint>
+
+// APFS default block size. Bytes read/written are divided by this to
+// approximate the operation count when the OS does not expose op counts
+// directly on iOS.
+constexpr double kBSGAssumedDiskOperationSizeBytes = 16.0 * 1024.0;
+
+struct BSGDiskIOMetrics {
+    int64_t iopsRead{0};
+    int64_t iopsWrite{0};
+    int64_t iopsTotal{0};
+    bool valid{false};
+};
+
+/// Compute a BSGDiskIOMetrics from two ordered snapshots.
+///
+/// Returns valid = false if either snapshot is invalid, if the duration
+/// is not strictly positive, or if the block size is not positive. Negative
+/// byte deltas (counter wrap or regression) are clamped to zero.
+static inline BSGDiskIOMetrics BSGComputeDiskIOMetrics(const BSGDiskIOSnapshot &start,
+                                                       const BSGDiskIOSnapshot &end) noexcept {
+    BSGDiskIOMetrics metrics;
+    if (!start.valid || !end.valid) {
+        return metrics;
+    }
+
+    double duration = end.timestamp - start.timestamp;
+    if (duration <= 0.0) {
+        return metrics;
+    }
+
+    if (kBSGAssumedDiskOperationSizeBytes <= 0.0) {
+        return metrics;
+    }
+
+    uint64_t readDelta = end.bytesRead >= start.bytesRead
+        ? (end.bytesRead - start.bytesRead)
+        : 0;
+    uint64_t writeDelta = end.bytesWritten >= start.bytesWritten
+        ? (end.bytesWritten - start.bytesWritten)
+        : 0;
+
+    double readOpsPerSec = (static_cast<double>(readDelta) / kBSGAssumedDiskOperationSizeBytes) / duration;
+    double writeOpsPerSec = (static_cast<double>(writeDelta) / kBSGAssumedDiskOperationSizeBytes) / duration;
+
+    metrics.iopsRead = static_cast<int64_t>(std::llround(readOpsPerSec));
+    metrics.iopsWrite = static_cast<int64_t>(std::llround(writeOpsPerSec));
+    metrics.iopsTotal = metrics.iopsRead + metrics.iopsWrite;
+    metrics.valid = true;
+    return metrics;
+}

--- a/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOSnapshot.h
+++ b/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOSnapshot.h
@@ -8,8 +8,10 @@
 
 #pragma once
 
-#import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
 
+#import <sys/mount.h>
+#import <sys/param.h>
 #import <sys/resource.h>
 #import <unistd.h>
 
@@ -26,10 +28,37 @@ int proc_pid_rusage(int pid, int flavor, rusage_info_t *buffer);
 }
 #endif
 
+/// Fallback used when statfs() is unavailable. APFS on iOS reports a 4 KB
+/// native block size (f_bsize); this matches that so the fallback does not
+/// silently skew the derived operation count.
+constexpr uint32_t kBSGFallbackDiskBlockSizeBytes = 4096;
+
+/// The filesystem's native block size, read once per process.
+///
+/// proc_pid_rusage reports bytes transferred, not operation counts, so the
+/// byte delta is divided by this to approximate operations. Reading the real
+/// f_bsize avoids the 4x under-reporting that a hardcoded 16 KB "allocation
+/// cluster" size would produce on device. statfs is called at most once -
+/// calling it per snapshot would add a syscall to every span start and end.
+static inline uint32_t BSGDiskBlockSizeBytes() noexcept {
+    static uint32_t blockSize = []() -> uint32_t {
+        struct statfs sfs;
+        if (statfs([NSTemporaryDirectory() fileSystemRepresentation], &sfs) == 0 &&
+            sfs.f_bsize > 0) {
+            return (uint32_t)sfs.f_bsize;
+        }
+        return kBSGFallbackDiskBlockSizeBytes;
+    }();
+    return blockSize;
+}
+
 struct BSGDiskIOSnapshot {
     CFAbsoluteTime timestamp{0};
     uint64_t bytesRead{0};
     uint64_t bytesWritten{0};
+    /// Filesystem block size in bytes at the time of capture. Defaults to the
+    /// fallback so unit tests constructing snapshots by hand get a sane value.
+    uint32_t blockSize{kBSGFallbackDiskBlockSizeBytes};
     bool valid{false};
 };
 
@@ -41,6 +70,7 @@ struct BSGDiskIOSnapshot {
 static inline BSGDiskIOSnapshot BSGCaptureDiskIOSnapshot() noexcept {
     BSGDiskIOSnapshot snapshot;
     snapshot.timestamp = CFAbsoluteTimeGetCurrent();
+    snapshot.blockSize = BSGDiskBlockSizeBytes();
 
     rusage_info_current info{};
     int rc = proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&info);

--- a/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOSnapshot.h
+++ b/Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOSnapshot.h
@@ -1,0 +1,55 @@
+//
+//  BSGDiskIOSnapshot.h
+//  BugsnagPerformance
+//
+//  Created by gaurav agarawal on 03/08/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+#pragma once
+
+#import <CoreFoundation/CoreFoundation.h>
+
+#import <sys/resource.h>
+#import <unistd.h>
+
+#include <cstdint>
+
+// libproc.h is not in the iOS public SDK, so forward-declare the single
+// entry point we need. The symbol resolves at runtime via libSystem,
+// where proc_pid_rusage has always been available.
+#ifdef __cplusplus
+extern "C" {
+#endif
+int proc_pid_rusage(int pid, int flavor, rusage_info_t *buffer);
+#ifdef __cplusplus
+}
+#endif
+
+struct BSGDiskIOSnapshot {
+    CFAbsoluteTime timestamp{0};
+    uint64_t bytesRead{0};
+    uint64_t bytesWritten{0};
+    bool valid{false};
+};
+
+/// Capture a disk-I/O snapshot for the current process.
+///
+/// Uses proc_pid_rusage(RUSAGE_INFO_V4) to read ri_diskio_bytesread and
+/// ri_diskio_byteswritten. On failure (non-zero return) the returned
+/// snapshot has valid = false and disk metrics are omitted for the span.
+static inline BSGDiskIOSnapshot BSGCaptureDiskIOSnapshot() noexcept {
+    BSGDiskIOSnapshot snapshot;
+    snapshot.timestamp = CFAbsoluteTimeGetCurrent();
+
+    rusage_info_current info{};
+    int rc = proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&info);
+    if (rc != 0) {
+        return snapshot;
+    }
+
+    snapshot.bytesRead = info.ri_diskio_bytesread;
+    snapshot.bytesWritten = info.ri_diskio_byteswritten;
+    snapshot.valid = true;
+    return snapshot;
+}

--- a/Sources/BugsnagPerformance/Private/Metrics.h
+++ b/Sources/BugsnagPerformance/Private/Metrics.h
@@ -20,11 +20,13 @@ public:
     : rendering(metrics.rendering)
     , cpu(metrics.cpu)
     , memory(metrics.memory)
+    , disk(metrics.disk)
     {}
 
     BSGTriState rendering{BSGTriStateUnset};
     BSGTriState cpu{BSGTriStateUnset};
     BSGTriState memory{BSGTriStateUnset};
+    BSGTriState disk{BSGTriStateUnset};
 };
 
 };

--- a/Sources/BugsnagPerformance/Private/SpanLifecycle/SpanLifecycleHandlerImpl.h
+++ b/Sources/BugsnagPerformance/Private/SpanLifecycle/SpanLifecycleHandlerImpl.h
@@ -10,6 +10,7 @@
 #import "SpanLifecycleHandler.h"
 #import "../Batch.h"
 #import "../BugsnagPerformanceConfiguration+Private.h"
+#import "../DiskIO/BSGDiskIOCollector.h"
 #import "../FrameRateMetrics/FrameMetricsCollector.h"
 #import "../SpanStackingHandler.h"
 #import "../Sampler.h"
@@ -31,6 +32,7 @@ public:
                              std::shared_ptr<PlainSpanFactoryImpl> plainSpanFactory,
                              std::shared_ptr<Batch> batch,
                              FrameMetricsCollector *frameMetricsCollector,
+                             BSGDiskIOCollector *diskIOCollector,
                              BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> *onSpanStartCallbacks,
                              BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> *onSpanEndCallbacks,
                              void (^onSpanStarted)(),
@@ -42,6 +44,7 @@ public:
     , plainSpanFactory_(plainSpanFactory)
     , batch_(batch)
     , frameMetricsCollector_(frameMetricsCollector)
+    , diskIOCollector_(diskIOCollector)
     , onSpanStartCallbacks_(onSpanStartCallbacks)
     , onSpanEndCallbacks_(onSpanEndCallbacks)
     , onSpanStarted_(onSpanStarted)
@@ -72,6 +75,7 @@ private:
     std::shared_ptr<PlainSpanFactoryImpl> plainSpanFactory_;
     std::shared_ptr<SpanStore> store_;
     FrameMetricsCollector *frameMetricsCollector_;
+    BSGDiskIOCollector *diskIOCollector_;
     bool isStarted_{false};
     void (^onSpanStarted_)(){ ^(){} };
     void (^onSpanEndSet_)(BugsnagPerformanceSpan *){ ^(BugsnagPerformanceSpan *){} };
@@ -84,6 +88,7 @@ private:
     
     void processClosedSpan(BugsnagPerformanceSpan *span) noexcept;
     bool shouldInstrumentRendering(BugsnagPerformanceSpan *span) noexcept;
+    bool shouldSampleDiskIO(BugsnagPerformanceSpan *span) noexcept;
     void processFrameMetrics(BugsnagPerformanceSpan *span) noexcept;
     void callOnSpanStartCallbacks(BugsnagPerformanceSpan *span) noexcept;
     void callOnSpanEndCallbacks(BugsnagPerformanceSpan *span) noexcept;

--- a/Sources/BugsnagPerformance/Private/SpanLifecycle/SpanLifecycleHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/SpanLifecycle/SpanLifecycleHandlerImpl.mm
@@ -35,17 +35,22 @@ SpanLifecycleHandlerImpl::onSpanEndSet(BugsnagPerformanceSpan *span) noexcept {
     if (shouldInstrumentRendering(span)) {
         span.endFramerateSnapshot = [frameMetricsCollector_ currentSnapshot];
     }
-    if (shouldSampleDiskIO(span)) {
-        // Capture the end snapshot immediately at span end (before the span
-        // enters the delay queue). Any nil result — e.g. missing start
-        // snapshot, invalid platform read, or duration <= 0 — silently
-        // omits disk attributes for this span.
-        NSDictionary *diskAttributes = [diskIOCollector_ onSpanEnd:span];
-        if (diskAttributes.count > 0) {
-            [span forceMutate:^{
-                [span internalSetMultipleAttributes:diskAttributes];
-            }];
-        }
+    // Always call -onSpanEnd:, never gated on shouldSampleDiskIO. The gate is
+    // evaluated independently at start and end, so if the user's
+    // enabledMetrics.disk or the span's first-class status changes mid-span it
+    // can return true at start (storing a snapshot) and false at end, stranding
+    // that snapshot in the collector's map forever. Calling unconditionally
+    // guarantees the stored snapshot is always consumed and released - the
+    // collector returns nil when no start snapshot exists. This mirrors
+    // -abandonSpan: in onSpanCancelled, which is already unconditional.
+    //
+    // Any nil result - missing start snapshot, invalid platform read, or
+    // duration <= 0 - silently omits disk attributes for this span.
+    NSDictionary *diskAttributes = [diskIOCollector_ onSpanEnd:span];
+    if (diskAttributes.count > 0) {
+        [span forceMutate:^{
+            [span internalSetMultipleAttributes:diskAttributes];
+        }];
     }
     // Internal SDK bookkeeping that must happen as soon as the end time is set,
     // Before sampling or user on-span-end callbacks can discard the span.

--- a/Sources/BugsnagPerformance/Private/SpanLifecycle/SpanLifecycleHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/SpanLifecycle/SpanLifecycleHandlerImpl.mm
@@ -8,7 +8,6 @@
 
 #import "SpanLifecycleHandlerImpl.h"
 #import "../BugsnagPerformanceSpan+Private.h"
-#import "../Logging.h"  // TEMP: flow logs
 
 using namespace bugsnag;
 
@@ -20,19 +19,10 @@ SpanLifecycleHandlerImpl::preStartSetup() noexcept {
 
 void
 SpanLifecycleHandlerImpl::onSpanStarted(BugsnagPerformanceSpan *span, const SpanOptions &options) noexcept {
-    // TEMP: disk-IO flow log
-    bool diskEligible = shouldSampleDiskIO(span);
-    BSGLogInfo(@"[DiskIO Flow] Step A/onSpanStarted -- span=%@ firstClass=%d metrics.disk=%d enabledMetrics.disk=%d eligible=%d",
-               span.name,
-               (int)span.firstClass,
-               (int)span.metricsOptions.disk,
-               enabledMetrics_.disk ? 1 : 0,
-               diskEligible ? 1 : 0);
-
     if (shouldInstrumentRendering(span)) {
         span.startFramerateSnapshot = [frameMetricsCollector_ currentSnapshot];
     }
-    if (diskEligible) {
+    if (shouldSampleDiskIO(span)) {
         [diskIOCollector_ onSpanStart:span];
     }
     store_->addNewSpan(span, options.makeCurrentContext);
@@ -42,32 +32,19 @@ SpanLifecycleHandlerImpl::onSpanStarted(BugsnagPerformanceSpan *span, const Span
 
 void
 SpanLifecycleHandlerImpl::onSpanEndSet(BugsnagPerformanceSpan *span) noexcept {
-    // TEMP: disk-IO flow log
-    bool diskEligible = shouldSampleDiskIO(span);
-    BSGLogInfo(@"[DiskIO Flow] Step B/onSpanEndSet -- span=%@ firstClass=%d metrics.disk=%d enabledMetrics.disk=%d eligible=%d",
-               span.name,
-               (int)span.firstClass,
-               (int)span.metricsOptions.disk,
-               enabledMetrics_.disk ? 1 : 0,
-               diskEligible ? 1 : 0);
-
     if (shouldInstrumentRendering(span)) {
         span.endFramerateSnapshot = [frameMetricsCollector_ currentSnapshot];
     }
-    if (diskEligible) {
+    if (shouldSampleDiskIO(span)) {
         // Capture the end snapshot immediately at span end (before the span
         // enters the delay queue). Any nil result — e.g. missing start
         // snapshot, invalid platform read, or duration <= 0 — silently
         // omits disk attributes for this span.
         NSDictionary *diskAttributes = [diskIOCollector_ onSpanEnd:span];
-        BSGLogInfo(@"[DiskIO Flow] Step C/onSpanEndSet -- span=%@ attributes returned: count=%lu",
-                   span.name, (unsigned long)diskAttributes.count);
         if (diskAttributes.count > 0) {
             [span forceMutate:^{
                 [span internalSetMultipleAttributes:diskAttributes];
             }];
-            BSGLogInfo(@"[DiskIO Flow] Step D/onSpanEndSet -- span=%@ attributes APPLIED to span (will be batched & sent)",
-                       span.name);
         }
     }
     // Internal SDK bookkeeping that must happen as soon as the end time is set,
@@ -159,7 +136,11 @@ SpanLifecycleHandlerImpl::shouldInstrumentRendering(BugsnagPerformanceSpan *span
 
 bool
 SpanLifecycleHandlerImpl::shouldSampleDiskIO(BugsnagPerformanceSpan *span) noexcept {
-    if (!enabledMetrics_.disk) {
+    // Disk I/O collection is strictly gated behind BugsnagPerformance.start():
+    // before start, configure() has not applied the user's enabledMetrics yet
+    // (the pre-configuration default enables everything), and nothing may be
+    // collected when Bugsnag is never started.
+    if (!isStarted_ || !enabledMetrics_.disk) {
         return false;
     }
     switch (span.metricsOptions.disk) {
@@ -334,4 +315,3 @@ SpanLifecycleHandlerImpl::processClosedSpan(BugsnagPerformanceSpan *span) noexce
 
     batch_->add(span);
 }
-

--- a/Sources/BugsnagPerformance/Private/SpanLifecycle/SpanLifecycleHandlerImpl.mm
+++ b/Sources/BugsnagPerformance/Private/SpanLifecycle/SpanLifecycleHandlerImpl.mm
@@ -8,6 +8,7 @@
 
 #import "SpanLifecycleHandlerImpl.h"
 #import "../BugsnagPerformanceSpan+Private.h"
+#import "../Logging.h"  // TEMP: flow logs
 
 using namespace bugsnag;
 
@@ -19,8 +20,20 @@ SpanLifecycleHandlerImpl::preStartSetup() noexcept {
 
 void
 SpanLifecycleHandlerImpl::onSpanStarted(BugsnagPerformanceSpan *span, const SpanOptions &options) noexcept {
+    // TEMP: disk-IO flow log
+    bool diskEligible = shouldSampleDiskIO(span);
+    BSGLogInfo(@"[DiskIO Flow] Step A/onSpanStarted -- span=%@ firstClass=%d metrics.disk=%d enabledMetrics.disk=%d eligible=%d",
+               span.name,
+               (int)span.firstClass,
+               (int)span.metricsOptions.disk,
+               enabledMetrics_.disk ? 1 : 0,
+               diskEligible ? 1 : 0);
+
     if (shouldInstrumentRendering(span)) {
         span.startFramerateSnapshot = [frameMetricsCollector_ currentSnapshot];
+    }
+    if (diskEligible) {
+        [diskIOCollector_ onSpanStart:span];
     }
     store_->addNewSpan(span, options.makeCurrentContext);
     callOnSpanStartCallbacks(span);
@@ -29,8 +42,33 @@ SpanLifecycleHandlerImpl::onSpanStarted(BugsnagPerformanceSpan *span, const Span
 
 void
 SpanLifecycleHandlerImpl::onSpanEndSet(BugsnagPerformanceSpan *span) noexcept {
+    // TEMP: disk-IO flow log
+    bool diskEligible = shouldSampleDiskIO(span);
+    BSGLogInfo(@"[DiskIO Flow] Step B/onSpanEndSet -- span=%@ firstClass=%d metrics.disk=%d enabledMetrics.disk=%d eligible=%d",
+               span.name,
+               (int)span.firstClass,
+               (int)span.metricsOptions.disk,
+               enabledMetrics_.disk ? 1 : 0,
+               diskEligible ? 1 : 0);
+
     if (shouldInstrumentRendering(span)) {
         span.endFramerateSnapshot = [frameMetricsCollector_ currentSnapshot];
+    }
+    if (diskEligible) {
+        // Capture the end snapshot immediately at span end (before the span
+        // enters the delay queue). Any nil result — e.g. missing start
+        // snapshot, invalid platform read, or duration <= 0 — silently
+        // omits disk attributes for this span.
+        NSDictionary *diskAttributes = [diskIOCollector_ onSpanEnd:span];
+        BSGLogInfo(@"[DiskIO Flow] Step C/onSpanEndSet -- span=%@ attributes returned: count=%lu",
+                   span.name, (unsigned long)diskAttributes.count);
+        if (diskAttributes.count > 0) {
+            [span forceMutate:^{
+                [span internalSetMultipleAttributes:diskAttributes];
+            }];
+            BSGLogInfo(@"[DiskIO Flow] Step D/onSpanEndSet -- span=%@ attributes APPLIED to span (will be batched & sent)",
+                       span.name);
+        }
     }
     // Internal SDK bookkeeping that must happen as soon as the end time is set,
     // Before sampling or user on-span-end callbacks can discard the span.
@@ -86,6 +124,9 @@ SpanLifecycleHandlerImpl::onSpanCancelled(BugsnagPerformanceSpan *span) noexcept
     if (!span) {
         return;
     }
+    // Release any pending disk-IO start snapshot so the map does not grow
+    // for spans that will never end.
+    [diskIOCollector_ abandonSpan:span];
     batch_->removeSpan(span.traceIdHi, span.traceIdLo, span.spanId);
     onSpanDiscarded_(span);
     if (span.isBlocked) {
@@ -113,6 +154,21 @@ SpanLifecycleHandlerImpl::shouldInstrumentRendering(BugsnagPerformanceSpan *span
             return enabledMetrics_.rendering &&
             !span.wasStartOrEndTimeProvided &&
             span.firstClass == BSGTriStateYes;
+    }
+}
+
+bool
+SpanLifecycleHandlerImpl::shouldSampleDiskIO(BugsnagPerformanceSpan *span) noexcept {
+    if (!enabledMetrics_.disk) {
+        return false;
+    }
+    switch (span.metricsOptions.disk) {
+        case BSGTriStateYes:
+            return true;
+        case BSGTriStateNo:
+            return false;
+        case BSGTriStateUnset:
+            return span.firstClass == BSGTriStateYes;
     }
 }
 
@@ -278,3 +334,4 @@ SpanLifecycleHandlerImpl::processClosedSpan(BugsnagPerformanceSpan *span) noexce
 
     batch_->add(span);
 }
+

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -39,28 +39,31 @@ static inline NSURL *DefaultEndpointForKey(NSString *apiKey) {
 @implementation BugsnagPerformanceEnabledMetrics
 
 + (instancetype) withAllEnabled {
-    return [[BugsnagPerformanceEnabledMetrics alloc] initWithRendering:YES cpu:YES memory:YES];
+    return [[BugsnagPerformanceEnabledMetrics alloc] initWithRendering:YES cpu:YES memory:YES disk:YES];
 }
 
 - (instancetype) initWithRendering:(BOOL)rendering
                                cpu:(BOOL)cpu
-                            memory:(BOOL)memory {
+                            memory:(BOOL)memory
+                              disk:(BOOL)disk {
     if ((self = [super init])) {
         _rendering = rendering;
         _cpu = cpu;
         _memory = memory;
+        _disk = disk;
     }
     return self;
 }
 
 - (instancetype) init {
-    return [self initWithRendering:NO cpu:NO memory:NO];
+    return [self initWithRendering:NO cpu:NO memory:NO disk:NO];
 }
 
 - (instancetype) clone {
     return [[BugsnagPerformanceEnabledMetrics alloc] initWithRendering:self.rendering
                                                                    cpu:self.cpu
-                                                                memory:self.memory];
+                                                                memory:self.memory
+                                                                  disk:self.disk];
 }
 
 @end

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceConfiguration.mm
@@ -328,6 +328,9 @@ static inline NSUInteger minMaxDefault(NSUInteger value, NSUInteger min, NSUInte
         // any important notifications before the first work cycle is started.
         // It also gives time for us to receive our initial P value from the server.
         _initialRecurringWorkDelay = 1.0;
+
+        // Test-only; production never changes this from "no faults".
+        _diskIOSnapshotFaultMode = 0;
     }
     return self;
 }

--- a/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
+++ b/Sources/BugsnagPerformance/Public/BugsnagPerformanceSpanOptions.m
@@ -15,23 +15,29 @@
 
 - (instancetype)initWithRendering:(BSGTriState)rendering
                               cpu:(BSGTriState)cpu
-                           memory:(BSGTriState)memory {
+                           memory:(BSGTriState)memory
+                             disk:(BSGTriState)disk {
     if ((self = [super init])) {
         _rendering = rendering;
         _cpu = cpu;
         _memory = memory;
+        _disk = disk;
     }
     return self;
 }
 
 - (instancetype)init {
-    return [self initWithRendering:BSGTriStateUnset cpu:BSGTriStateUnset memory:BSGTriStateUnset];
+    return [self initWithRendering:BSGTriStateUnset
+                               cpu:BSGTriStateUnset
+                            memory:BSGTriStateUnset
+                              disk:BSGTriStateUnset];
 }
 
 - (instancetype)clone {
     return [[BugsnagPerformanceSpanMetricsOptions alloc] initWithRendering:self.rendering
                                                                        cpu:self.cpu
-                                                                    memory:self.memory];
+                                                                    memory:self.memory
+                                                                      disk:self.disk];
 }
 
 @end

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -10,13 +10,12 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
 #import <BugsnagPerformance/BugsnagPerformancePlugin.h>
 
-#import <TargetConditionals.h>
-
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 typedef BOOL (^ BugsnagPerformanceViewControllerInstrumentationCallback)(UIViewController *viewController);
+
 /**
  * A callback that gets called whenever a span starts.
  */

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceConfiguration.h
@@ -10,12 +10,13 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
 #import <BugsnagPerformance/BugsnagPerformancePlugin.h>
 
+#import <TargetConditionals.h>
+
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 typedef BOOL (^ BugsnagPerformanceViewControllerInstrumentationCallback)(UIViewController *viewController);
-
 /**
  * A callback that gets called whenever a span starts.
  */
@@ -33,6 +34,7 @@ OBJC_EXPORT
 @property(nonatomic) BOOL rendering; // (default NO)
 @property(nonatomic) BOOL cpu;       // (default NO)
 @property(nonatomic) BOOL memory;    // (default NO)
+@property(nonatomic) BOOL disk;      // (default NO)
 
 - (instancetype) clone;
 

--- a/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
+++ b/Sources/BugsnagPerformance/include/BugsnagPerformance/BugsnagPerformanceSpanOptions.h
@@ -41,6 +41,14 @@ typedef NS_ENUM(uint8_t, BSGTriState) {
  */
 @property(nonatomic) BSGTriState memory;
 
+/**
+ * No = never include these metrics
+ * Yes = Always include these metrics, as long as the corresponding enabledMetrics configuration option is on
+ * Unset = Include metrics only if the span is first class and the corresponding enabledMetrics configuration option is on
+ * Default: Unset
+ */
+@property(nonatomic) BSGTriState disk;
+
 - (_Nonnull instancetype)clone;
 
 @end

--- a/Tests/BugsnagPerformanceTests/DiskIOCollectorTests.mm
+++ b/Tests/BugsnagPerformanceTests/DiskIOCollectorTests.mm
@@ -224,6 +224,71 @@ static BugsnagPerformanceSpan *makeSpan() {
     XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
 }
 
+#pragma mark - Test-only fault injection
+
+// These guard the hook used by the Maze Runner disk IOPS scenarios. The most
+// important assertion is the first one: production must always run with
+// BSGDiskIOSnapshotFaultModeNone.
+
+- (void)testFaultModeDefaultsToNone {
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    XCTAssertEqual(collector.faultMode, BSGDiskIOSnapshotFaultModeNone);
+}
+
+- (void)testFailAtStartFaultStoresNoStartSnapshotAndOmitsAttributes {
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    collector.faultMode = BSGDiskIOSnapshotFaultModeFailAtStart;
+    BugsnagPerformanceSpan *span = makeSpan();
+
+    [collector onSpanStart:span];
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+
+    [NSThread sleepForTimeInterval:0.01];
+    XCTAssertNil([collector onSpanEnd:span]);
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+}
+
+- (void)testFailAtEndFaultOmitsAttributesAndStillCleansUp {
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    collector.faultMode = BSGDiskIOSnapshotFaultModeFailAtEnd;
+    BugsnagPerformanceSpan *span = makeSpan();
+
+    [collector onSpanStart:span];
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)1);
+
+    [NSThread sleepForTimeInterval:0.01];
+    XCTAssertNil([collector onSpanEnd:span]);
+    // The stored start snapshot must still be released.
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+}
+
+- (void)testZeroDurationFaultOmitsAttributes {
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    collector.faultMode = BSGDiskIOSnapshotFaultModeZeroDuration;
+    BugsnagPerformanceSpan *span = makeSpan();
+
+    [collector onSpanStart:span];
+    [NSThread sleepForTimeInterval:0.01];
+    XCTAssertNil([collector onSpanEnd:span]);
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+}
+
+- (void)testNegativeDeltaFaultClampsToZeroRatherThanEmittingInvalidValues {
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    collector.faultMode = BSGDiskIOSnapshotFaultModeNegativeDelta;
+    BugsnagPerformanceSpan *span = makeSpan();
+
+    [collector onSpanStart:span];
+    [NSThread sleepForTimeInterval:0.01];
+    NSDictionary<NSString *, NSNumber *> *attrs = [collector onSpanEnd:span];
+
+    XCTAssertNotNil(attrs);
+    XCTAssertEqual(attrs[@"bugsnag.system.disk.iops_read"].longLongValue, 0);
+    XCTAssertEqual(attrs[@"bugsnag.system.disk.iops_write"].longLongValue, 0);
+    XCTAssertEqual(attrs[@"bugsnag.system.disk.iops_total"].longLongValue, 0);
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+}
+
 @end
 
 #pragma mark - Lifecycle gating

--- a/Tests/BugsnagPerformanceTests/DiskIOCollectorTests.mm
+++ b/Tests/BugsnagPerformanceTests/DiskIOCollectorTests.mm
@@ -12,6 +12,8 @@
 #import "BugsnagPerformanceSpan+Private.h"
 #import "IdGenerator.h"
 #import "SpanOptions.h"
+#import "../../Sources/BugsnagPerformance/Private/SpanLifecycle/SpanLifecycleHandlerImpl.h"
+#import "../../Sources/BugsnagPerformance/Private/SpanStore/SpanStoreImpl.h"
 
 // TEMP: flow logs so each test narrates its steps in the test console output.
 // Uses fprintf(stderr) so xcodebuild's captured stdout/stderr picks it up
@@ -220,6 +222,101 @@ static BugsnagPerformanceSpan *makeSpan() {
 
     XCTAssertEqual(validEnds, kSpanCount);
     XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+}
+
+@end
+
+#pragma mark - Lifecycle gating
+
+// Asserts the SpanLifecycleHandlerImpl gating: disk IOPS attributes must never
+// be collected or applied unless BugsnagPerformance has been started AND
+// enabledMetrics.disk is on.
+@interface DiskIOLifecycleGatingTests : XCTestCase
+@end
+
+@implementation DiskIOLifecycleGatingTests {
+    BSGDiskIOCollector *collector_;
+    std::shared_ptr<SpanLifecycleHandlerImpl> handler_;
+}
+
+- (void)setUpHandler {
+    auto sampler = std::make_shared<Sampler>();
+    auto spanStackingHandler = std::make_shared<SpanStackingHandler>();
+    auto spanAttributesProvider = std::make_shared<SpanAttributesProvider>();
+    collector_ = [BSGDiskIOCollector new];
+    handler_ = std::make_shared<SpanLifecycleHandlerImpl>(
+        sampler,
+        std::make_shared<SpanStoreImpl>(spanStackingHandler),
+        std::make_shared<ConditionTimeoutExecutor>(),
+        std::make_shared<PlainSpanFactoryImpl>(sampler, spanStackingHandler, spanAttributesProvider),
+        std::make_shared<Batch>(),
+        [FrameMetricsCollector new],
+        collector_,
+        [BSGPrioritizedStore<BugsnagPerformanceSpanStartCallback> new],
+        [BSGPrioritizedStore<BugsnagPerformanceSpanEndCallback> new],
+        ^{},
+        ^(BugsnagPerformanceSpan *) {},
+        ^(BugsnagPerformanceSpan *) {});
+}
+
+- (BugsnagPerformanceConfiguration *)configWithDiskEnabled:(BOOL)diskEnabled {
+    auto config = [[BugsnagPerformanceConfiguration alloc] initWithApiKey:@"12312312312312312312312312312312"];
+    config.enabledMetrics.disk = diskEnabled;
+    return config;
+}
+
+- (void)testNoDiskCollectionWhenNeverStarted {
+    [self setUpHandler];
+    // Even with disk metrics enabled in the configuration, nothing may be
+    // collected before start() — this covers the pre-main/early-span window
+    // and the "Bugsnag is never started" case.
+    handler_->configure([self configWithDiskEnabled:YES]);
+
+    BugsnagPerformanceSpan *span = makeSpan();
+    handler_->onSpanStarted(span, SpanOptions());
+    XCTAssertEqual(collector_.pendingSpanCount, (NSUInteger)0);
+
+    [NSThread sleepForTimeInterval:0.01];
+    handler_->onSpanEndSet(span);
+    XCTAssertNil([span getAttribute:@"bugsnag.system.disk.iops_read"]);
+    XCTAssertNil([span getAttribute:@"bugsnag.system.disk.iops_write"]);
+    XCTAssertNil([span getAttribute:@"bugsnag.system.disk.iops_total"]);
+}
+
+- (void)testNoDiskCollectionWhenDiskMetricsDisabled {
+    [self setUpHandler];
+    // Default configuration: enabledMetrics.disk is NO.
+    handler_->configure([self configWithDiskEnabled:NO]);
+    handler_->start();
+
+    BugsnagPerformanceSpan *span = makeSpan();
+    handler_->onSpanStarted(span, SpanOptions());
+    XCTAssertEqual(collector_.pendingSpanCount, (NSUInteger)0);
+
+    [NSThread sleepForTimeInterval:0.01];
+    handler_->onSpanEndSet(span);
+    XCTAssertNil([span getAttribute:@"bugsnag.system.disk.iops_read"]);
+    XCTAssertNil([span getAttribute:@"bugsnag.system.disk.iops_write"]);
+    XCTAssertNil([span getAttribute:@"bugsnag.system.disk.iops_total"]);
+}
+
+- (void)testDiskCollectionWhenEnabledAndStarted {
+    [self setUpHandler];
+    handler_->configure([self configWithDiskEnabled:YES]);
+    handler_->start();
+
+    // makeSpan() creates a first-class span with metricsOptions.disk unset,
+    // which is the eligible combination.
+    BugsnagPerformanceSpan *span = makeSpan();
+    handler_->onSpanStarted(span, SpanOptions());
+    XCTAssertEqual(collector_.pendingSpanCount, (NSUInteger)1);
+
+    [NSThread sleepForTimeInterval:0.01];
+    handler_->onSpanEndSet(span);
+    XCTAssertNotNil([span getAttribute:@"bugsnag.system.disk.iops_read"]);
+    XCTAssertNotNil([span getAttribute:@"bugsnag.system.disk.iops_write"]);
+    XCTAssertNotNil([span getAttribute:@"bugsnag.system.disk.iops_total"]);
+    XCTAssertEqual(collector_.pendingSpanCount, (NSUInteger)0);
 }
 
 @end

--- a/Tests/BugsnagPerformanceTests/DiskIOCollectorTests.mm
+++ b/Tests/BugsnagPerformanceTests/DiskIOCollectorTests.mm
@@ -1,0 +1,225 @@
+//
+//  DiskIOCollectorTests.mm
+//  BugsnagPerformance
+//
+//  Created by gaurav agarawal on 03/08/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "../../Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOCollector.h"
+#import "BugsnagPerformanceSpan+Private.h"
+#import "IdGenerator.h"
+#import "SpanOptions.h"
+
+// TEMP: flow logs so each test narrates its steps in the test console output.
+// Uses fprintf(stderr) so xcodebuild's captured stdout/stderr picks it up
+// (NSLog goes to os_log and is NOT captured by xcodebuild output redirection).
+#define BSG_TEST_LOG(fmt, ...) do { \
+    NSString *__msg = [NSString stringWithFormat:(@"[DiskIOTest] " fmt "\n"), ##__VA_ARGS__]; \
+    fputs(__msg.UTF8String, stderr); fflush(stderr); \
+    NSLog(@"[DiskIOTest] " fmt, ##__VA_ARGS__); \
+} while (0)
+
+using namespace bugsnag;
+
+@interface DiskIOCollectorTests : XCTestCase
+@end
+
+@implementation DiskIOCollectorTests
+
+- (void)setUp {
+    BSG_TEST_LOG(@"=== BEGIN %@ ===", NSStringFromSelector(self.invocation.selector));
+}
+
+- (void)tearDown {
+    BSG_TEST_LOG(@"=== END   %@ ===", NSStringFromSelector(self.invocation.selector));
+}
+
+static BugsnagPerformanceSpan *makeSpan() {
+    MetricsOptions metricsOptions;
+    TraceId tid = {.value = 1};
+    return [[BugsnagPerformanceSpan alloc] initWithName:@"test"
+                                                traceId:tid
+                                                 spanId:IdGenerator::generateSpanId()
+                                               parentId:IdGenerator::generateSpanId()
+                                              startTime:SpanOptions().startTime
+                                             firstClass:BSGTriStateYes
+                                    samplingProbability:1.0
+                                    attributeCountLimit:128
+                                         metricsOptions:metricsOptions
+                                 conditionsToEndOnClose:@[]
+                                           onSpanEndSet:^(BugsnagPerformanceSpan * _Nonnull) {}
+                                           onSpanClosed:^(BugsnagPerformanceSpan * _Nonnull) {}
+                                          onSpanBlocked:^BugsnagPerformanceSpanCondition * _Nullable(BugsnagPerformanceSpan * _Nonnull, NSTimeInterval) { return nil; }
+                                        onSpanCancelled:^(BugsnagPerformanceSpan * _Nonnull) {}];
+}
+
+- (void)testStartFollowedByEndReturnsThreeIOPSAttributes {
+    BSG_TEST_LOG(@"Step 1: create collector + span");
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    BugsnagPerformanceSpan *span = makeSpan();
+
+    BSG_TEST_LOG(@"Step 2: calling onSpanStart (spanId=%016llx)", (unsigned long long)span.spanId);
+    [collector onSpanStart:span];
+    BSG_TEST_LOG(@"Step 3: pending=%lu (expected 1)", (unsigned long)collector.pendingSpanCount);
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)1);
+
+    // Ensure duration > 0 so metrics can be computed.
+    BSG_TEST_LOG(@"Step 4: sleeping 10 ms so span duration > 0");
+    [NSThread sleepForTimeInterval:0.01];
+
+    BSG_TEST_LOG(@"Step 5: calling onSpanEnd");
+    NSDictionary<NSString *, NSNumber *> *attrs = [collector onSpanEnd:span];
+    BSG_TEST_LOG(@"Step 6: got %lu attributes: %@", (unsigned long)attrs.count, attrs);
+
+    XCTAssertNotNil(attrs);
+    XCTAssertNotNil(attrs[@"bugsnag.system.disk.iops_read"]);
+    XCTAssertNotNil(attrs[@"bugsnag.system.disk.iops_write"]);
+    XCTAssertNotNil(attrs[@"bugsnag.system.disk.iops_total"]);
+
+    // Start entry must have been removed.
+    BSG_TEST_LOG(@"Step 7: pending after end=%lu (expected 0)", (unsigned long)collector.pendingSpanCount);
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+}
+
+- (void)testTotalEqualsReadPlusWrite {
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    BugsnagPerformanceSpan *span = makeSpan();
+
+    BSG_TEST_LOG(@"Step 1: onSpanStart + 10 ms sleep + onSpanEnd");
+    [collector onSpanStart:span];
+    [NSThread sleepForTimeInterval:0.01];
+    NSDictionary<NSString *, NSNumber *> *attrs = [collector onSpanEnd:span];
+    XCTAssertNotNil(attrs);
+
+    int64_t r = attrs[@"bugsnag.system.disk.iops_read"].longLongValue;
+    int64_t w = attrs[@"bugsnag.system.disk.iops_write"].longLongValue;
+    int64_t t = attrs[@"bugsnag.system.disk.iops_total"].longLongValue;
+    BSG_TEST_LOG(@"Step 2: r=%lld w=%lld t=%lld (expecting t == r + w)", r, w, t);
+    XCTAssertEqual(t, r + w);
+}
+
+- (void)testEndWithoutMatchingStartReturnsNil {
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    BugsnagPerformanceSpan *span = makeSpan();
+
+    BSG_TEST_LOG(@"Step 1: calling onSpanEnd WITHOUT a prior onSpanStart");
+    NSDictionary *attrs = [collector onSpanEnd:span];
+    BSG_TEST_LOG(@"Step 2: got attrs=%@ (expected nil)", attrs);
+    XCTAssertNil(attrs);
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+}
+
+- (void)testNilSpanIsIgnored {
+    // The public API is annotated non-null, but the collector still guards
+    // against nil defensively. Bypass the compile-time nullability check with
+    // a runtime-typed variable so we can validate that defensive behavior.
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    BugsnagPerformanceSpan *nilSpan = nil;
+
+    BSG_TEST_LOG(@"Step 1: calling onSpanStart with nil");
+    [collector onSpanStart:nilSpan];
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+
+    BSG_TEST_LOG(@"Step 2: calling onSpanEnd with nil (expecting nil result)");
+    XCTAssertNil([collector onSpanEnd:nilSpan]);
+
+    BSG_TEST_LOG(@"Step 3: calling abandonSpan with nil (should not crash)");
+    [collector abandonSpan:nilSpan];
+}
+
+- (void)testAbandonReleasesPendingStart {
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    BugsnagPerformanceSpan *span = makeSpan();
+
+    BSG_TEST_LOG(@"Step 1: onSpanStart");
+    [collector onSpanStart:span];
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)1);
+
+    BSG_TEST_LOG(@"Step 2: abandonSpan -- simulates cancellation");
+    [collector abandonSpan:span];
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+
+    // A subsequent onSpanEnd for the same span must return nil since the
+    // start snapshot has been dropped.
+    BSG_TEST_LOG(@"Step 3: onSpanEnd should now return nil");
+    XCTAssertNil([collector onSpanEnd:span]);
+}
+
+- (void)testTwoSpansAreTrackedIndependently {
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    BugsnagPerformanceSpan *spanA = makeSpan();
+    BugsnagPerformanceSpan *spanB = makeSpan();
+
+    BSG_TEST_LOG(@"Step 1: onSpanStart for A (%016llx) and B (%016llx)",
+                 (unsigned long long)spanA.spanId,
+                 (unsigned long long)spanB.spanId);
+    [collector onSpanStart:spanA];
+    [collector onSpanStart:spanB];
+    BSG_TEST_LOG(@"Step 2: pending=%lu (expected 2)", (unsigned long)collector.pendingSpanCount);
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)2);
+
+    [NSThread sleepForTimeInterval:0.01];
+    BSG_TEST_LOG(@"Step 3: onSpanEnd(A) -- B must remain pending");
+    NSDictionary *attrsA = [collector onSpanEnd:spanA];
+    XCTAssertNotNil(attrsA);
+    BSG_TEST_LOG(@"Step 4: pending=%lu (expected 1)", (unsigned long)collector.pendingSpanCount);
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)1);
+
+    BSG_TEST_LOG(@"Step 5: onSpanEnd(B)");
+    NSDictionary *attrsB = [collector onSpanEnd:spanB];
+    XCTAssertNotNil(attrsB);
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+}
+
+- (void)testConcurrentStartAndEndAreThreadSafe {
+    BSGDiskIOCollector *collector = [BSGDiskIOCollector new];
+    NSMutableArray<BugsnagPerformanceSpan *> *spans = [NSMutableArray array];
+    const NSUInteger kSpanCount = 200;
+    for (NSUInteger i = 0; i < kSpanCount; i++) {
+        [spans addObject:makeSpan()];
+    }
+    BSG_TEST_LOG(@"Step 1: created %lu spans", (unsigned long)kSpanCount);
+
+    dispatch_queue_t startQueue = dispatch_queue_create("bsg.diskio.tests.start", DISPATCH_QUEUE_CONCURRENT);
+    dispatch_queue_t endQueue = dispatch_queue_create("bsg.diskio.tests.end", DISPATCH_QUEUE_CONCURRENT);
+
+    dispatch_group_t group = dispatch_group_create();
+
+    BSG_TEST_LOG(@"Step 2: dispatching %lu concurrent onSpanStart calls", (unsigned long)kSpanCount);
+    for (BugsnagPerformanceSpan *span in spans) {
+        dispatch_group_async(group, startQueue, ^{
+            [collector onSpanStart:span];
+        });
+    }
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+    BSG_TEST_LOG(@"Step 3: all starts done; pending=%lu", (unsigned long)collector.pendingSpanCount);
+    // Ensure duration > 0.
+    [NSThread sleepForTimeInterval:0.02];
+
+    __block NSUInteger validEnds = 0;
+    NSLock *counterLock = [NSLock new];
+    BSG_TEST_LOG(@"Step 4: dispatching %lu concurrent onSpanEnd calls", (unsigned long)kSpanCount);
+    for (BugsnagPerformanceSpan *span in spans) {
+        dispatch_group_async(group, endQueue, ^{
+            NSDictionary *attrs = [collector onSpanEnd:span];
+            if (attrs != nil) {
+                [counterLock lock];
+                validEnds++;
+                [counterLock unlock];
+            }
+        });
+    }
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+    BSG_TEST_LOG(@"Step 5: %lu / %lu ends produced valid attributes; final pending=%lu",
+                 (unsigned long)validEnds,
+                 (unsigned long)kSpanCount,
+                 (unsigned long)collector.pendingSpanCount);
+
+    XCTAssertEqual(validEnds, kSpanCount);
+    XCTAssertEqual(collector.pendingSpanCount, (NSUInteger)0);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/DiskIOMetricsTests.mm
+++ b/Tests/BugsnagPerformanceTests/DiskIOMetricsTests.mm
@@ -1,0 +1,206 @@
+//
+//  DiskIOMetricsTests.mm
+//  BugsnagPerformance
+//
+//  Created by gaurav agarawal on 03/08/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "../../Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOMetrics.h"
+#import "../../Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOSnapshot.h"
+
+// TEMP: flow logs so each test narrates its steps in the test console output.
+// Uses fprintf(stderr) so xcodebuild's captured stdout/stderr picks it up
+// (NSLog goes to os_log and is NOT captured by xcodebuild output redirection).
+#define BSG_TEST_LOG(fmt, ...) do { \
+    NSString *__msg = [NSString stringWithFormat:(@"[DiskIOTest] " fmt "\n"), ##__VA_ARGS__]; \
+    fputs(__msg.UTF8String, stderr); fflush(stderr); \
+    NSLog(@"[DiskIOTest] " fmt, ##__VA_ARGS__); \
+} while (0)
+
+static void logMetrics(const char *label, const BSGDiskIOMetrics &m) {
+    NSString *msg = [NSString stringWithFormat:
+        @"[DiskIOTest]   %s -> valid=%d iops_read=%lld iops_write=%lld iops_total=%lld\n",
+        label, m.valid ? 1 : 0,
+        (long long)m.iopsRead,
+        (long long)m.iopsWrite,
+        (long long)m.iopsTotal];
+    fputs(msg.UTF8String, stderr); fflush(stderr);
+    NSLog(@"%@", [msg stringByReplacingOccurrencesOfString:@"\n" withString:@""]);
+}
+
+@interface DiskIOMetricsTests : XCTestCase
+@end
+
+@implementation DiskIOMetricsTests
+
+- (void)setUp {
+    BSG_TEST_LOG(@"=== BEGIN %@ ===", NSStringFromSelector(self.invocation.selector));
+}
+
+- (void)tearDown {
+    BSG_TEST_LOG(@"=== END   %@ ===", NSStringFromSelector(self.invocation.selector));
+}
+
+static BSGDiskIOSnapshot makeSnapshot(CFAbsoluteTime t, uint64_t r, uint64_t w) {
+    BSGDiskIOSnapshot s;
+    s.timestamp = t;
+    s.bytesRead = r;
+    s.bytesWritten = w;
+    s.valid = true;
+    return s;
+}
+
+- (void)testKnownGoodDatasetFromScopingDoc {
+    // 524288 bytes read + 262144 bytes written over 2s at 16 KB block size
+    // -> read: 524288/16384 = 32 ops, 32/2 = 16 ops/sec
+    // -> write: 262144/16384 = 16 ops, 16/2 = 8 ops/sec
+    BSGDiskIOSnapshot start = makeSnapshot(0.0, 0, 0);
+    BSGDiskIOSnapshot end = makeSnapshot(2.0, 524288, 262144);
+    BSG_TEST_LOG(@"Step 1: input start(t=0 r=0 w=0), end(t=2 r=524288 w=262144)");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting read=16 write=8 total=24");
+
+    XCTAssertTrue(metrics.valid);
+    XCTAssertEqual(metrics.iopsRead, 16);
+    XCTAssertEqual(metrics.iopsWrite, 8);
+    XCTAssertEqual(metrics.iopsTotal, 24);
+}
+
+- (void)testZeroDeltaProducesZeroIOPS {
+    BSGDiskIOSnapshot start = makeSnapshot(0.0, 1000, 2000);
+    BSGDiskIOSnapshot end = makeSnapshot(1.0, 1000, 2000);
+    BSG_TEST_LOG(@"Step 1: input start(r=1000 w=2000), end same counters over 1s");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting all zeros");
+
+    XCTAssertTrue(metrics.valid);
+    XCTAssertEqual(metrics.iopsRead, 0);
+    XCTAssertEqual(metrics.iopsWrite, 0);
+    XCTAssertEqual(metrics.iopsTotal, 0);
+}
+
+- (void)testZeroDurationReturnsInvalid {
+    BSGDiskIOSnapshot start = makeSnapshot(5.0, 0, 0);
+    BSGDiskIOSnapshot end = makeSnapshot(5.0, 524288, 262144);
+    BSG_TEST_LOG(@"Step 1: input with duration = end.t (5.0) - start.t (5.0) = 0");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting metrics.valid = false");
+    XCTAssertFalse(metrics.valid);
+}
+
+- (void)testNegativeDurationReturnsInvalid {
+    BSGDiskIOSnapshot start = makeSnapshot(10.0, 0, 0);
+    BSGDiskIOSnapshot end = makeSnapshot(5.0, 524288, 262144);
+    BSG_TEST_LOG(@"Step 1: input with negative duration (start.t=10 > end.t=5)");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting metrics.valid = false");
+    XCTAssertFalse(metrics.valid);
+}
+
+- (void)testInvalidStartSnapshotReturnsInvalid {
+    BSGDiskIOSnapshot start;
+    start.timestamp = 0.0;
+    start.bytesRead = 0;
+    start.bytesWritten = 0;
+    start.valid = false;
+    BSGDiskIOSnapshot end = makeSnapshot(2.0, 524288, 262144);
+    BSG_TEST_LOG(@"Step 1: start snapshot marked invalid");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting metrics.valid = false");
+    XCTAssertFalse(metrics.valid);
+}
+
+- (void)testInvalidEndSnapshotReturnsInvalid {
+    BSGDiskIOSnapshot start = makeSnapshot(0.0, 0, 0);
+    BSGDiskIOSnapshot end;
+    end.timestamp = 2.0;
+    end.bytesRead = 524288;
+    end.bytesWritten = 262144;
+    end.valid = false;
+    BSG_TEST_LOG(@"Step 1: end snapshot marked invalid");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting metrics.valid = false");
+    XCTAssertFalse(metrics.valid);
+}
+
+- (void)testNegativeReadDeltaClampsToZero {
+    // Counter regressed backwards (should never happen on the platform, but
+    // handle it defensively).
+    BSGDiskIOSnapshot start = makeSnapshot(0.0, 1000000, 500000);
+    BSGDiskIOSnapshot end = makeSnapshot(2.0, 900000, 762144);
+    BSG_TEST_LOG(@"Step 1: read counter regressed (1000000 -> 900000); write went up by 262144 over 2s");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting read=0 (clamped), write=8, total=8");
+
+    XCTAssertTrue(metrics.valid);
+    XCTAssertEqual(metrics.iopsRead, 0);
+    XCTAssertEqual(metrics.iopsWrite, 8);
+    XCTAssertEqual(metrics.iopsTotal, 8);
+}
+
+- (void)testRoundingUsesLlround {
+    // 12288 bytes read over 1s at 16 KB block size -> 0.75 ops/sec -> rounds to 1.
+    BSGDiskIOSnapshot start = makeSnapshot(0.0, 0, 0);
+    BSGDiskIOSnapshot end = makeSnapshot(1.0, 12288, 0);
+    BSG_TEST_LOG(@"Step 1: 12288 bytes read over 1s = 0.75 ops/sec (should round to 1)");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting read=1, write=0, total=1");
+
+    XCTAssertTrue(metrics.valid);
+    XCTAssertEqual(metrics.iopsRead, 1);
+    XCTAssertEqual(metrics.iopsWrite, 0);
+    XCTAssertEqual(metrics.iopsTotal, 1);
+}
+
+- (void)testSubBlockDeltaRoundsToZero {
+    // 4096 bytes read over 1s at 16 KB block size -> 0.25 ops/sec -> rounds to 0.
+    BSGDiskIOSnapshot start = makeSnapshot(0.0, 0, 0);
+    BSGDiskIOSnapshot end = makeSnapshot(1.0, 4096, 0);
+    BSG_TEST_LOG(@"Step 1: 4096 bytes read over 1s = 0.25 ops/sec (should round to 0)");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting all zeros (rounded)");
+
+    XCTAssertTrue(metrics.valid);
+    XCTAssertEqual(metrics.iopsRead, 0);
+    XCTAssertEqual(metrics.iopsWrite, 0);
+    XCTAssertEqual(metrics.iopsTotal, 0);
+}
+
+- (void)testShortSubSecondSpanStillComputesNormally {
+    // 8192 bytes read over 0.1s at 16 KB -> 0.5 ops / 0.1s = 5 ops/sec.
+    BSGDiskIOSnapshot start = makeSnapshot(0.0, 0, 0);
+    BSGDiskIOSnapshot end = makeSnapshot(0.1, 8192, 8192);
+    BSG_TEST_LOG(@"Step 1: 8192 R + 8192 W over 0.1s at 16 KB block -> 5 ops/sec each");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting read=5, write=5, total=10");
+
+    XCTAssertTrue(metrics.valid);
+    XCTAssertEqual(metrics.iopsRead, 5);
+    XCTAssertEqual(metrics.iopsWrite, 5);
+    XCTAssertEqual(metrics.iopsTotal, 10);
+}
+
+@end

--- a/Tests/BugsnagPerformanceTests/DiskIOMetricsTests.mm
+++ b/Tests/BugsnagPerformanceTests/DiskIOMetricsTests.mm
@@ -44,31 +44,36 @@ static void logMetrics(const char *label, const BSGDiskIOMetrics &m) {
     BSG_TEST_LOG(@"=== END   %@ ===", NSStringFromSelector(self.invocation.selector));
 }
 
+// The tests pin the block size explicitly rather than reading the host's real
+// f_bsize, so expected values stay deterministic across simulators/devices.
+static constexpr uint32_t kTestBlockSize = 4096;
+
 static BSGDiskIOSnapshot makeSnapshot(CFAbsoluteTime t, uint64_t r, uint64_t w) {
     BSGDiskIOSnapshot s;
     s.timestamp = t;
     s.bytesRead = r;
     s.bytesWritten = w;
+    s.blockSize = kTestBlockSize;
     s.valid = true;
     return s;
 }
 
 - (void)testKnownGoodDatasetFromScopingDoc {
-    // 524288 bytes read + 262144 bytes written over 2s at 16 KB block size
-    // -> read: 524288/16384 = 32 ops, 32/2 = 16 ops/sec
-    // -> write: 262144/16384 = 16 ops, 16/2 = 8 ops/sec
+    // 524288 bytes read + 262144 bytes written over 2s at 4 KB block size
+    // -> read: 524288/4096 = 128 ops, 128/2 = 64 ops/sec
+    // -> write: 262144/4096 = 64 ops, 64/2 = 32 ops/sec
     BSGDiskIOSnapshot start = makeSnapshot(0.0, 0, 0);
     BSGDiskIOSnapshot end = makeSnapshot(2.0, 524288, 262144);
     BSG_TEST_LOG(@"Step 1: input start(t=0 r=0 w=0), end(t=2 r=524288 w=262144)");
 
     BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
     logMetrics("Step 2: result", metrics);
-    BSG_TEST_LOG(@"Step 3: expecting read=16 write=8 total=24");
+    BSG_TEST_LOG(@"Step 3: expecting read=64 write=32 total=96");
 
     XCTAssertTrue(metrics.valid);
-    XCTAssertEqual(metrics.iopsRead, 16);
-    XCTAssertEqual(metrics.iopsWrite, 8);
-    XCTAssertEqual(metrics.iopsTotal, 24);
+    XCTAssertEqual(metrics.iopsRead, 64);
+    XCTAssertEqual(metrics.iopsWrite, 32);
+    XCTAssertEqual(metrics.iopsTotal, 96);
 }
 
 - (void)testZeroDeltaProducesZeroIOPS {
@@ -113,6 +118,7 @@ static BSGDiskIOSnapshot makeSnapshot(CFAbsoluteTime t, uint64_t r, uint64_t w) 
     start.timestamp = 0.0;
     start.bytesRead = 0;
     start.bytesWritten = 0;
+    start.blockSize = kTestBlockSize;
     start.valid = false;
     BSGDiskIOSnapshot end = makeSnapshot(2.0, 524288, 262144);
     BSG_TEST_LOG(@"Step 1: start snapshot marked invalid");
@@ -129,8 +135,22 @@ static BSGDiskIOSnapshot makeSnapshot(CFAbsoluteTime t, uint64_t r, uint64_t w) 
     end.timestamp = 2.0;
     end.bytesRead = 524288;
     end.bytesWritten = 262144;
+    end.blockSize = kTestBlockSize;
     end.valid = false;
     BSG_TEST_LOG(@"Step 1: end snapshot marked invalid");
+
+    BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
+    logMetrics("Step 2: result", metrics);
+    BSG_TEST_LOG(@"Step 3: expecting metrics.valid = false");
+    XCTAssertFalse(metrics.valid);
+}
+
+- (void)testZeroBlockSizeReturnsInvalid {
+    // Defensive: a non-positive block size must never divide by zero.
+    BSGDiskIOSnapshot start = makeSnapshot(0.0, 0, 0);
+    BSGDiskIOSnapshot end = makeSnapshot(2.0, 524288, 262144);
+    end.blockSize = 0;
+    BSG_TEST_LOG(@"Step 1: end snapshot has blockSize = 0");
 
     BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
     logMetrics("Step 2: result", metrics);
@@ -141,25 +161,26 @@ static BSGDiskIOSnapshot makeSnapshot(CFAbsoluteTime t, uint64_t r, uint64_t w) 
 - (void)testNegativeReadDeltaClampsToZero {
     // Counter regressed backwards (should never happen on the platform, but
     // handle it defensively).
+    // write delta = 762144 - 500000 = 262144 -> 262144/4096 = 64 ops, /2s = 32
     BSGDiskIOSnapshot start = makeSnapshot(0.0, 1000000, 500000);
     BSGDiskIOSnapshot end = makeSnapshot(2.0, 900000, 762144);
     BSG_TEST_LOG(@"Step 1: read counter regressed (1000000 -> 900000); write went up by 262144 over 2s");
 
     BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
     logMetrics("Step 2: result", metrics);
-    BSG_TEST_LOG(@"Step 3: expecting read=0 (clamped), write=8, total=8");
+    BSG_TEST_LOG(@"Step 3: expecting read=0 (clamped), write=32, total=32");
 
     XCTAssertTrue(metrics.valid);
     XCTAssertEqual(metrics.iopsRead, 0);
-    XCTAssertEqual(metrics.iopsWrite, 8);
-    XCTAssertEqual(metrics.iopsTotal, 8);
+    XCTAssertEqual(metrics.iopsWrite, 32);
+    XCTAssertEqual(metrics.iopsTotal, 32);
 }
 
 - (void)testRoundingUsesLlround {
-    // 12288 bytes read over 1s at 16 KB block size -> 0.75 ops/sec -> rounds to 1.
+    // 3072 bytes read over 1s at 4 KB block size -> 0.75 ops/sec -> rounds to 1.
     BSGDiskIOSnapshot start = makeSnapshot(0.0, 0, 0);
-    BSGDiskIOSnapshot end = makeSnapshot(1.0, 12288, 0);
-    BSG_TEST_LOG(@"Step 1: 12288 bytes read over 1s = 0.75 ops/sec (should round to 1)");
+    BSGDiskIOSnapshot end = makeSnapshot(1.0, 3072, 0);
+    BSG_TEST_LOG(@"Step 1: 3072 bytes read over 1s = 0.75 ops/sec (should round to 1)");
 
     BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
     logMetrics("Step 2: result", metrics);
@@ -172,10 +193,10 @@ static BSGDiskIOSnapshot makeSnapshot(CFAbsoluteTime t, uint64_t r, uint64_t w) 
 }
 
 - (void)testSubBlockDeltaRoundsToZero {
-    // 4096 bytes read over 1s at 16 KB block size -> 0.25 ops/sec -> rounds to 0.
+    // 1024 bytes read over 1s at 4 KB block size -> 0.25 ops/sec -> rounds to 0.
     BSGDiskIOSnapshot start = makeSnapshot(0.0, 0, 0);
-    BSGDiskIOSnapshot end = makeSnapshot(1.0, 4096, 0);
-    BSG_TEST_LOG(@"Step 1: 4096 bytes read over 1s = 0.25 ops/sec (should round to 0)");
+    BSGDiskIOSnapshot end = makeSnapshot(1.0, 1024, 0);
+    BSG_TEST_LOG(@"Step 1: 1024 bytes read over 1s = 0.25 ops/sec (should round to 0)");
 
     BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
     logMetrics("Step 2: result", metrics);
@@ -188,19 +209,29 @@ static BSGDiskIOSnapshot makeSnapshot(CFAbsoluteTime t, uint64_t r, uint64_t w) 
 }
 
 - (void)testShortSubSecondSpanStillComputesNormally {
-    // 8192 bytes read over 0.1s at 16 KB -> 0.5 ops / 0.1s = 5 ops/sec.
+    // 8192 bytes read + 8192 written over 0.1s at 4 KB -> 2 ops / 0.1s = 20 ops/sec.
     BSGDiskIOSnapshot start = makeSnapshot(0.0, 0, 0);
     BSGDiskIOSnapshot end = makeSnapshot(0.1, 8192, 8192);
-    BSG_TEST_LOG(@"Step 1: 8192 R + 8192 W over 0.1s at 16 KB block -> 5 ops/sec each");
+    BSG_TEST_LOG(@"Step 1: 8192 R + 8192 W over 0.1s at 4 KB block -> 20 ops/sec each");
 
     BSGDiskIOMetrics metrics = BSGComputeDiskIOMetrics(start, end);
     logMetrics("Step 2: result", metrics);
-    BSG_TEST_LOG(@"Step 3: expecting read=5, write=5, total=10");
+    BSG_TEST_LOG(@"Step 3: expecting read=20, write=20, total=40");
 
     XCTAssertTrue(metrics.valid);
-    XCTAssertEqual(metrics.iopsRead, 5);
-    XCTAssertEqual(metrics.iopsWrite, 5);
-    XCTAssertEqual(metrics.iopsTotal, 10);
+    XCTAssertEqual(metrics.iopsRead, 20);
+    XCTAssertEqual(metrics.iopsWrite, 20);
+    XCTAssertEqual(metrics.iopsTotal, 40);
+}
+
+- (void)testCapturedSnapshotUsesRealFilesystemBlockSize {
+    // The live capture path must populate a positive block size (real f_bsize
+    // or the 4 KB fallback) - never the old hardcoded 16 KB cluster size.
+    BSGDiskIOSnapshot snapshot = BSGCaptureDiskIOSnapshot();
+    BSG_TEST_LOG(@"Step 1: captured live snapshot, blockSize=%u", snapshot.blockSize);
+
+    XCTAssertGreaterThan(snapshot.blockSize, 0u);
+    XCTAssertEqual(snapshot.blockSize, BSGDiskBlockSizeBytes());
 }
 
 @end

--- a/Tests/BugsnagPerformanceTests/DiskIOSnapshotTests.mm
+++ b/Tests/BugsnagPerformanceTests/DiskIOSnapshotTests.mm
@@ -1,0 +1,102 @@
+//
+//  DiskIOSnapshotTests.mm
+//  BugsnagPerformance
+//
+//  Created by gaurav agarawal on 03/08/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "../../Sources/BugsnagPerformance/Private/DiskIO/BSGDiskIOSnapshot.h"
+
+// TEMP: flow logs so each test narrates its steps in the test console output.
+// Uses fprintf(stderr) so xcodebuild's captured stdout/stderr picks it up
+// (NSLog goes to os_log and is NOT captured by xcodebuild output redirection).
+#define BSG_TEST_LOG(fmt, ...) do { \
+    NSString *__msg = [NSString stringWithFormat:(@"[DiskIOTest] " fmt "\n"), ##__VA_ARGS__]; \
+    fputs(__msg.UTF8String, stderr); fflush(stderr); \
+    NSLog(@"[DiskIOTest] " fmt, ##__VA_ARGS__); \
+} while (0)
+
+@interface DiskIOSnapshotTests : XCTestCase
+@end
+
+@implementation DiskIOSnapshotTests
+
+- (void)setUp {
+    BSG_TEST_LOG(@"=== BEGIN %@ ===", NSStringFromSelector(self.invocation.selector));
+}
+
+- (void)tearDown {
+    BSG_TEST_LOG(@"=== END   %@ ===", NSStringFromSelector(self.invocation.selector));
+}
+
+- (void)testCaptureReturnsValidSnapshot {
+    BSG_TEST_LOG(@"Step 1: calling BSGCaptureDiskIOSnapshot()");
+    BSGDiskIOSnapshot snapshot = BSGCaptureDiskIOSnapshot();
+    BSG_TEST_LOG(@"Step 2: got snapshot valid=%d t=%.4f bytesRead=%llu bytesWritten=%llu",
+                 snapshot.valid,
+                 snapshot.timestamp,
+                 (unsigned long long)snapshot.bytesRead,
+                 (unsigned long long)snapshot.bytesWritten);
+
+    XCTAssertTrue(snapshot.valid,
+                  @"proc_pid_rusage(RUSAGE_INFO_V4) is expected to succeed for the "
+                  @"current process on iOS/simulator; got valid=false");
+    XCTAssertGreaterThan(snapshot.timestamp, 0.0);
+}
+
+- (void)testTimestampsAreMonotonicAcrossCaptures {
+    BSG_TEST_LOG(@"Step 1: capturing first snapshot");
+    BSGDiskIOSnapshot first = BSGCaptureDiskIOSnapshot();
+    BSG_TEST_LOG(@"Step 2: capturing second snapshot");
+    BSGDiskIOSnapshot second = BSGCaptureDiskIOSnapshot();
+    if (!first.valid || !second.valid) {
+        BSG_TEST_LOG(@"Step 3: SKIPPING assertion (one snapshot invalid: first=%d second=%d)",
+                     first.valid, second.valid);
+        return;
+    }
+    BSG_TEST_LOG(@"Step 3: asserting second.t (%.4f) >= first.t (%.4f)",
+                 second.timestamp, first.timestamp);
+    XCTAssertGreaterThanOrEqual(second.timestamp, first.timestamp);
+}
+
+- (void)testByteCountersAreMonotonicOverASmallWrite {
+    BSG_TEST_LOG(@"Step 1: capturing BEFORE snapshot");
+    BSGDiskIOSnapshot before = BSGCaptureDiskIOSnapshot();
+    if (!before.valid) {
+        BSG_TEST_LOG(@"Step 2: SKIPPING (before snapshot invalid)");
+        return;
+    }
+    BSG_TEST_LOG(@"Step 2: BEFORE bytesRead=%llu bytesWritten=%llu",
+                 (unsigned long long)before.bytesRead,
+                 (unsigned long long)before.bytesWritten);
+
+    // Force a small amount of real disk write to bump ri_diskio_byteswritten.
+    NSString *tmp = [NSTemporaryDirectory() stringByAppendingPathComponent:
+                     [NSString stringWithFormat:@"bsg-diskio-%u.bin", arc4random()]];
+    NSMutableData *payload = [NSMutableData dataWithLength:64 * 1024];
+    NSError *error = nil;
+    BSG_TEST_LOG(@"Step 3: writing 64 KB to %@", tmp);
+    [payload writeToFile:tmp options:NSDataWritingAtomic error:&error];
+    [[NSFileManager defaultManager] removeItemAtPath:tmp error:nil];
+
+    BSG_TEST_LOG(@"Step 4: capturing AFTER snapshot");
+    BSGDiskIOSnapshot after = BSGCaptureDiskIOSnapshot();
+    if (!after.valid) {
+        BSG_TEST_LOG(@"Step 5: SKIPPING (after snapshot invalid)");
+        return;
+    }
+    BSG_TEST_LOG(@"Step 5: AFTER bytesRead=%llu (delta=%lld) bytesWritten=%llu (delta=%lld)",
+                 (unsigned long long)after.bytesRead,
+                 (long long)after.bytesRead - (long long)before.bytesRead,
+                 (unsigned long long)after.bytesWritten,
+                 (long long)after.bytesWritten - (long long)before.bytesWritten);
+
+    // Counters are process-wide and monotonic: end must not go backwards.
+    XCTAssertGreaterThanOrEqual(after.bytesRead, before.bytesRead);
+    XCTAssertGreaterThanOrEqual(after.bytesWritten, before.bytesWritten);
+}
+
+@end

--- a/features/default/metrics/disk_iops_telemetry.feature
+++ b/features/default/metrics/disk_iops_telemetry.feature
@@ -1,0 +1,104 @@
+Feature: Spans with collected Disk IOPS metrics
+
+  Scenario: With default settings, disk IOPS metrics are disabled
+    Given I load scenario "DiskIOPSScenario"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.2"
+    And I configure scenario "disk_work_bytes" to "0"
+    And I configure scenario "variant_name" to "DefaultSettingsDiskDisabled"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * a span field "name" equals "DiskIOPSScenarioDefaultSettingsDiskDisabled"
+    * every span field "kind" equals 1
+    * every span attribute "bugsnag.system.disk.iops_read" does not exist
+    * every span attribute "bugsnag.system.disk.iops_write" does not exist
+    * every span attribute "bugsnag.system.disk.iops_total" does not exist
+
+  Scenario: When disk metrics are disabled, no attributes are produced no matter what
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "false"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.2"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_metrics_disk" to "yes"
+    And I configure scenario "variant_name" to "NoMetrics"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "DiskIOPSScenarioNoMetrics"
+    * every span attribute "bugsnag.system.disk.iops_read" does not exist
+    * every span attribute "bugsnag.system.disk.iops_write" does not exist
+    * every span attribute "bugsnag.system.disk.iops_total" does not exist
+
+  Scenario: First class spans produce disk IOPS attributes
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.2"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "FirstClass"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "DiskIOPSScenarioFirstClass"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * a span integer attribute "bugsnag.system.disk.iops_read" is greater than or equal to 0
+    * a span integer attribute "bugsnag.system.disk.iops_write" is greater than or equal to 0
+    * a span integer attribute "bugsnag.system.disk.iops_total" is greater than or equal to 0
+
+  Scenario: Non-first-class spans do not produce disk IOPS attributes by default
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.2"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "no"
+    And I configure scenario "variant_name" to "NonFirstClass"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "DiskIOPSScenarioNonFirstClass"
+    * every span bool attribute "bugsnag.span.first_class" is false
+    * every span attribute "bugsnag.system.disk.iops_read" does not exist
+    * every span attribute "bugsnag.system.disk.iops_write" does not exist
+    * every span attribute "bugsnag.system.disk.iops_total" does not exist
+
+  Scenario: When metrics.disk = yes, non-first-class spans still produce disk IOPS attributes
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.2"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "no"
+    And I configure scenario "opts_metrics_disk" to "yes"
+    And I configure scenario "variant_name" to "NonFirstClassWithMetrics"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "DiskIOPSScenarioNonFirstClassWithMetrics"
+    * every span bool attribute "bugsnag.span.first_class" is false
+    * a span integer attribute "bugsnag.system.disk.iops_read" is greater than or equal to 0
+    * a span integer attribute "bugsnag.system.disk.iops_write" is greater than or equal to 0
+    * a span integer attribute "bugsnag.system.disk.iops_total" is greater than or equal to 0
+
+  Scenario: When metrics.disk = no, first-class spans do not produce disk IOPS attributes
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.2"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "opts_metrics_disk" to "no"
+    And I configure scenario "variant_name" to "FirstClassWithMetricsOff"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "DiskIOPSScenarioFirstClassWithMetricsOff"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span attribute "bugsnag.system.disk.iops_read" does not exist
+    * every span attribute "bugsnag.system.disk.iops_write" does not exist
+    * every span attribute "bugsnag.system.disk.iops_total" does not exist
+

--- a/features/default/metrics/disk_iops_telemetry.feature
+++ b/features/default/metrics/disk_iops_telemetry.feature
@@ -1,5 +1,11 @@
 Feature: Spans with collected Disk IOPS metrics
 
+  # Note on value assertions:
+  # Disk byte counters are process-wide and best-effort. Some CI hosts /
+  # simulators legitimately report a zero delta over a short span, so the
+  # happy-path scenarios assert key presence, integer (OTEL intValue) typing
+  # and non-negativity rather than a strictly positive value.
+
   Scenario: With default settings, disk IOPS metrics are disabled
     Given I load scenario "DiskIOPSScenario"
     And I configure scenario "run_delay" to "0"
@@ -45,9 +51,9 @@ Feature: Spans with collected Disk IOPS metrics
     And I wait to receive at least 1 span
     Then a span field "name" equals "DiskIOPSScenarioFirstClass"
     * every span bool attribute "bugsnag.span.first_class" is true
-    * a span integer attribute "bugsnag.system.disk.iops_read" is greater than or equal to 0
-    * a span integer attribute "bugsnag.system.disk.iops_write" is greater than or equal to 0
-    * a span integer attribute "bugsnag.system.disk.iops_total" is greater than or equal to 0
+    * span integer attribute "bugsnag.system.disk.iops_read" should be greater than or equal to 0
+    * span integer attribute "bugsnag.system.disk.iops_write" should be greater than or equal to 0
+    * span integer attribute "bugsnag.system.disk.iops_total" should be greater than or equal to 0
 
   Scenario: Non-first-class spans do not produce disk IOPS attributes by default
     Given I load scenario "DiskIOPSScenario"
@@ -80,9 +86,9 @@ Feature: Spans with collected Disk IOPS metrics
     And I wait to receive at least 1 span
     Then a span field "name" equals "DiskIOPSScenarioNonFirstClassWithMetrics"
     * every span bool attribute "bugsnag.span.first_class" is false
-    * a span integer attribute "bugsnag.system.disk.iops_read" is greater than or equal to 0
-    * a span integer attribute "bugsnag.system.disk.iops_write" is greater than or equal to 0
-    * a span integer attribute "bugsnag.system.disk.iops_total" is greater than or equal to 0
+    * span integer attribute "bugsnag.system.disk.iops_read" should be greater than or equal to 0
+    * span integer attribute "bugsnag.system.disk.iops_write" should be greater than or equal to 0
+    * span integer attribute "bugsnag.system.disk.iops_total" should be greater than or equal to 0
 
   Scenario: When metrics.disk = no, first-class spans do not produce disk IOPS attributes
     Given I load scenario "DiskIOPSScenario"
@@ -102,3 +108,213 @@ Feature: Spans with collected Disk IOPS metrics
     * every span attribute "bugsnag.system.disk.iops_write" does not exist
     * every span attribute "bugsnag.system.disk.iops_total" does not exist
 
+  # PLAT-16902 - happy path across the full span lifecycle.
+  # A start snapshot, an end snapshot and a successful computation are all
+  # required for these three keys to appear on the exported span, so their
+  # presence on the completed span proves the whole lifecycle ran.
+  Scenario: Eligible span exports a complete, well-formed disk IOPS attribute set
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "1.0"
+    And I configure scenario "disk_work_bytes" to "1048576"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "HappyPath"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for exactly 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * a span field "name" equals "DiskIOPSScenarioHappyPath"
+    * every span field "kind" equals 1
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" matches the regex "com.bugsnag.fixtures.cocoaperformance(xcframework)?"
+    * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.cocoa"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    # All three keys present, integer-typed (intValue) and non-negative.
+    * span integer attribute "bugsnag.system.disk.iops_read" should be greater than or equal to 0
+    * span integer attribute "bugsnag.system.disk.iops_write" should be greater than or equal to 0
+    * span integer attribute "bugsnag.system.disk.iops_total" should be greater than or equal to 0
+    # total is emitted alongside, and consistent with, read + write.
+    * the span named "DiskIOPSScenarioHappyPath" integer attribute "bugsnag.system.disk.iops_total" equals the sum of integer attributes "bugsnag.system.disk.iops_read" and "bugsnag.system.disk.iops_write"
+
+  # PLAT-16903 - start snapshot unavailable.
+  # The span is opened before BugsnagPerformance.start(), so disk sampling is
+  # gated off and no start snapshot is stored. It is ended after start, when
+  # sampling is active, driving the real "no start snapshot" omission path.
+  Scenario: Span exports cleanly with no disk attributes when the start snapshot is unavailable
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.5"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "start_before_bugsnag_start" to "true"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "DiskIOPSScenarioEarlySpan"
+    * every span field "kind" equals 1
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * the span named "DiskIOPSScenarioEarlySpan" attribute "bugsnag.system.disk.iops_read" does not exist
+    * the span named "DiskIOPSScenarioEarlySpan" attribute "bugsnag.system.disk.iops_write" does not exist
+    * the span named "DiskIOPSScenarioEarlySpan" attribute "bugsnag.system.disk.iops_total" does not exist
+
+  # PLAT-16903 - start snapshot capture fails at the platform level.
+  Scenario: Span exports cleanly when start snapshot capture fails
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.5"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "disk_fault_mode" to "fail_start"
+    And I configure scenario "variant_name" to "StartSnapshotFailed"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for exactly 1 span
+    Then a span field "name" equals "DiskIOPSScenarioStartSnapshotFailed"
+    * every span field "kind" equals 1
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span attribute "bugsnag.system.disk.iops_read" does not exist
+    * every span attribute "bugsnag.system.disk.iops_write" does not exist
+    * every span attribute "bugsnag.system.disk.iops_total" does not exist
+
+  # PLAT-16904 - end snapshot unavailable. The start snapshot is captured and
+  # then consumed (and therefore cleaned up) before the end read is rejected.
+  Scenario: Span exports cleanly when end snapshot capture fails
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.5"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "disk_fault_mode" to "fail_end"
+    And I configure scenario "variant_name" to "EndSnapshotFailed"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for exactly 1 span
+    Then a span field "name" equals "DiskIOPSScenarioEndSnapshotFailed"
+    * every span field "kind" equals 1
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span attribute "bugsnag.system.disk.iops_read" does not exist
+    * every span attribute "bugsnag.system.disk.iops_write" does not exist
+    * every span attribute "bugsnag.system.disk.iops_total" does not exist
+
+  # PLAT-16905 - invalid duration (end timestamp == start timestamp).
+  Scenario: Span exports cleanly with no disk attributes when the computed duration is not positive
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.5"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "disk_fault_mode" to "zero_duration"
+    And I configure scenario "variant_name" to "ZeroDuration"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for exactly 1 span
+    Then a span field "name" equals "DiskIOPSScenarioZeroDuration"
+    * every span field "kind" equals 1
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span attribute "bugsnag.system.disk.iops_read" does not exist
+    * every span attribute "bugsnag.system.disk.iops_write" does not exist
+    * every span attribute "bugsnag.system.disk.iops_total" does not exist
+
+  # PLAT-16905 - counter regression / negative delta.
+  # By design this is clamped to zero rather than omitted, so the span must
+  # still export a valid, non-negative (zero) attribute set - never a negative
+  # or otherwise malformed value.
+  Scenario: Negative byte deltas are clamped to zero rather than exported as invalid values
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.5"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "disk_fault_mode" to "negative_delta"
+    And I configure scenario "variant_name" to "NegativeDelta"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for exactly 1 span
+    Then a span field "name" equals "DiskIOPSScenarioNegativeDelta"
+    * every span integer attribute "bugsnag.system.disk.iops_read" equals 0
+    * every span integer attribute "bugsnag.system.disk.iops_write" equals 0
+    * every span integer attribute "bugsnag.system.disk.iops_total" equals 0
+
+  # PLAT-16907 - overlapping spans keep independent snapshot state.
+  # Neither span is the other's parent, so a leaked/shared snapshot would show
+  # up as a missing or internally inconsistent attribute set on one of them.
+  Scenario: Concurrent overlapping spans each export their own disk IOPS attributes
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "0.5"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "concurrent" to "true"
+    And I configure scenario "variant_name" to "Concurrent"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait for exactly 2 spans
+    Then a span field "name" equals "DiskIOPSScenarioConcurrentA"
+    * a span field "name" equals "DiskIOPSScenarioConcurrentB"
+    * a span named "DiskIOPSScenarioConcurrentA" started before a span named "DiskIOPSScenarioConcurrentB"
+    * a span named "DiskIOPSScenarioConcurrentA" ended before a span named "DiskIOPSScenarioConcurrentB"
+    # Each span carries its own complete, self-consistent attribute set.
+    * the span named "DiskIOPSScenarioConcurrentA" integer attribute "bugsnag.system.disk.iops_read" is greater than or equal to 0
+    * the span named "DiskIOPSScenarioConcurrentA" integer attribute "bugsnag.system.disk.iops_write" is greater than or equal to 0
+    * the span named "DiskIOPSScenarioConcurrentA" integer attribute "bugsnag.system.disk.iops_total" equals the sum of integer attributes "bugsnag.system.disk.iops_read" and "bugsnag.system.disk.iops_write"
+    * the span named "DiskIOPSScenarioConcurrentB" integer attribute "bugsnag.system.disk.iops_read" is greater than or equal to 0
+    * the span named "DiskIOPSScenarioConcurrentB" integer attribute "bugsnag.system.disk.iops_write" is greater than or equal to 0
+    * the span named "DiskIOPSScenarioConcurrentB" integer attribute "bugsnag.system.disk.iops_total" equals the sum of integer attributes "bugsnag.system.disk.iops_read" and "bugsnag.system.disk.iops_write"
+
+  # PLAT-16906 - disk metrics coexist with the pre-existing resource metrics.
+  Scenario: Disk metrics do not displace existing CPU and memory metrics
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "true"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure bugsnag "memoryMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "1.5"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "AllMetrics"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "DiskIOPSScenarioAllMetrics"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    # Existing CPU payload shape is preserved. The exact sample count is timing
+    # dependent (and covered by metrics_cpu.feature); what matters here is that
+    # adding disk metrics does not drop or empty the existing attributes.
+    * the span named "DiskIOPSScenarioAllMetrics" array attribute "bugsnag.system.cpu_measures_total" is not empty
+    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
+    * the span named "DiskIOPSScenarioAllMetrics" array attribute "bugsnag.system.cpu_measures_main_thread" is not empty
+    # Existing memory payload shape is preserved.
+    * the span named "DiskIOPSScenarioAllMetrics" array attribute "bugsnag.system.memory.timestamps" is not empty
+    * span integer attribute "bugsnag.system.memory.spaces.device.size" should be greater than 0
+    * the span named "DiskIOPSScenarioAllMetrics" array attribute "bugsnag.system.memory.spaces.device.used" is not empty
+    # And disk metrics are added alongside them.
+    * span integer attribute "bugsnag.system.disk.iops_total" should be greater than or equal to 0
+
+  # PLAT-16906 - the non-disk code path is unaffected when disk is off.
+  Scenario: Existing CPU and memory metrics are unchanged for spans without disk metrics
+    Given I load scenario "DiskIOPSScenario"
+    And I configure bugsnag "diskMetrics" to "false"
+    And I configure bugsnag "cpuMetrics" to "true"
+    And I configure bugsnag "memoryMetrics" to "true"
+    And I configure scenario "run_delay" to "0"
+    And I configure scenario "span_duration" to "1.5"
+    And I configure scenario "disk_work_bytes" to "524288"
+    And I configure scenario "opts_first_class" to "yes"
+    And I configure scenario "variant_name" to "NoDiskMetricsRegression"
+    And I start bugsnag
+    And I run the loaded scenario
+    And I wait to receive at least 1 span
+    Then a span field "name" equals "DiskIOPSScenarioNoDiskMetricsRegression"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * the span named "DiskIOPSScenarioNoDiskMetricsRegression" array attribute "bugsnag.system.cpu_measures_total" is not empty
+    * a span float attribute "bugsnag.system.cpu_mean_total" is greater than 0.0
+    * the span named "DiskIOPSScenarioNoDiskMetricsRegression" array attribute "bugsnag.system.memory.timestamps" is not empty
+    * span integer attribute "bugsnag.system.memory.spaces.device.size" should be greater than 0
+    * every span attribute "bugsnag.system.disk.iops_read" does not exist
+    * every span attribute "bugsnag.system.disk.iops_write" does not exist
+    * every span attribute "bugsnag.system.disk.iops_total" does not exist

--- a/features/default/resource-usage-aggregation-extended.feature
+++ b/features/default/resource-usage-aggregation-extended.feature
@@ -24,12 +24,12 @@ Feature: Foreground App Session Span - Extended Validations
     * span float attribute "bugsnag.system.cpu_mean_overhead" should be greater than 0.0
     * span float attribute "bugsnag.system.cpu_max_overhead" should be greater than 0.0
     # All CPU attributes < 100
-    * span float attribute "bugsnag.system.cpu_mean_total" should be less than 100.0
-    * span float attribute "bugsnag.system.cpu_max_total" should be less than 100.0
-    * span float attribute "bugsnag.system.cpu_mean_main_thread" should be less than 100.0
-    * span float attribute "bugsnag.system.cpu_max_main_thread" should be less than 100.0
-    * span float attribute "bugsnag.system.cpu_mean_overhead" should be less than 100.0
-    * span float attribute "bugsnag.system.cpu_max_overhead" should be less than 100.0
+    * span float attribute "bugsnag.system.cpu_mean_total" should be less than 101.0
+    * span float attribute "bugsnag.system.cpu_max_total" should be less than 101.0
+    * span float attribute "bugsnag.system.cpu_mean_main_thread" should be less than 101.0
+    * span float attribute "bugsnag.system.cpu_max_main_thread" should be less than 101.0
+    * span float attribute "bugsnag.system.cpu_mean_overhead" should be less than 101.0
+    * span float attribute "bugsnag.system.cpu_max_overhead" should be less than 101.0
     # min ≤ mean ≤ max for all CPU fields
     * a span float attribute "bugsnag.system.cpu_min_total" is less than or equal to span float attribute "bugsnag.system.cpu_mean_total"
     * a span float attribute "bugsnag.system.cpu_mean_total" is less than or equal to span float attribute "bugsnag.system.cpu_max_total"

--- a/features/default/resource-usage-aggregation-extended.feature
+++ b/features/default/resource-usage-aggregation-extended.feature
@@ -24,12 +24,12 @@ Feature: Foreground App Session Span - Extended Validations
     * span float attribute "bugsnag.system.cpu_mean_overhead" should be greater than 0.0
     * span float attribute "bugsnag.system.cpu_max_overhead" should be greater than 0.0
     # All CPU attributes < 100
-    * span float attribute "bugsnag.system.cpu_mean_total" should be less than 101.0
-    * span float attribute "bugsnag.system.cpu_max_total" should be less than 101.0
-    * span float attribute "bugsnag.system.cpu_mean_main_thread" should be less than 101.0
-    * span float attribute "bugsnag.system.cpu_max_main_thread" should be less than 101.0
-    * span float attribute "bugsnag.system.cpu_mean_overhead" should be less than 101.0
-    * span float attribute "bugsnag.system.cpu_max_overhead" should be less than 101.0
+    * span float attribute "bugsnag.system.cpu_mean_total" should be less than 100.0
+    * span float attribute "bugsnag.system.cpu_max_total" should be less than 100.0
+    * span float attribute "bugsnag.system.cpu_mean_main_thread" should be less than 100.0
+    * span float attribute "bugsnag.system.cpu_max_main_thread" should be less than 100.0
+    * span float attribute "bugsnag.system.cpu_mean_overhead" should be less than 100.0
+    * span float attribute "bugsnag.system.cpu_max_overhead" should be less than 100.0
     # min ≤ mean ≤ max for all CPU fields
     * a span float attribute "bugsnag.system.cpu_min_total" is less than or equal to span float attribute "bugsnag.system.cpu_mean_total"
     * a span float attribute "bugsnag.system.cpu_mean_total" is less than or equal to span float attribute "bugsnag.system.cpu_max_total"

--- a/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/Fixture.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		09F025152BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */; };
 		09F23AC12CF0CBB500F0D769 /* AutoInstrumentGenericViewLoadScenario2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F23AC02CF0CBB500F0D769 /* AutoInstrumentGenericViewLoadScenario2.swift */; };
 		09F3F5282D6C728300BAA0A3 /* MemoryMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F3F5272D6C728300BAA0A3 /* MemoryMetricsScenario.swift */; };
+		32083092301FFEBE00E0958A /* DiskIOPSScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32083091301FFEBC00E0958A /* DiskIOPSScenario.swift */; };
 		09F3F5302D6F17B300BAA0A3 /* RenderingMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F3F52F2D6F17B300BAA0A3 /* RenderingMetricsScenario.swift */; };
 		1C377BA02E78BDFE002148B2 /* StartupConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C377B9F2E78BDF8002148B2 /* StartupConfiguration.swift */; };
 		1C7852A62E5FA7DF00BB8E2D /* ManualSpanWithContextParentNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7852A52E5FA7C700BB8E2D /* ManualSpanWithContextParentNilScenario.swift */; };
@@ -187,6 +188,7 @@
 		09F025142BAC50EC007D9F73 /* ViewDidLoadDoesntTriggerScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDidLoadDoesntTriggerScenario.swift; sourceTree = "<group>"; };
 		09F23AC02CF0CBB500F0D769 /* AutoInstrumentGenericViewLoadScenario2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentGenericViewLoadScenario2.swift; sourceTree = "<group>"; };
 		09F3F5272D6C728300BAA0A3 /* MemoryMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryMetricsScenario.swift; sourceTree = "<group>"; };
+		32083091301FFEBC00E0958A /* DiskIOPSScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskIOPSScenario.swift; sourceTree = "<group>"; };
 		09F3F52F2D6F17B300BAA0A3 /* RenderingMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderingMetricsScenario.swift; sourceTree = "<group>"; };
 		1C377B9F2E78BDF8002148B2 /* StartupConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupConfiguration.swift; sourceTree = "<group>"; };
 		1C7852A52E5FA7C700BB8E2D /* ManualSpanWithContextParentNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanWithContextParentNilScenario.swift; sourceTree = "<group>"; };
@@ -390,6 +392,7 @@
 				969EE0E12E784E6400600F63 /* ConditionsOverrideEndTimeBackwardsScenario.swift */,
 				098FC87B2D40EAB8001B627D /* CPUMetricsScenario.swift */,
 				1C8CB8C02EC3C970007BF492 /* DebugModeScenario.swift */,
+				32083091301FFEBC00E0958A /* DiskIOPSScenario.swift */,
 				09DC62292C6DE242000AA8E1 /* EarlySpanOnEndScenario.swift */,
 				CBC90CDD29CDCFF700280884 /* FirstClassNoScenario.swift */,
 				CBC90CDF29CDD02800280884 /* FirstClassYesScenario.swift */,
@@ -585,6 +588,7 @@
 				01A58C1529096AF4006E4DF7 /* SamplingProbabilityZeroScenario.swift in Sources */,
 				CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */,
 				09F3F5282D6C728300BAA0A3 /* MemoryMetricsScenario.swift in Sources */,
+				32083092301FFEBE00E0958A /* DiskIOPSScenario.swift in Sources */,
 				966634DE2C9DE2E0004A934D /* FrameMetricsFronzenFramesScenario.swift in Sources */,
 				09E9BDAF2C80907B00DC7C8E /* ModifyEarlySpansScenario.swift in Sources */,
 				1C8CB8C12EC3C975007BF492 /* DebugModeScenario.swift in Sources */,

--- a/features/fixtures/ios/Fixture/StartupEnabledMetrics.swift
+++ b/features/fixtures/ios/Fixture/StartupEnabledMetrics.swift
@@ -12,10 +12,12 @@ class StartupEnabledMetrics: Codable {
     public var rendering: Bool
     public var cpu: Bool
     public var memory: Bool
+    public var disk: Bool
 
     init() {
         self.rendering = false
         self.cpu = false
         self.memory = false
+        self.disk = false
     }
 }

--- a/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/FixtureXcFramework.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		1C3E2DB42EAA5F4900B32AD2 /* AutoInstrumentGenericViewLoadScenario2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C3E2DAF2EAA5F4900B32AD2 /* AutoInstrumentGenericViewLoadScenario2.swift */; };
 		1C8CB8C32EC3D0D2007BF492 /* DebugModeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C8CB8C22EC3D0D2007BF492 /* DebugModeScenario.swift */; };
 		1CA34CAB2E81A09F00512E2F /* StartupConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA34CAA2E81A09F00512E2F /* StartupConfiguration.swift */; };
+		32083092301FFEBE00E0958A /* DiskIOPSScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32083091301FFEBC00E0958A /* DiskIOPSScenario.swift */; };
 		55A1B7CB2CBFF140009D68A7 /* BugsnagPerformance.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55A1B7C92CBFF140009D68A7 /* BugsnagPerformance.xcframework */; };
 		55A1B7CC2CBFF140009D68A7 /* BugsnagPerformance.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 55A1B7C92CBFF140009D68A7 /* BugsnagPerformance.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		55A1B7CD2CBFF140009D68A7 /* BugsnagPerformanceSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55A1B7CA2CBFF140009D68A7 /* BugsnagPerformanceSwift.xcframework */; };
@@ -103,9 +104,9 @@
 		96EB8B522EB277CE00DDBF86 /* StartupEnabledMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EB8B512EB277CE00DDBF86 /* StartupEnabledMetrics.swift */; };
 		96F129332DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F129322DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift */; };
 		96F5268C2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */; };
+		96F9010B2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F9010A2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */; };
 		96F901152EE81E6D0026F5B9 /* BackgroundThreadStartScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F901142EE81E6D0026F5B9 /* BackgroundThreadStartScenario.swift */; };
 		96F901192EE836E10026F5B9 /* ManualParentBlockedSpanScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F901182EE836E10026F5B9 /* ManualParentBlockedSpanScenario.swift */; };
-		96F9010B2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F9010A2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */; };
 		CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */; };
 		CB0AD76E2965BBDA002A3FB6 /* InitialPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */; };
 		CB2B8A9D2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2B8A9C2A0CCEF90054FBBE /* AutoInstrumentFileURLRequestScenario.swift */; };
@@ -210,6 +211,7 @@
 		1C3E2DB02EAA5F4900B32AD2 /* ManualSpanWithRemoteContextParentScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSpanWithRemoteContextParentScenario.swift; sourceTree = "<group>"; };
 		1C8CB8C22EC3D0D2007BF492 /* DebugModeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugModeScenario.swift; sourceTree = "<group>"; };
 		1CA34CAA2E81A09F00512E2F /* StartupConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupConfiguration.swift; sourceTree = "<group>"; };
+		32083091301FFEBC00E0958A /* DiskIOPSScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskIOPSScenario.swift; sourceTree = "<group>"; };
 		55A1B7C92CBFF140009D68A7 /* BugsnagPerformance.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BugsnagPerformance.xcframework; path = ../../../BugsnagPerformance.xcframework; sourceTree = "<group>"; };
 		55A1B7CA2CBFF140009D68A7 /* BugsnagPerformanceSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BugsnagPerformanceSwift.xcframework; path = ../../../BugsnagPerformanceSwift.xcframework; sourceTree = "<group>"; };
 		960EECE82B2316E1009FAA11 /* AutoInstrumentGenericViewLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentGenericViewLoadScenario.swift; sourceTree = "<group>"; };
@@ -251,9 +253,9 @@
 		96EB8B512EB277CE00DDBF86 /* StartupEnabledMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupEnabledMetrics.swift; sourceTree = "<group>"; };
 		96F129322DCE0CDD00A6FB2B /* RenderingMetricsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderingMetricsScenario.swift; sourceTree = "<group>"; };
 		96F5268B2C259E4E0095D600 /* ManualNetworkSpanCallbackSetToNilScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNetworkSpanCallbackSetToNilScenario.swift; sourceTree = "<group>"; };
+		96F9010A2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkEarlyCallbackScenario.swift; sourceTree = "<group>"; };
 		96F901142EE81E6D0026F5B9 /* BackgroundThreadStartScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundThreadStartScenario.swift; sourceTree = "<group>"; };
 		96F901182EE836E10026F5B9 /* ManualParentBlockedSpanScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualParentBlockedSpanScenario.swift; sourceTree = "<group>"; };
-		96F9010A2EE7B81F0026F5B9 /* AutoInstrumentNetworkEarlyCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoInstrumentNetworkEarlyCallbackScenario.swift; sourceTree = "<group>"; };
 		CB0496932913CA300097E526 /* BatchingWithTimeoutScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchingWithTimeoutScenario.swift; sourceTree = "<group>"; };
 		CB0AD76D2965BBDA002A3FB6 /* InitialPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPScenario.swift; sourceTree = "<group>"; };
 		CB211D0629EEB615008F748D /* BugsnagPerformanceConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "BugsnagPerformanceConfiguration+Private.h"; path = "../../../../Sources/BugsnagPerformance/Private/BugsnagPerformanceConfiguration+Private.h"; sourceTree = "<group>"; };
@@ -366,6 +368,7 @@
 		01FE4DC128E1AF0700D1F239 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				32083091301FFEBC00E0958A /* DiskIOPSScenario.swift */,
 				E1A5A6402FE052BB00A663EA /* AppSessionResourceUsageScenario.swift */,
 				96D528CB2C72B14300FEA2E2 /* AppDataOverrideScenario.swift */,
 				96D090D62EEB3E1D00BAA6D4 /* AppStartInterruptedScenario.swift */,
@@ -634,6 +637,7 @@
 				1C3E2DB42EAA5F4900B32AD2 /* AutoInstrumentGenericViewLoadScenario2.swift in Sources */,
 				09301DC12B63A65A000A7C12 /* ComplexViewScenario.swift in Sources */,
 				96D528CE2C75DC7000FEA2E2 /* FixedSamplingProbabilityOneScenario.swift in Sources */,
+				32083092301FFEBE00E0958A /* DiskIOPSScenario.swift in Sources */,
 				CB0496942913CA300097E526 /* BatchingWithTimeoutScenario.swift in Sources */,
 				967F6F1A29C4AD300054EED8 /* ReleaseStageNotEnabledScenario.swift in Sources */,
 				96EB8B522EB277CE00DDBF86 /* StartupEnabledMetrics.swift in Sources */,

--- a/features/fixtures/ios/Scenarios/DiskIOPSScenario.swift
+++ b/features/fixtures/ios/Scenarios/DiskIOPSScenario.swift
@@ -10,6 +10,15 @@ import BugsnagPerformance
 @objcMembers
 class DiskIOPSScenario: Scenario {
 
+    override func setInitialBugsnagConfiguration() {
+        super.setInitialBugsnagConfiguration()
+        // Pin the sampling probability for this scenario so the span is
+        // always delivered, regardless of any P value persisted by a
+        // previously-run scenario (same pattern as
+        // FixedSamplingProbabilityOneScenario).
+        bugsnagPerfConfig.samplingProbability = 1.0
+    }
+
     override func run() {
         let runDelay = toDouble(string: scenarioConfig["run_delay"])
         if runDelay > 0 {

--- a/features/fixtures/ios/Scenarios/DiskIOPSScenario.swift
+++ b/features/fixtures/ios/Scenarios/DiskIOPSScenario.swift
@@ -10,15 +10,6 @@ import BugsnagPerformance
 @objcMembers
 class DiskIOPSScenario: Scenario {
 
-    override func setInitialBugsnagConfiguration() {
-        super.setInitialBugsnagConfiguration()
-        // Pin the sampling probability for this scenario so the span is
-        // always delivered, regardless of any P value persisted by a
-        // previously-run scenario (same pattern as
-        // FixedSamplingProbabilityOneScenario).
-        bugsnagPerfConfig.samplingProbability = 1.0
-    }
-
     override func run() {
         let runDelay = toDouble(string: scenarioConfig["run_delay"])
         if runDelay > 0 {

--- a/features/fixtures/ios/Scenarios/DiskIOPSScenario.swift
+++ b/features/fixtures/ios/Scenarios/DiskIOPSScenario.swift
@@ -9,10 +9,16 @@ import BugsnagPerformance
 
 @objcMembers
 class DiskIOPSScenario: Scenario {
+
     override func run() {
         let runDelay = toDouble(string: scenarioConfig["run_delay"])
-        DispatchQueue.main.asyncAfter(deadline: .now() + runDelay) {
-            self.delayedRun()
+        if runDelay > 0 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + runDelay) {
+                self.delayedRun()
+            }
+        } else {
+            // Run synchronously when delay is 0 so there is no timing gap.
+            delayedRun()
         }
     }
 
@@ -23,7 +29,7 @@ class DiskIOPSScenario: Scenario {
         let span = BugsnagPerformance.startSpan(name: spanName, options: opts)
 
         // Produce some disk activity inside the span so the byte counters
-        // have a chance to advance. Best-effort — some hosts may still show
+        // have a chance to advance. Best-effort - some hosts may still show
         // zero deltas.
         let workBytes = Int(toDouble(string: scenarioConfig["disk_work_bytes"]))
         if workBytes > 0 {
@@ -31,8 +37,15 @@ class DiskIOPSScenario: Scenario {
         }
 
         let spanDuration = toDouble(string: scenarioConfig["span_duration"])
+
+        // End span + wait for batch flush to guarantee Maze Runner receives
+        // the trace before the 30s step timeout.
         DispatchQueue.main.asyncAfter(deadline: .now() + spanDuration) {
-            span.end();
+            span.end()
+            // Give the SDK time to package and upload the batch.
+            DispatchQueue.global().asyncAfter(deadline: .now() + 1.5) {
+                self.waitForCurrentBatch()
+            }
         }
     }
 

--- a/features/fixtures/ios/Scenarios/DiskIOPSScenario.swift
+++ b/features/fixtures/ios/Scenarios/DiskIOPSScenario.swift
@@ -1,0 +1,51 @@
+//
+//  DiskIOPSScenario.swift
+//  Fixture
+//
+//  Created by gaurav agarawal on 03/08/26.
+//
+
+import BugsnagPerformance
+
+@objcMembers
+class DiskIOPSScenario: Scenario {
+    override func run() {
+        let runDelay = toDouble(string: scenarioConfig["run_delay"])
+        DispatchQueue.main.asyncAfter(deadline: .now() + runDelay) {
+            self.delayedRun()
+        }
+    }
+
+    func delayedRun() {
+        let opts = BugsnagPerformanceSpanOptions()
+        opts.setFirstClass(toTriState(string: scenarioConfig["opts_first_class"]))
+        opts.metricsOptions.disk = toTriState(string: scenarioConfig["opts_metrics_disk"])
+        let span = BugsnagPerformance.startSpan(name: spanName, options: opts)
+
+        // Produce some disk activity inside the span so the byte counters
+        // have a chance to advance. Best-effort — some hosts may still show
+        // zero deltas.
+        let workBytes = Int(toDouble(string: scenarioConfig["disk_work_bytes"]))
+        if workBytes > 0 {
+            self.doDiskWork(bytes: workBytes)
+        }
+
+        let spanDuration = toDouble(string: scenarioConfig["span_duration"])
+        DispatchQueue.main.asyncAfter(deadline: .now() + spanDuration) {
+            span.end();
+        }
+    }
+
+    func doDiskWork(bytes: Int) {
+        let payload = Data(count: bytes)
+        let dir = FileManager.default.temporaryDirectory
+        let path = dir.appendingPathComponent("bsg-disk-iops-\(UUID().uuidString).bin")
+        do {
+            try payload.write(to: path, options: [.atomic])
+            _ = try? Data(contentsOf: path)
+            try? FileManager.default.removeItem(at: path)
+        } catch {
+            logError("DiskIOPSScenario: disk work failed: \(error)")
+        }
+    }
+}

--- a/features/fixtures/ios/Scenarios/DiskIOPSScenario.swift
+++ b/features/fixtures/ios/Scenarios/DiskIOPSScenario.swift
@@ -10,6 +10,37 @@ import BugsnagPerformance
 @objcMembers
 class DiskIOPSScenario: Scenario {
 
+    /// Name used by the "span started before BugsnagPerformance.start()" mode.
+    /// Fixed rather than derived from `spanName` because the span is created
+    /// before `variant_name` is meaningful for this path.
+    static let earlySpanName = "DiskIOPSScenarioEarlySpan"
+
+    /// Raw values of `BSGDiskIOSnapshotFaultMode` (see `BSGDiskIOCollector.h`).
+    /// The enum is not exposed to Swift, so the raw bitmask is used.
+    private static let faultModeNone: UInt = 0
+    private static let faultModeFailAtStart: UInt = 1 << 0
+    private static let faultModeFailAtEnd: UInt = 1 << 1
+    private static let faultModeZeroDuration: UInt = 1 << 2
+    private static let faultModeNegativeDelta: UInt = 1 << 3
+
+    /// Span opened before Bugsnag was started (see `start_before_bugsnag_start`).
+    private var earlySpan: BugsnagPerformanceSpan?
+
+    override func startBugsnag() {
+        applyFaultMode()
+        // Opening the span here keeps it strictly before `BugsnagPerformance.start()`.
+        // Disk sampling is gated behind `isStarted_`, so no start snapshot can be
+        // captured — this drives the real "start snapshot unavailable" path
+        // without any fault injection.
+        if toBool(string: scenarioConfig["start_before_bugsnag_start"]) {
+            let opts = BugsnagPerformanceSpanOptions()
+            opts.setFirstClass(.yes)
+            opts.setMakeCurrentContext(false)
+            earlySpan = BugsnagPerformance.startSpan(name: DiskIOPSScenario.earlySpanName, options: opts)
+        }
+        super.startBugsnag()
+    }
+
     override func run() {
         let runDelay = toDouble(string: scenarioConfig["run_delay"])
         if runDelay > 0 {
@@ -23,18 +54,29 @@ class DiskIOPSScenario: Scenario {
     }
 
     func delayedRun() {
+        if let earlySpan = earlySpan {
+            runEarlySpanMode(span: earlySpan)
+            return
+        }
+        if toBool(string: scenarioConfig["concurrent"]) {
+            runConcurrentMode()
+            return
+        }
+        runSingleSpanMode()
+    }
+
+    // MARK: - Modes
+
+    private func runSingleSpanMode() {
         let opts = BugsnagPerformanceSpanOptions()
         opts.setFirstClass(toTriState(string: scenarioConfig["opts_first_class"]))
         opts.metricsOptions.disk = toTriState(string: scenarioConfig["opts_metrics_disk"])
         let span = BugsnagPerformance.startSpan(name: spanName, options: opts)
 
-        // Produce some disk activity inside the span so the byte counters
-        // have a chance to advance. Best-effort - some hosts may still show
-        // zero deltas.
-        let workBytes = Int(toDouble(string: scenarioConfig["disk_work_bytes"]))
-        if workBytes > 0 {
-            self.doDiskWork(bytes: workBytes)
-        }
+        // Produce some disk activity inside the span so the byte counters have a
+        // chance to advance. Best-effort - some hosts may still show zero deltas,
+        // so assertions must not require strictly > 0 values.
+        doConfiguredDiskWork()
 
         let spanDuration = toDouble(string: scenarioConfig["span_duration"])
 
@@ -42,10 +84,93 @@ class DiskIOPSScenario: Scenario {
         // the trace before the 30s step timeout.
         DispatchQueue.main.asyncAfter(deadline: .now() + spanDuration) {
             span.end()
-            // Give the SDK time to package and upload the batch.
-            DispatchQueue.global().asyncAfter(deadline: .now() + 1.5) {
-                self.waitForCurrentBatch()
+            self.flushAfterDelay()
+        }
+    }
+
+    /// Ends a span that was started before `BugsnagPerformance.start()`.
+    /// The collector holds no start snapshot for it, so the end path must omit
+    /// all disk attributes while still exporting the span intact.
+    private func runEarlySpanMode(span: BugsnagPerformanceSpan) {
+        doConfiguredDiskWork()
+        let spanDuration = toDouble(string: scenarioConfig["span_duration"])
+        DispatchQueue.main.asyncAfter(deadline: .now() + spanDuration) {
+            span.end()
+            self.earlySpan = nil
+            self.flushAfterDelay()
+        }
+    }
+
+    /// Two deliberately overlapping spans, each with its own start snapshot.
+    /// Neither is the other's parent (`makeCurrentContext = false`) so a snapshot
+    /// leak between them would be observable in the exported payload.
+    private func runConcurrentMode() {
+        let spanA = BugsnagPerformance.startSpan(name: spanName + "A", options: concurrentSpanOptions())
+        doConfiguredDiskWork()
+
+        let spanB = BugsnagPerformance.startSpan(name: spanName + "B", options: concurrentSpanOptions())
+        doConfiguredDiskWork()
+
+        // Clamp so the overlap window is always observable even if the feature
+        // file passes a very small duration.
+        let spanDuration = max(toDouble(string: scenarioConfig["span_duration"]), 0.2)
+
+        // A starts first and ends first; B stays open across the remainder,
+        // guaranteeing a real overlap window between the two spans.
+        DispatchQueue.main.asyncAfter(deadline: .now() + spanDuration) {
+            spanA.end()
+            self.doConfiguredDiskWork()
+            DispatchQueue.main.asyncAfter(deadline: .now() + spanDuration) {
+                spanB.end()
+                self.flushAfterDelay()
             }
+        }
+    }
+
+    private func concurrentSpanOptions() -> BugsnagPerformanceSpanOptions {
+        let opts = BugsnagPerformanceSpanOptions()
+        opts.setFirstClass(toTriState(string: scenarioConfig["opts_first_class"]))
+        opts.metricsOptions.disk = toTriState(string: scenarioConfig["opts_metrics_disk"])
+        opts.setMakeCurrentContext(false)
+        return opts
+    }
+
+    // MARK: - Helpers
+
+    /// Maps the `disk_fault_mode` scenario config onto the internal test-only
+    /// fault mask. Must run before `BugsnagPerformance.start()`.
+    private func applyFaultMode() {
+        let mode = scenarioConfig["disk_fault_mode"] ?? "none"
+        let mask: UInt
+        switch mode {
+        case "none":
+            mask = DiskIOPSScenario.faultModeNone
+        case "fail_start":
+            mask = DiskIOPSScenario.faultModeFailAtStart
+        case "fail_end":
+            mask = DiskIOPSScenario.faultModeFailAtEnd
+        case "zero_duration":
+            mask = DiskIOPSScenario.faultModeZeroDuration
+        case "negative_delta":
+            mask = DiskIOPSScenario.faultModeNegativeDelta
+        default:
+            fatalError("\(mode): Unknown disk_fault_mode")
+        }
+        bugsnagPerfConfig.internal.diskIOSnapshotFaultMode = mask
+        logDebug("DiskIOPSScenario: diskIOSnapshotFaultMode = \(mask)")
+    }
+
+    private func doConfiguredDiskWork() {
+        let workBytes = Int(toDouble(string: scenarioConfig["disk_work_bytes"]))
+        if workBytes > 0 {
+            doDiskWork(bytes: workBytes)
+        }
+    }
+
+    private func flushAfterDelay() {
+        // Give the SDK time to package and upload the batch.
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1.5) {
+            self.waitForCurrentBatch()
         }
     }
 

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -71,6 +71,7 @@ class Scenario: NSObject {
         bugsnagPerfConfig.enabledMetrics.rendering = startupConfig.enabledMetrics.rendering
         bugsnagPerfConfig.enabledMetrics.cpu = startupConfig.enabledMetrics.cpu
         bugsnagPerfConfig.enabledMetrics.memory = startupConfig.enabledMetrics.memory
+        bugsnagPerfConfig.enabledMetrics.disk = startupConfig.enabledMetrics.disk
     }
 
     func urlHasAnyPrefixIn(url: URL, prefixes: [URL]) -> Bool {
@@ -135,6 +136,10 @@ class Scenario: NSObject {
         case "memoryMetrics":
             bugsnagPerfConfig.enabledMetrics.memory = (value == "true")
             logDebug("config.enabledMetrics.memory = \(bugsnagPerfConfig.enabledMetrics.memory)")
+            break
+        case "diskMetrics":
+            bugsnagPerfConfig.enabledMetrics.disk = (value == "true")
+            logDebug("config.enabledMetrics.disk = \(bugsnagPerfConfig.enabledMetrics.disk)")
             break
         case "renderingMetrics":
             bugsnagPerfConfig.enabledMetrics.rendering = (value == "true")

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -34,6 +34,7 @@ class Scenario: NSObject {
         logDebug("Scenario.setInitialBugsnagConfiguration()")
         bugsnagPerfConfig.internal.clearPersistenceOnStart = true
         bugsnagPerfConfig.internal.autoTriggerExportOnBatchSize = 1
+        bugsnagPerfConfig.samplingProbability = 1.0
         bugsnagPerfConfig.apiKey = "12312312312312312312312312312312"
         bugsnagPerfConfig.autoInstrumentAppStarts = false
         bugsnagPerfConfig.autoInstrumentAppStartsLegacy = false

--- a/features/fixtures/ios/Scenarios/Scenario.swift
+++ b/features/fixtures/ios/Scenarios/Scenario.swift
@@ -34,7 +34,6 @@ class Scenario: NSObject {
         logDebug("Scenario.setInitialBugsnagConfiguration()")
         bugsnagPerfConfig.internal.clearPersistenceOnStart = true
         bugsnagPerfConfig.internal.autoTriggerExportOnBatchSize = 1
-        bugsnagPerfConfig.samplingProbability = 1.0
         bugsnagPerfConfig.apiKey = "12312312312312312312312312312312"
         bugsnagPerfConfig.autoInstrumentAppStarts = false
         bugsnagPerfConfig.autoInstrumentAppStartsLegacy = false

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -206,8 +206,8 @@ end
 Then('a span integer attribute {string} is greater than or equal to {int}') do |attribute, expected|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') } }.compact
-  attribute_values = selected_attributes.map { |a| a['value']['intValue'].to_i >= expected }
-  Maze.check.false(attribute_values.empty?)
+  Maze.check.false(selected_attributes.empty?)
+  Maze.check.true(selected_attributes.any? { |a| a['value']['intValue'].to_i >= expected })
 end
 
 Then('a span integer attribute {string} equals {int}') do |attribute, expected|

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -203,6 +203,13 @@ Then('a span integer attribute {string} is greater than {int}') do |attribute, e
   Maze.check.false(attribute_values.empty?)
 end
 
+Then('a span integer attribute {string} is greater than or equal to {int}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') } }.compact
+  attribute_values = selected_attributes.map { |a| a['value']['intValue'].to_i >= expected }
+  Maze.check.false(attribute_values.empty?)
+end
+
 Then('a span integer attribute {string} equals {int}') do |attribute, expected|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') } }.compact

--- a/features/steps/hooks.rb
+++ b/features/steps/hooks.rb
@@ -9,12 +9,23 @@ Maze.hooks.after do |scenario|
 
   case Maze::Helper.get_current_platform
   when 'ios'
-    # get_log can be slow (1 or 2 seconds) on device farms
+    # get_logs can be slow (1 or 2 seconds) on device farms
     if scenario.failed? || Maze.config.farm == :local
-      FileUtils.makedirs(path)
-      File.open(File.join(path, 'syslog.log'), 'wb') do |file|
+      begin
         manager = Maze::Api::Appium::DeviceManager.new
-        manager.get_log('syslog').each { |entry| file.puts entry.message }
+        # `get_log` was renamed to `get_logs` in Maze Runner 11.
+        entries = if manager.respond_to?(:get_logs)
+                    manager.get_logs('syslog')
+                  else
+                    manager.get_log('syslog')
+                  end
+        FileUtils.makedirs(path)
+        File.open(File.join(path, 'syslog.log'), 'wb') do |file|
+          entries.each { |entry| file.puts entry.message }
+        end
+      rescue StandardError => e
+        # Never let log collection mask the actual scenario result.
+        $logger.warn "Unable to capture device syslog: #{e.class}: #{e.message}"
       end
     end
   end

--- a/features/steps/span_integer_steps.rb
+++ b/features/steps/span_integer_steps.rb
@@ -96,3 +96,62 @@ Then('span float attribute {string} should be less than {float}') do |attribute,
   end
   Maze.check.true(found, "No span found with attribute '#{attribute}'.")
 end
+
+# Strict integer >= check. The `a span integer attribute ... is greater than or
+# equal to ...` step in app_steps.rb only asserts that the attribute exists, so
+# this variant is used where the value itself must be validated.
+Then('span integer attribute {string} should be greater than or equal to {int}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') } }.compact
+  Maze.check.false(selected_attributes.empty?, "No span found with integer attribute '#{attribute}'")
+  selected_attributes.each do |a|
+    val = a['value']['intValue'].to_i
+    Maze.check.true(val >= expected, "Expected #{attribute} (#{val}) >= #{expected}")
+  end
+end
+
+Then('every span integer attribute {string} equals {int}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') } }.compact
+  Maze.check.false(selected_attributes.empty?, "No span found with integer attribute '#{attribute}'")
+  selected_attributes.each do |a|
+    val = a['value']['intValue'].to_i
+    Maze.check.true(val == expected, "Expected #{attribute} (#{val}) == #{expected}")
+  end
+end
+
+# Named-span variants, needed to assert per-span independence for concurrent spans.
+def span_named(name)
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  span = spans.find { |s| s['name'] == name }
+  raise Test::Unit::AssertionFailedError, "No span named '#{name}' was received" if span.nil?
+  span
+end
+
+def named_span_int_attribute(name, attribute)
+  span = span_named(name)
+  attr = (span['attributes'] || []).find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') }
+  raise Test::Unit::AssertionFailedError, "Span '#{name}' has no integer attribute '#{attribute}'" if attr.nil?
+  attr['value']['intValue'].to_i
+end
+
+Then('the span named {string} integer attribute {string} is greater than or equal to {int}') do |name, attribute, expected|
+  val = named_span_int_attribute(name, attribute)
+  Maze.check.true(val >= expected, "Expected #{name}.#{attribute} (#{val}) >= #{expected}")
+end
+
+Then('the span named {string} attribute {string} does not exist') do |name, attribute|
+  span = span_named(name)
+  attr = (span['attributes'] || []).find { |a| a['key'] == attribute }
+  Maze.check.nil(attr, "Span '#{name}' unexpectedly has attribute '#{attribute}'")
+end
+
+# Consistency/independence check: total must be self-consistent within the same
+# span, which cannot hold if a snapshot leaked between overlapping spans.
+Then('the span named {string} integer attribute {string} equals the sum of integer attributes {string} and {string}') do |name, total_attr, a_attr, b_attr|
+  total = named_span_int_attribute(name, total_attr)
+  val_a = named_span_int_attribute(name, a_attr)
+  val_b = named_span_int_attribute(name, b_attr)
+  Maze.check.true(total == val_a + val_b,
+                  "Expected #{name}.#{total_attr} (#{total}) == #{a_attr} (#{val_a}) + #{b_attr} (#{val_b})")
+end

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -39,6 +39,14 @@ if [[ ("$PLATFORM" = iOS || "$PLATFORM" = tvOS) && "$OS" == 9.* ]]; then
 	XCODEBUILD_EXTRA_ARGS+=("-skip-testing:BugsnagNetworkRequestPlugin-${PLATFORM}Tests")
 fi
 
+if [[ ("$PLATFORM" = iOS || "$PLATFORM" = tvOS) && "$OS" == 9.* ]]; then
+	# BugsnagNetworkRequestPlugin requires iOS/tvOS 10 or later
+	XCODEBUILD_EXTRA_ARGS+=("-skip-testing:BugsnagPerformanceTests-iOSTests/DiskIOCollectorTests")
+	XCODEBUILD_EXTRA_ARGS+=("-skip-testing:BugsnagPerformanceTests-iOSTests/DiskIOMetricsTests")
+	XCODEBUILD_EXTRA_ARGS+=("-skip-testing:BugsnagPerformanceTests-iOSTests/DiskIOSnapshotTests")
+	XCODEBUILD_EXTRA_ARGS+=("-skip-testing:BugsnagPerformanceTests-iOSTests/DiskIOLifecycleGatingTests")
+fi
+
 make test "$@" XCODEBUILD_EXTRA_ARGS="${XCODEBUILD_EXTRA_ARGS[*]}" || die
 
 rm -rf "$xcresult"


### PR DESCRIPTION
## Goal

Add iOS disk IOPS performance instrumentation in bugsnag-cocoa-performance so disk I/O activity can be measured and reported as part of app performance monitoring. This helps identify disk-related bottlenecks and supports performance analysis for ROAD-2233.


## Design

Implemented disk IOPS collection at the Cocoa performance layer to align with existing performance metric capture patterns in the SDK. The approach focuses on:

collecting disk I/O counters from iOS-compatible system APIs,
translating raw values into stable performance measurements,
minimizing runtime overhead, and
integrating with the existing metric/event pipeline so data is reported consistently with other performance signals.
This design keeps the feature isolated and maintainable while ensuring compatibility with current performance reporting behavior.


## Changeset

Added support for disk IOPS metric collection on iOS.
Wired disk I/O measurements into the existing performance monitoring flow.
Updated metric modeling/aggregation paths to carry the new disk IOPS values.
Added or updated related tests and supporting code/docs as needed for ROAD-2233.

## Testing
Ran unit/integration tests covering new disk IOPS metric behavior.
Verified metric capture and reporting paths with disk I/O instrumentation enabled.
Performed manual validation to confirm:
no regressions in existing performance metrics,
expected disk IOPS values are emitted under I/O activity,
no meaningful startup/runtime performance impact from the new collection logic.